### PR TITLE
[ui] Add combobox component

### DIFF
--- a/ui/src/components/combobox/Combobox.stories.tsx
+++ b/ui/src/components/combobox/Combobox.stories.tsx
@@ -60,19 +60,19 @@ WithImages.args = {
 		{
 			label: 'Option 1',
 			image: {
-				src: '/public/ch.svg',
+				src: 'ch.svg',
 			},
 		},
 		{
 			label: 'Option 2',
 			image: {
-				src: '/public/ch.svg',
+				src: 'ch.svg',
 			},
 		},
 		{
 			label: 'Option 3',
 			image: {
-				src: '/public/ch.svg',
+				src: 'ch.svg',
 			},
 		},
 	],

--- a/ui/src/components/combobox/Combobox.stories.tsx
+++ b/ui/src/components/combobox/Combobox.stories.tsx
@@ -1,0 +1,79 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { useState } from 'react';
+
+import { SoCombobox, SoComboboxProps, SO_COMBOBOX_SIZES } from './Combobox';
+
+export default {
+	component: SoCombobox,
+	argTypes: {
+		block: {
+			defaultValue: false,
+			description: 'If true, the control will be rendered with 100% width',
+			control: { type: 'boolean' },
+		},
+		labelHidden: {
+			defaultValue: false,
+			description: 'If true, the label is only available to screenreaders, but visually hidden.',
+			control: { type: 'boolean' },
+		},
+		size: {
+			defaultValue: 'base',
+			options: SO_COMBOBOX_SIZES,
+			control: { type: 'select' },
+		},
+	},
+} as ComponentMeta<typeof SoCombobox>;
+
+const Template: ComponentStory<typeof SoCombobox> = (args: SoComboboxProps) => {
+	const options: SoComboboxProps['options'] = args?.options || [
+		{
+			label: 'Option 1',
+		},
+		{
+			label: 'Option 2',
+		},
+		{
+			label: 'Option 3',
+		},
+	];
+
+	const [value, setValue] = useState(options[0]);
+
+	args = {
+		label: 'Select Label',
+		value,
+		options,
+		...args,
+		onChange: (selectedItem) => {
+			setValue(selectedItem);
+		},
+	};
+
+	return <SoCombobox {...args} />;
+};
+
+export const Standard: typeof Template = Template.bind({});
+export const WithImages: typeof Template = Template.bind({});
+WithImages.args = {
+	label: 'Country Selector Example',
+	options: [
+		{
+			label: 'Option 1',
+			image: {
+				src: '/public/ch.svg',
+			},
+		},
+		{
+			label: 'Option 2',
+			image: {
+				src: '/public/ch.svg',
+			},
+		},
+		{
+			label: 'Option 3',
+			image: {
+				src: '/public/ch.svg',
+			},
+		},
+	],
+};

