### PR TITLE
feat: Add rules for recipients app for surveys and organisations collections

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -47,10 +47,16 @@ service cloud.firestore {
       match /messages/{messageId} {
           allow read, update: if canAccessPayment(request.auth.token, recipientId);
       }
-
+      
       match /surveys/{surveyId} {
         allow read, update: if request.auth.token.email == resource.data.access_email;
+        allow read: if canAccessPayment(request.auth.token, recipientId);
       }
+    }
+
+    // recipients app access to organisations, for now check only if authenticated
+    match /organisations/{data} {
+      allow read: if request.auth != null
     }
 
     match /transparency-stats/{data} {


### PR DESCRIPTION
Added rules for surveys and organizations collections for recipients app usage. 

Rule for organizations collection  should be improved to let only access referenced organisation, but it will need some improvements in other places probably.