### PR TITLE
Fixes empty state display bug with missing spaces

### DIFF
--- a/admin/src/views/NextSurveysView.tsx
+++ b/admin/src/views/NextSurveysView.tsx
@@ -77,6 +77,7 @@ export function NextSurveysView() {
 	return (
 		<Box sx={{ m: 2, display: 'grid', rowGap: 2 }}>
 			<DataGrid
+				autoHeight
 				rows={Array.from(documents.values()).map((row) => ({
 					date: toDateTime(row.surveyDoc.get('due_date_at')).toFormat('MM/yyyy'),
 					id: row.surveyDoc.ref.path,

--- a/admin/src/views/PaymentsConfirmationView.tsx
+++ b/admin/src/views/PaymentsConfirmationView.tsx
@@ -111,6 +111,7 @@ export function PaymentsConfirmationView() {
 		<Box sx={{ m: 2, display: 'grid', rowGap: 2 }}>
 			<SearchBar onTextSearch={(text) => setSearchTerm(text)} />
 			<DataGrid
+				autoHeight
 				rows={Array.from(documents.values())
 					.filter(nameFilter)
 					.map((row) => ({


### PR DESCRIPTION
Fixes #516. 

Previously, when the lists `upcoming survey` or `payments confirmations` collections were empty, the message "no row" was hidden. 

According to the documentation of the material UI's `DataGrid` component : 

> By default, the Data Grid has no intrinsic dimensions. Instead, it takes up the space given by its parent.
Source: [Data Grid Documentation](https://mui.com/x/react-data-grid/layout/)

One approach could be to set a minimum height for the parent of the `DataGrid`. 
The chosen approach is to make use of the autoHeight prop,  which enables `DataGrid` to adjust its size based on its content. 

Using this prop, we get the following result : 
<img width="1916" alt="Screenshot 2023-08-23 at 16 17 04" src="https://github.com/socialincome-san/public/assets/3779257/95646829-1825-46cc-bd76-5fadd7301387">

