### PR TITLE
feat(shared): make checks required - second attempt

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -32,10 +32,7 @@ jobs:
           firebase setup:emulators:ui
 
       - name: Install Dependencies
-        run: |
-          npm --workspace @socialincome/functions install \
-          npm --workspace @socialincome/shared install \
-          npm --workspace=@socialincome/admin install
+        run: npm --workspace=@socialincome/admin install
 
       - name: Run Tests
         run: npm run admin:test

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -1,8 +1,6 @@
 name: Admin - build and deploy
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
@@ -16,14 +14,11 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
-          paths:
-            - "admin/**"
-            - "shared/src/**"
-            - ".github/workflows/admin.yml"
+          paths: '["admin/**", "shared/src/**", ".github/workflows/admin.yml"]'
 
   test_deploy:
     needs: check_applicability
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: needs.check_applicability.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -37,7 +32,10 @@ jobs:
           firebase setup:emulators:ui
 
       - name: Install Dependencies
-        run: npm --workspace=@socialincome/admin install
+        run: |
+          npm --workspace @socialincome/functions install \
+          npm --workspace @socialincome/shared install \
+          npm --workspace=@socialincome/admin install
 
       - name: Run Tests
         run: npm run admin:test

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -14,7 +14,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
-          paths: '["admin/**", "shared/src/**", ".github/workflows/admin.yml"]'
+          paths: '["admin/**", "shared/**", ".github/workflows/admin.yml"]'
 
   test_deploy:
     needs: check_applicability

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -1,20 +1,24 @@
 name: Functions - build and deploy
 on:
   pull_request:
-    paths:
-      - "functions/**"
-      - "shared/src/**"
-      - ".github/workflows/functions.yml"
   push:
     branches:
       - main
-    paths:
-      - "functions/**"
-      - "shared/src/**"
-      - ".github/workflows/functions.yml"
 
 jobs:
+  check_applicability:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          paths: '["functions/**", "shared/src/**", ".github/workflows/functions.yml"]'
+
   test_deploy:
+    needs: check_applicability
+    if: needs.check_applicability.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -14,7 +14,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
-          paths: '["functions/**", "shared/src/**", ".github/workflows/functions.yml"]'
+          paths: '["functions/**", "shared/**", ".github/workflows/functions.yml"]'
 
   test_deploy:
     needs: check_applicability

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -2,25 +2,29 @@ name: UI - build and deploy
 
 on:
   pull_request:
-    paths:
-      - "ui/**"
-      - "package-lock.json"
-      - ".github/workflows/ui.yml"
   push:
     branches:
       - main
-    paths:
-      - "ui/**"
-      - "package-lock.json"
-      - ".github/workflows/ui.yml"
 
 env:
   DIST_PATH: "ui/storybook-static"
   PR_NUMBER: ${{ github.event.number }}
 
 jobs:
+  check_applicability:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          paths: '["ui/**", "package-lock.json", ".github/workflows/ui.yml"]'
+
   build:
     runs-on: ubuntu-latest
+    needs: check_applicability
+    if: needs.check_applicability.outputs.should_skip != 'true'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ admin-serve:
 	docker compose up admin
 
 admin-test:
-	docker compose run --rm admin bash -c "npm --workspace @socialincome/functions install && npm --workspace @socialincome/admin install && npm run admin:test"
+	docker compose run --rm admin bash -c "npm --workspace @socialincome/shared install && npm --workspace @socialincome/functions install && npm --workspace @socialincome/admin install && npm run admin:test"
 
 functions-build:
 	docker compose run --rm functions bash -c "npm --workspace @socialincome/functions install && npm run functions:build"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ admin-serve:
 	docker compose up admin
 
 admin-test:
-	docker compose run --rm admin bash -c "npm --workspace @socialincome/shared install && npm --workspace @socialincome/functions install && npm --workspace @socialincome/admin install && npm run admin:test"
+	docker compose run --rm admin bash -c "npm --workspace @socialincome/admin install && npm run admin:test"
 
 functions-build:
 	docker compose run --rm functions bash -c "npm --workspace @socialincome/functions install && npm run functions:build"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ admin-serve:
 	docker compose up admin
 
 admin-test:
