### PR TITLE
Provide default value for ids in serializable models, fix phone toJson

### DIFF
--- a/recipients_app/lib/data/models/payment/social_income_payment.dart
+++ b/recipients_app/lib/data/models/payment/social_income_payment.dart
@@ -8,7 +8,8 @@ part "social_income_payment.g.dart";
 @JsonSerializable()
 @TimestampConverter()
 class SocialIncomePayment extends Equatable {
-  final String? id;
+  @JsonKey(defaultValue: "")
+  final String id;
   final int? amount;
 
   @JsonKey(name: "payment_at")

--- a/recipients_app/lib/data/models/payment/social_income_payment.g.dart
+++ b/recipients_app/lib/data/models/payment/social_income_payment.g.dart
@@ -8,7 +8,7 @@ part of 'social_income_payment.dart';
 
 SocialIncomePayment _$SocialIncomePaymentFromJson(Map<String, dynamic> json) =>
     SocialIncomePayment(
-      id: json['id'] as String?,
+      id: json['id'] as String? ?? '',
       amount: json['amount'] as int?,
       paymentAt: const TimestampConverter().fromJson(json['payment_at']),
       currency: json['currency'] as String?,

--- a/recipients_app/lib/data/models/recipient.dart
+++ b/recipients_app/lib/data/models/recipient.dart
@@ -10,12 +10,12 @@ import "package:json_annotation/json_annotation.dart";
 
 part "recipient.g.dart";
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 @TimestampConverter()
 @DocumentReferenceConverter()
 @DateTimeConverter()
 class Recipient extends Equatable {
-  @JsonKey(name: "user_id")
+  @JsonKey(name: "user_id", defaultValue: "")
   final String userId;
 
   @JsonKey(name: "communication_mobile_phone")

--- a/recipients_app/lib/data/models/recipient.g.dart
+++ b/recipients_app/lib/data/models/recipient.g.dart
@@ -7,7 +7,7 @@ part of 'recipient.dart';
 // **************************************************************************
 
 Recipient _$RecipientFromJson(Map<String, dynamic> json) => Recipient(
-      userId: json['user_id'] as String,
+      userId: json['user_id'] as String? ?? '',
       communicationMobilePhone: json['communication_mobile_phone'] == null
           ? null
           : Phone.fromJson(
@@ -37,8 +37,8 @@ Recipient _$RecipientFromJson(Map<String, dynamic> json) => Recipient(
 
 Map<String, dynamic> _$RecipientToJson(Recipient instance) => <String, dynamic>{
       'user_id': instance.userId,
-      'communication_mobile_phone': instance.communicationMobilePhone,
-      'mobile_money_phone': instance.mobileMoneyPhone,
+      'communication_mobile_phone': instance.communicationMobilePhone?.toJson(),
+      'mobile_money_phone': instance.mobileMoneyPhone?.toJson(),
       'paymentProvider': instance.paymentProvider,
       'first_name': instance.firstName,
       'last_name': instance.lastName,

--- a/recipients_app/lib/data/models/survey/survey.dart
+++ b/recipients_app/lib/data/models/survey/survey.dart
@@ -8,7 +8,8 @@ part "survey.g.dart";
 @JsonSerializable()
 @TimestampConverter()
 class Survey extends Equatable {
-  final String? id;
+  @JsonKey(defaultValue: "")
+  final String id;
   final SurveyServerStatus? status;
   @JsonKey(name: "due_date_at")
   final Timestamp? dueDateAt;

--- a/recipients_app/lib/data/models/survey/survey.g.dart
+++ b/recipients_app/lib/data/models/survey/survey.g.dart
@@ -7,7 +7,7 @@ part of 'survey.dart';
 // **************************************************************************
 
 Survey _$SurveyFromJson(Map<String, dynamic> json) => Survey(
-      id: json['id'] as String?,
+      id: json['id'] as String? ?? '',
       status: $enumDecodeNullable(_$SurveyServerStatusEnumMap, json['status']),
       dueDateAt: const TimestampConverter().fromJson(json['due_date_at']),
       completedAt: const TimestampConverter().fromJson(json['completed_at']),

--- a/recipients_app/lib/data/repositories/payment_repository.dart
+++ b/recipients_app/lib/data/repositories/payment_repository.dart
@@ -30,7 +30,7 @@ class PaymentRepository {
       payments.add(payment.copyWith(id: paymentDoc.id));
     }
 
-    payments.sort((a, b) => a.id!.compareTo(b.id!));
+    payments.sort((a, b) => a.id.compareTo(b.id));
 
     return payments;
   }

--- a/recipients_app/lib/data/repositories/survey_repository.dart
+++ b/recipients_app/lib/data/repositories/survey_repository.dart
@@ -31,7 +31,7 @@ class SurveyRepository {
       );
     }
 
-    surveys.sort((a, b) => a.id!.compareTo(b.id!));
+    surveys.sort((a, b) => a.id.compareTo(b.id));
 
     return surveys;
   }


### PR DESCRIPTION
* Added default values for `id` like properties in serializable models. As we are taking them from `document` id we need to set them after serialization id done and the default value will allow us to keep ids as not nullable values.
* Fixed `Phone` for `Recipient.toJson` with `explicitToJson: true`. By default serializer is not calling child `toJson` and it is throwing error during profile update.  