--- a/ui/src/components/combobox/Combobox.tsx
+++ b/ui/src/components/combobox/Combobox.tsx
@@ -1,0 +1,226 @@
+import { Combobox, Transition } from '@headlessui/react';
+import { CheckIcon, ChevronDownIcon, ChevronUpDownIcon } from '@heroicons/react/24/solid';
+import classNames from 'classnames';
+import { Fragment, useState } from 'react';
+
+type ComboboxProps = Parameters<typeof Combobox>[0];
+
+export const SO_COMBOBOX_SIZES = ['base', 'xl'] as const;
+
+export type SoComboboxItem = {
+	/**
+	 * The visible text
+	 */
+	label: string;
+
+	/**
+	 * An optional image
+	 */
+	image?: {
+		src: string;
+	};
+};
+
+export interface SoComboboxProps extends Pick<ComboboxProps, 'name' | 'disabled'> {
+	/**
+	 * The select's label elements
+	 */
+	label: string;
+
+	/**
+	 * Options available for selection
+	 */
+	options: SoComboboxItem[];
+
+	/**
+	 * The selected/current value
+	 */
+	value: SoComboboxItem;
+
+	/**
+	 * Emits the selected value on change
+	 */
+	onChange?(value: SoComboboxItem): void;
+
+	/**
+	 * If true, the options get visible when the user focuses the text field
+	 */
+	openOnFocus?: boolean;
+
+	/**
+	 * Render full width
+	 */
+	block?: boolean;
+
+	/**
+	 * If true, the label is visually hidden. It will still be available to screenreaders.
+	 */
+	labelHidden?: boolean;
+
+	/**
+	 * Visual size of the button
+	 */
+	size?: typeof SO_COMBOBOX_SIZES[number];
+}
+
+/**
+ * Comboboxes are the foundation of accessible autocompletes and command palettes, complete with robust support for keyboard navigation.
+ * Use the `SoCombobox` instead of the `SoSelect` whenever you have more than only a couple of options. The Combobox allows a more fine
+ * grained search over all options compared to the select.
+ * @see https://headlessui.com/react/combobox
+ */
+export const SoCombobox = ({
+	label,
+	options,
+	name,
+	size = 'base',
+	value = options[0],
+	openOnFocus = true,
+	block = false,
+	labelHidden = false,
+	...props
+}: SoComboboxProps) => {
+	const [query, setQuery] = useState('');
+
+	const filteredOptions =
+		query === ''
+			? options
+			: options.filter((option) => {
+					return option.label.toLowerCase().includes(query.toLowerCase());
+			  });
+
+	/**
+	 * Handles user input in the text field
+	 */
+	const inputChange = (event: React.ChangeEvent<HTMLInputElement>) => setQuery(event.target.value);
+	const inputDisplayValue = (option: SoComboboxItem) => option?.label || value.label;
+
+	return (
+		<Combobox {...props}>
+			{({ open }) => (
+				<>
+					<Combobox.Label
+						className={classNames('block', 'font-medium', 'text-gray-700', 'mb-1', { 'sr-only': labelHidden })}
+					>
+						{label}
+					</Combobox.Label>
+					<div
+						className={classNames(
+							'relative',
+							'cursor-default',
+							'rounded-lg',
+							'border',
+							'inline-flex',
+							'items-center',
+							'border-gray-300',
+							'bg-white',
+							'text-left',
+							'transition',
+							'hover:shadow-lg',
+							'hover:shadow-gray-200',
+							`text-${size}`,
+							{ 'w-full': block }
+						)}
+					>
+						{value?.image && (
+							<img src={value.image.src} alt="" className="ml-3 h-6 w-6 flex-shrink-0 rounded-full object-cover" />
+						)}
+						<Combobox.Input
+							className={classNames(
+								'border-none',
+								'p-3',
+								'pl-3',
+								'pr-10',
+								'bg-transparent',
+								'text-gray-900',
+								'focus:ring-0',
+								`text-${size}`,
+								{
+									'w-full': block,
+								}
+							)}
+							displayValue={inputDisplayValue}
+							onChange={inputChange}
+						/>
+						<Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
+							<ChevronDownIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
+						</Combobox.Button>
+					</div>
+					<Transition
+						show={open}
+						as={Fragment}
+						leave="transition ease-in duration-100"
+						leaveFrom="opacity-100"
+						leaveTo="opacity-0"
+						afterLeave={() => setQuery('')}
+					>
+						<Combobox.Options
+							static
+							className={classNames(
+								'absolute',
+								'z-10',
+								'mt-1',
+								'max-h-56',
+								'overflow-auto',
+								'rounded-lg',
+								'bg-white',
+								'py-1',
+								'shadow-lg',
+								'ring-1',
+								'ring-black',
+								'ring-opacity-5',
+								'focus:outline-none',
+								`text-${size}`,
+								{ 'w-full': block }
+							)}
+						>
+							{filteredOptions.length === 0 && query !== '' ? (
+								<div className="relative cursor-default select-none py-2 px-4 text-gray-700">Nothing found.</div>
+							) : (
+								filteredOptions.map((option) => (
+									<Combobox.Option
+										key={option.label}
+										className={({ active }) =>
+											classNames(
+												active ? 'text-white bg-so-color-accent-2-primary-500' : 'text-gray-900',
+												'relative cursor-default select-none py-2 pl-3 pr-12'
+											)
+										}
+										value={option}
+									>
+										{({ selected, active }) => (
+											<>
+												<div className="flex items-center">
+													{option?.image && (
+														<img
+															src={option.image.src}
+															alt=""
+															className="h-6 w-6 flex-shrink-0 rounded-full object-cover"
+														/>
+													)}
+													<span
+														className={classNames(active ? 'font-semibold' : 'font-normal', 'truncate', {
+															'ml-3': value.image,
+														})}
+													>
+														{option.label}
+													</span>
+												</div>
+
+												{selected && (
+													<span className={classNames('absolute inset-y-0 right-0 flex items-center pr-4')}>
+														<CheckIcon className="h-5 w-5" aria-hidden="true" />
+													</span>
+												)}
+											</>
+										)}
+									</Combobox.Option>
+								))
+							)}
+						</Combobox.Options>
+					</Transition>
+				</>
+			)}
+		</Combobox>
+	);
+};

