### PR TITLE
[functions] stripe firestore ingestion: avoid undefined

### DIFF
--- a/admin/src/collections/Contributions.ts
+++ b/admin/src/collections/Contributions.ts
@@ -73,6 +73,7 @@ export const contributionsCollection = buildCollection<Contribution>({
 				{ id: StatusKey.SUCCEEDED, label: 'Succeeded' },
 				{ id: StatusKey.PENDING, label: 'Pending' },
 				{ id: StatusKey.FAILED, label: 'Failed' },
+				{ id: StatusKey.UNKNOWN, label: 'Unknown' },
 			],
 			defaultValue: StatusKey.SUCCEEDED,
 		},

--- a/shared/types/admin/Contribution.ts
+++ b/shared/types/admin/Contribution.ts
@@ -15,6 +15,7 @@ export enum StatusKey {
 	FAILED = 'failed',
 	PENDING = 'pending',
 	SUCCEEDED = 'succeeded',
+	UNKNOWN = 'unknown'
 }
 
 export type Contribution = {

--- a/shared/types/admin/Contribution.ts
+++ b/shared/types/admin/Contribution.ts
@@ -24,8 +24,8 @@ export type Contribution = {
 	amount: number;
 	currency: string;
 	amount_chf: number;
-	fees_chf: number | undefined;
+	fees_chf: number;
 	reference_id: string; // e.g stripe charge id
-	monthly_interval: number | undefined;
-	status: StatusKey | undefined;
+	monthly_interval: number;
+	status: StatusKey;
 };


### PR DESCRIPTION
By default, firestore doesn't want to have undefined values.

Got the following error during the batch import of the production stripe charges:
```
Cannot use "undefined" as a Firestore value (found in field "monthly_interval"). If you want to ignore undefined values, enable `ignoreUndefinedProperties`.
```