### PR TITLE
feat(recipients_app): Unify language property for user selected language, regenerated g files

### DIFF
--- a/recipients_app/lib/core/cubits/settings/settings_cubit.dart
+++ b/recipients_app/lib/core/cubits/settings/settings_cubit.dart
@@ -13,7 +13,7 @@ class SettingsCubit extends Cubit<SettingsState> {
 
   /// Currently english = en and krio = kri are supported
   void changeLanguage(String languageString) {
-    final locale = languageString == "krio"
+    final locale = languageString == "kri"
         ? const Locale("kri")
         : const Locale("en", "US");
 

--- a/recipients_app/lib/data/models/payment/social_income_payment.g.dart
+++ b/recipients_app/lib/data/models/payment/social_income_payment.g.dart
@@ -15,6 +15,7 @@ SocialIncomePayment _$SocialIncomePaymentFromJson(Map<String, dynamic> json) =>
       status: $enumDecodeNullable(_$PaymentStatusEnumMap, json['status']),
       comments: json['comments'] as String?,
       updatedBy: json['last_updated_by'] as String?,
+      updatedAt: const TimestampConverter().fromJson(json['last_updated_at']),
     );
 
 Map<String, dynamic> _$SocialIncomePaymentToJson(
@@ -27,6 +28,7 @@ Map<String, dynamic> _$SocialIncomePaymentToJson(
       'status': _$PaymentStatusEnumMap[instance.status],
       'comments': instance.comments,
       'last_updated_by': instance.updatedBy,
+      'last_updated_at': const TimestampConverter().toJson(instance.updatedAt),
     };
 
 const _$PaymentStatusEnumMap = {

--- a/recipients_app/lib/data/models/recipient.dart
+++ b/recipients_app/lib/data/models/recipient.dart
@@ -51,7 +51,7 @@ class Recipient extends Equatable {
   @JsonKey(name: "gender")
   final String? gender;
 
-  @JsonKey(name: "selected_language")
+  @JsonKey(name: "main_language")
   final String? selectedLanguage;
 
   @JsonKey(name: "organisation")

--- a/recipients_app/lib/data/models/recipient.g.dart
+++ b/recipients_app/lib/data/models/recipient.g.dart
@@ -24,7 +24,7 @@ Recipient _$RecipientFromJson(Map<String, dynamic> json) => Recipient(
       callingName: json['calling_name'] as String?,
       paymentProvider: json['paymentProvider'] as String?,
       gender: json['gender'] as String?,
-      selectedLanguage: json['selected_language'] as String?,
+      selectedLanguage: json['main_language'] as String?,
       termsAccepted: json['terms_accepted'] as bool?,
       recipientSince: _$JsonConverterFromJson<String, DateTime>(
           json['recipient_since'], const DateTimeConverter().fromJson),
@@ -49,7 +49,7 @@ Map<String, dynamic> _$RecipientToJson(Recipient instance) => <String, dynamic>{
       'preferred_name': instance.preferredName,
       'calling_name': instance.callingName,
       'gender': instance.gender,
-      'selected_language': instance.selectedLanguage,
+      'main_language': instance.selectedLanguage,
       'organisation':
           _$JsonConverterToJson<dynamic, DocumentReference<Object?>>(
               instance.organizationRef,

--- a/recipients_app/lib/view/pages/account_page.dart
+++ b/recipients_app/lib/view/pages/account_page.dart
@@ -237,11 +237,11 @@ class AccountPageState extends State<AccountPage> {
                   items: [
                     DropdownMenuItem(
                       child: Text(localizations.english),
-                      value: "english",
+                      value: "en",
                     ),
                     DropdownMenuItem(
                       child: Text(localizations.krio),
-                      value: "krio",
+                      value: "kri",
                     ),
                   ],
                   validator: (value) {

--- a/recipients_app/pubspec.lock
+++ b/recipients_app/pubspec.lock
@@ -105,6 +105,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      sha256: "6c4dd11d05d056e76320b828a1db0fc01ccd376922526f8e9d6c796a5adbac20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      sha256: "10c6bcdbf9d049a0b666702cf1cee4ddfdc38f02a19d35ae392863b47519848b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.6"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      sha256: "6d6ee4276b1c5f34f21fdf39425202712d2be82019983d52f351c94aafbc2c41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.10"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      sha256: ff627b645b28fb8bdb69e645f910c2458fd6b65f6585c3a53e0626024897dedf
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.6.2"
   characters:
     dependency: transitive
     description:
@@ -153,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.7.0"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      sha256: "4ad01d6e56db961d29661561effde45e519939fdaeb46c351275b182eac70189"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.0"
   collection:
     dependency: "direct main"
     description:
@@ -313,6 +369,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.6.5"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -357,6 +421,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -683,6 +755,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -723,6 +803,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.3"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   typed_data:
     dependency: transitive
     description:

--- a/recipients_app/pubspec.yaml
+++ b/recipients_app/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
 dev_dependencies:
   alchemist: ^0.6.1
   bloc_test: ^9.1.4
+  build_runner: ^2.4.6
 
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Unified usage of preferred language field.

Right now both app and admin tool will use the same `main_language` property.

Also regenerated g files (it seems that we forgot about it on adding update date for payments 😮  )