### PR TITLE
[ui] Add typography foundations

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,7 @@
 	"tabWidth": 2,
 	"overrides": [
 		{
-			"files": ["*.md"],
+			"files": ["*.md", "*.mdx"],
 			"options": {
 				"tabWidth": 2,
 				"printWidth": 72,

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
 	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 
 	// List of extensions which should be recommended for users of this workspace.
-	"recommendations": ["esbenp.prettier-vscode", "bradlc.vscode-tailwindcss"],
+	"recommendations": ["esbenp.prettier-vscode", "bradlc.vscode-tailwindcss", "unifiedjs.vscode-mdx"],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []
 }

--- a/ui/src/components/typography/Typography.stories.tsx
+++ b/ui/src/components/typography/Typography.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { SoTypography, SO_TYPOGRAPHY_SIZES } from './Typography';
+
+export default {
+	component: SoTypography,
+	argTypes: {
+		size: {
+			options: SO_TYPOGRAPHY_SIZES,
+			control: { type: 'select' },
+		},
+	},
+} as ComponentMeta<typeof SoTypography>;
+
+const Template: ComponentStory<typeof SoTypography> = ({ children, ...args }) => (
+	<SoTypography {...args}>{children}</SoTypography>
+);
+
+export const Overview: typeof Template = Template.bind({});
+Overview.args = {
+	children: 'Text',
+	element: 'h1',
+	size: 'xl',
+};

--- a/ui/src/components/typography/Typography.tsx
+++ b/ui/src/components/typography/Typography.tsx
@@ -1,0 +1,44 @@
+import classNames from 'classnames';
+
+export const SO_TYPOGRAPHY_SIZES = [
+	'xs',
+	'sm',
+	'base',
+	'lg',
+	'xl',
+	'2xl',
+	'3xl',
+	'4xl',
+	'5xl',
+	'6xl',
+	'7xl',
+	'8xl',
+	'9xl',
+] as const;
+
+export type SoTypographySize = typeof SO_TYPOGRAPHY_SIZES[number];
+
+export interface SoTypographyProps extends React.PropsWithChildren, React.HTMLAttributes<any> {
+	/**
+	 * The DOM element type e.g. h1, h2, h3,..., p
+	 */
+	element?: keyof Pick<JSX.IntrinsicElements, 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span'>;
+
+	/**
+	 * The text size from the predefined stack
+	 */
+	size?: SoTypographySize;
+}
+
+/**
+ * Component to apply different text styles
+ */
+export const SoTypography = ({ element = 'p', size = 'base', className, children, ...props }: SoTypographyProps) => {
+	const DOMelement = element;
+
+	return (
+		<DOMelement className={classNames(className, `text-${size}`)} {...props}>
+			{children}
+		</DOMelement>
+	);
+};

--- a/ui/src/foundations/Typography.stories.mdx
+++ b/ui/src/foundations/Typography.stories.mdx
@@ -1,0 +1,93 @@
+<!-- Typography.stories.mdx -->
+
+import { Meta, Typeset } from '@storybook/addon-docs/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { SoTypography } from '../components/typography/Typography';
+import { DocTypographyList } from '../lib/util/documentation/components/TypographyList';
+
+<Meta title="Foundations/Typography" />
+
+# Typography
+
+Social Income uses the [Unica77](https://lineto.com/typefaces/unica77)
+font family. The font family is not open-source, therefore the fonts in
+the source repository can only be used in the context of the Social
+Income projects.
+
+There is a React component to utilize the typography stack, see
+**Components** > **Typography**.
+
+**Font:** Unica77 (`font-family: 'SoSans';`)
+
+**Weights:** 400(regular), 500(medium), 700(bold)
+
+export const typeScale = [
+	{
+		size: '9xl',
+		title: 'Extra Large 9',
+		children: <SoTypography size="9xl">9xl</SoTypography>,
+	},
+	{
+		size: '8xl',
+		title: 'Extra Large 8',
+		children: <SoTypography size="8xl">8xl</SoTypography>,
+	},
+	{
+		size: '7xl',
+		title: 'Extra Large 7',
+		children: <SoTypography size="7xl">7xl</SoTypography>,
+	},
+	{
+		size: '6xl',
+		title: 'Extra Large 6',
+		children: <SoTypography size="6xl">6xl</SoTypography>,
+	},
+	{
+		size: '5xl',
+		title: 'Extra Large 5',
+		children: <SoTypography size="5xl">5xl</SoTypography>,
+	},
+	{
+		size: '4xl',
+		title: 'Extra Large 4',
+		children: <SoTypography size="4xl">4xl</SoTypography>,
+	},
+	{
+		size: '3xl',
+		title: 'Extra Large 3',
+		children: <SoTypography size="3xl">3xl</SoTypography>,
+	},
+	{
+		size: '2xl',
+		title: 'Extra Large 2',
+		children: <SoTypography size="2xl">2xl</SoTypography>,
+	},
+	{
+		size: 'xl',
+		title: 'Extra Large',
+		children: <SoTypography size="xl">xl</SoTypography>,
+	},
+	{
+		size: 'lg',
+		title: 'Large',
+		children: <SoTypography size="lg">lg</SoTypography>,
+	},
+	{
+		size: 'base',
+		title: 'Base',
+		description: 'Default size for body text',
+		children: <SoTypography size="base">base</SoTypography>,
+	},
+	{
+		size: 'sm',
+		title: 'Small',
+		children: <SoTypography size="sm">sm</SoTypography>,
+	},
+	{
+		size: 'xs',
+		title: 'Extra Small',
+		children: <SoTypography size="xs">xs</SoTypography>,
+	},
+];
+
+<DocTypographyList items={typeScale} />

--- a/ui/src/lib/util/documentation/components/TypographyItem.tsx
+++ b/ui/src/lib/util/documentation/components/TypographyItem.tsx
@@ -1,0 +1,23 @@
+import classNames from 'classnames';
+
+export interface DocTypographyItemProps extends React.PropsWithChildren {
+	title: string;
+	description: string;
+}
+
+/**
+ * An util element for visual representation of Typography elements inside Storybook
+ */
+export const DocTypographyItem = ({ title, children, description }) => {
+	return (
+		<>
+			<figure className="so-docs-typography-item__example text-right" aria-hidden>
+				{children}
+			</figure>
+			<div className="so-docs-typography-item__text">
+				<h2 className="so-docs-typography-item__title font-bold">{title}</h2>
+				{description}
+			</div>
+		</>
+	);
+};

--- a/ui/src/lib/util/documentation/components/TypographyList.tsx
+++ b/ui/src/lib/util/documentation/components/TypographyList.tsx
@@ -1,0 +1,16 @@
+import { DocTypographyItem, DocTypographyItemProps } from './TypographyItem';
+import './typography-list.css';
+
+export interface DocTypographyListProps {
+	items: DocTypographyItemProps[];
+}
+
+export const DocTypographyList = ({ items }: DocTypographyListProps) => {
+	return (
+		<div className="so-docs-typography-list grid gap-y-4 gap-x-8 rounded shadow-sm border p-10">
+			{items.map(({ children, ...itemProps }) => (
+				<DocTypographyItem {...itemProps}>{children}</DocTypographyItem>
+			))}
+		</div>
+	);
+};

--- a/ui/src/lib/util/documentation/components/typography-list.css
+++ b/ui/src/lib/util/documentation/components/typography-list.css
@@ -1,0 +1,3 @@
+.so-docs-typography-list {
+	grid-template-columns: auto 1fr;
+}

--- a/ui/src/main.css
+++ b/ui/src/main.css
@@ -15,6 +15,30 @@
 	--so-color-accent-2-secondary-100: var(--so-blue-500);
 }
 
+@layer base {
+	@font-face {
+		font-family: 'SoSans';
+		font-weight: normal;
+		src: url('../../shared/assets/fonts/Unica77LLSub-Regular.woff2') format('woff2');
+	}
+
+	@font-face {
+		font-family: 'SoSans';
+		font-weight: 500;
+		src: url('../../shared/assets/fonts/Unica77LLSub-Medium.woff2') format('woff2');
+	}
+
+	@font-face {
+		font-family: 'SoSans';
+		font-weight: 700;
+		src: url('../../shared/assets/fonts/Unica77LLWeb-Bold.woff2') format('woff2');
+	}
+
+	html {
+		font-family: 'SoSans', system-ui, sans-serif;
+	}
+}
+
 *:focus-visible {
 	outline: 2px solid var(--focus-ring-color, var(--so-color-accent-2-primary-500));
 	outline-offset: 2px;

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -1,7 +1,12 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
 	content: ['./src/**/*.{js,jsx,ts,tsx,mdx,html}'],
-	safelist: ['text-xl', 'text-base'],
+	safelist: [
+		{
+			pattern: /text-*/,
+			variants: ['sm', 'lg'],
+		},
+	],
 	theme: {
 		extend: {
 			colors: {


### PR DESCRIPTION
Add very basic typography documentation and a component for applying the stack.

Out of scope but planned: Applying variable font sizing (`clamp`) to the predefined typography stack.

**Note**: These sizes are not taken from the old website. We use the predefined sizing stack of Tailwind here, for the sake of standardization.