-	docker compose run --rm admin bash -c "npm --workspace @socialincome/admin install && npm run admin:test"
+	docker compose run --rm admin bash -c "npm --workspace @socialincome/functions install && npm --workspace @socialincome/admin install && npm run admin:test"
 
 functions-build:
 	docker compose run --rm functions bash -c "npm --workspace @socialincome/functions install && npm run functions:build"

--- a/admin/package.json
+++ b/admin/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "webpack --mode production --config webpack.config.js",
 		"serve": "webpack serve",
-		"test": "firebase emulators:exec --project demo-social-income-prod --config ../firebase.json --import ../seed  'npm run test:app'",
+		"test": "firebase emulators:exec --project demo-social-income-prod --only firestore --config ../firebase.json --import ../seed  'npm run test:app'",
 		"test:app": "jest --forceExit --roots tests"
 	},
 	"devDependencies": {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       - "3000:3000"
     depends_on:
       - firebase
-    command: /bin/bash -c "npm --workspace=@socialincome/admin install && npm run admin:serve"
+    command: /bin/bash -c "npm --workspace=@socialincome/functions install && npm --workspace=@socialincome/admin install && npm run admin:serve"
 
   functions:
     image: socialincome/local-helper

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       - "3000:3000"
     depends_on:
       - firebase
-    command: /bin/bash -c "npm --workspace=@socialincome/functions install && npm --workspace=@socialincome/admin install && npm run admin:serve"
+    command: /bin/bash -c "npm --workspace=@socialincome/admin install && npm run admin:serve"
 
   functions:
     image: socialincome/local-helper

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
 	"scripts": {
 		"format-code": "prettier --write .",
 		"admin:build": "$npm_execpath --workspace=@socialincome/admin run build",
-		"admin:serve": "$npm_execpath --workspace=@socialincome/admin run serve",
-		"admin:test": "$npm_execpath --workspace=@socialincome/admin run test",
+		"admin:serve": "$npm_execpath run functions:build && $npm_execpath --workspace=@socialincome/admin run serve",
+		"admin:test": "$npm_execpath run functions:build && $npm_execpath --workspace=@socialincome/admin run test",
 		"functions:build": "$npm_execpath --workspace=@socialincome/functions run build",
 		"functions:deploy": "$npm_execpath --workspace=@socialincome/functions run deploy",
 		"functions:serve": "$npm_execpath --workspace=@socialincome/functions run serve",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"format-code": "prettier --write .",
 		"admin:build": "$npm_execpath --workspace=@socialincome/admin run build",
 		"admin:serve": "$npm_execpath run functions:build && $npm_execpath --workspace=@socialincome/admin run serve",
-		"admin:test": "$npm_execpath run functions:build && $npm_execpath --workspace=@socialincome/admin run test",
+		"admin:test": "$npm_execpath --workspace=@socialincome/admin run test",
 		"functions:build": "$npm_execpath --workspace=@socialincome/functions run build",
 		"functions:deploy": "$npm_execpath --workspace=@socialincome/functions run deploy",
 		"functions:serve": "$npm_execpath --workspace=@socialincome/functions run serve",


### PR DESCRIPTION
Currently, we only trigger the checks when a file changes in the relevant module to not run them unnecessarily and slow down the merge process.

However, there is one problem with that. We can't make the checks required since they are not always triggered. This is also explained in https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks.
The github suggests a workaround by having another dummy workflow which always triggers, but that feels unnecessarily verbose.

A million commits later, I'm proposing to use this https://github.com/marketplace/actions/skip-duplicate-actions plugin which should address it as well.

I sneaked in another change. @mkue running the tests for the admin we go the following errors when starting the firebase emulators:
<img width="1210" alt="image" src="https://user-images.githubusercontent.com/1204548/194767238-be96dae7-de01-4dd8-8d12-b9bbf8522e18.png">

This is because we need the functions now to be built, since they are a dependency of the admin. Building it now before running the tests. Wdyt @mkue?
Then the output looks like
<img width="1259" alt="image" src="https://user-images.githubusercontent.com/1204548/194767744-99903f99-32d3-4b5f-a3b5-7b8ec7bbdfe4.png">

Next step is then to mark all checks as required in the Github Settings

