### PR TITLE
[functions] parallel stripe batch ingestion

### DIFF
--- a/functions/src/etl/stripeWebhook.ts
+++ b/functions/src/etl/stripeWebhook.ts
@@ -114,6 +114,7 @@ export const batchImportStripeChargesFunc = functions
 	})
 	.https.onCall(async () => {
 		const stripeBatchSize = 100; // max batch size supported by stripe
+		const charges = []
 		try {
 			const stripe = new Stripe(STRIPE_API_READ_KEY, { apiVersion: '2022-08-01' });
 			functions.logger.info('Querying Stripe API...');
@@ -121,8 +122,13 @@ export const batchImportStripeChargesFunc = functions
 				expand: ['data.balance_transaction', 'data.invoice'],
 				limit: stripeBatchSize,
 			})) {
-				await storeCharge(charge);
+				charges.push(charge)
 			}
+			functions.logger.info(`Querying stripe finished.`);
+
+			await Promise.all(
+				charges.map(charge => storeCharge(charge))
+			)
 			functions.logger.info(`Ingestion finished.`);
 		} catch (error) {
 			functions.logger.error(error);

--- a/functions/src/etl/stripeWebhook.ts
+++ b/functions/src/etl/stripeWebhook.ts
@@ -114,7 +114,7 @@ export const batchImportStripeChargesFunc = functions
 	})
 	.https.onCall(async () => {
 		const stripeBatchSize = 100; // max batch size supported by stripe
-		const charges = []
+		const charges = [];
 		try {
 			const stripe = new Stripe(STRIPE_API_READ_KEY, { apiVersion: '2022-08-01' });
 			functions.logger.info('Querying Stripe API...');
@@ -122,13 +122,11 @@ export const batchImportStripeChargesFunc = functions
 				expand: ['data.balance_transaction', 'data.invoice'],
 				limit: stripeBatchSize,
 			})) {
-				charges.push(charge)
+				charges.push(charge);
 			}
 			functions.logger.info(`Querying stripe finished.`);
 
-			await Promise.all(
-				charges.map(charge => storeCharge(charge))
-			)
+			await Promise.all(charges.map((charge) => storeCharge(charge)));
 			functions.logger.info(`Ingestion finished.`);
 		} catch (error) {
 			functions.logger.error(error);


### PR DESCRIPTION
Ingesting the stripe charges into firestore sequentially times out after 540 secs which is the max runtime for a firebase v1 function. Latency from our firebase functions to firestore is surprisingly slow. Could be because the functions are running in the US, but our firestore is in Europe? At some point, we should run the functions in the same DC.

Switching to parallel ingestion.