--- a/ui/src/components/select/Select.stories.tsx
+++ b/ui/src/components/select/Select.stories.tsx
@@ -60,19 +60,19 @@ WithImages.args = {
 		{
 			label: 'Option 1',
 			image: {
-				src: '/public/ch.svg',
+				src: 'ch.svg',
 			},
 		},
 		{
 			label: 'Option 2',
 			image: {
-				src: '/public/ch.svg',
+				src: 'ch.svg',
 			},
 		},
 		{
 			label: 'Option 3',
 			image: {
-				src: '/public/ch.svg',
+				src: 'ch.svg',
 			},
 		},
 	],

--- a/ui/src/components/select/Select.tsx
+++ b/ui/src/components/select/Select.tsx
@@ -5,7 +5,7 @@ import { Fragment } from 'react';
 
 type ListboxProps = Parameters<typeof Listbox>[0];
 
-export const SO_SELECT_SIZES = ['base', 'xl'];
+export const SO_SELECT_SIZES = ['base', 'xl'] as const;
 
 export type SoSelectItem = {
 	/**

--- a/ui/src/components/select/Select.tsx
+++ b/ui/src/components/select/Select.tsx
@@ -75,10 +75,12 @@ export const SoSelect = ({
 		<Listbox {...props}>
 			{({ open }) => (
 				<>
-					<Listbox.Label className={classNames('block', 'font-medium', 'text-gray-700', { 'sr-only': labelHidden })}>
+					<Listbox.Label
+						className={classNames('block', 'font-medium', 'text-gray-700', 'mb-1', { 'sr-only': labelHidden })}
+					>
 						{label}
 					</Listbox.Label>
-					<div className="relative mt-1">
+					<div className="relative">
 						<Listbox.Button
 							className={classNames(
 								'relative',


### PR DESCRIPTION
_Cntributes to #84_

Comboboxes are the foundation of accessible autocompletes and command palettes, complete with robust support for keyboard navigation. Use the `SoCombobox` instead of the `SoSelect` whenever you have more than only a couple of options. The Combobox allows a more fine-grained search over all options compared to the select.

## Differences to the combobox from the current UI library

In the current combobox, the query field is inside the options' popover:

![Screenshot from 2022-10-07 15-12-49](https://user-images.githubusercontent.com/105358/194562060-9299a88a-b350-492a-b125-02a4ddf0400e.png)

While technically feasible, the effort to make this usable in an accessible manner is currently too high. Therefore, querying is currently limited to typing directly into the field before it is opened.
