### PR TITLE
[shared] avoid skipping deployments

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -16,6 +16,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5
         with:
           paths: '["admin/**", "shared/**", ".github/workflows/admin.yml"]'
+          skip_after_successful_duplicate: 'false'
 
   test_deploy:
     name: Test & Deploy Admin

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -16,7 +16,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5
         with:
           paths: '["admin/**", "shared/**", ".github/workflows/admin.yml"]'
-          skip_after_successful_duplicate: 'false'
+          skip_after_successful_duplicate: "false"
 
   test_deploy:
     name: Test & Deploy Admin

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -16,6 +16,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5
         with:
           paths: '["functions/**", "shared/**", ".github/workflows/functions.yml"]'
+          skip_after_successful_duplicate: 'false'
 
   test_deploy:
     name: Test & Deploy Functions

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -16,7 +16,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5
         with:
           paths: '["functions/**", "shared/**", ".github/workflows/functions.yml"]'
-          skip_after_successful_duplicate: 'false'
+          skip_after_successful_duplicate: "false"
 
   test_deploy:
     name: Test & Deploy Functions

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -21,7 +21,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5
         with:
           paths: '["ui/**", "package-lock.json", ".github/workflows/ui.yml"]'
-          skip_after_successful_duplicate: 'false'
+          skip_after_successful_duplicate: "false"
 
   build:
     name: Build UI

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -21,6 +21,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5
         with:
           paths: '["ui/**", "package-lock.json", ".github/workflows/ui.yml"]'
+          skip_after_successful_duplicate: 'false'
 
   build:
     name: Build UI


### PR DESCRIPTION
To avoid skipping deployments like https://github.com/socialincome-san/public/actions/runs/3332682463/jobs/5513834686

```
Skip execution because the exact same files have been successfully checked in run https://github.com/socialincome-san/public/actions/runs/3332582140
```