### PR TITLE
Fix broken sponsor link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Income (tax-deductible in Switzerland).
 
 ## Sponsor Dev Community
 
-[Become a sponsor](https://github.com/sponsors/san-socialincome) and
+[Become a sponsor](https://github.com/sponsors/socialincome-san) and
 help ensure the development of open source software for more equality
 and less poverty. Donations through the GitHub Sponsor program are used
 for building a strong developer community and organizing Social Coding


### PR DESCRIPTION
The sponsor link was linking to a broken GitHub sponsors page. This small PR fixes it :)