### PR TITLE
(website) refactor: footer migration

### DIFF
--- a/ui/src/components/combobox/Combobox.tsx
+++ b/ui/src/components/combobox/Combobox.tsx
@@ -180,7 +180,7 @@ export const SoCombobox = ({
 										key={option.label}
 										className={({ active }) =>
 											classNames(
-												active ? 'bg-so-color-accent-2-primary-500 text-white' : 'text-gray-900',
+												active ? 'bg-so-color-accent-2-primary-500' : 'text-gray-900',
 												'relative cursor-default select-none py-2 pl-3 pr-12',
 											)
 										}

--- a/ui/src/components/combobox/Combobox.tsx
+++ b/ui/src/components/combobox/Combobox.tsx
@@ -23,7 +23,7 @@ export type SoComboboxItem = {
 	};
 };
 
-export interface SoComboboxProps extends Pick<ComboboxProps, 'name' | 'disabled'> {
+export interface SoComboboxProps<V extends SoComboboxItem> extends Pick<ComboboxProps, 'name' | 'disabled'> {
 	/**
 	 * The select's label elements
 	 */
@@ -37,7 +37,7 @@ export interface SoComboboxProps extends Pick<ComboboxProps, 'name' | 'disabled'
 	/**
 	 * The selected/current value
 	 */
-	value: SoComboboxItem;
+	value: V;
 	/**
 	 * If true, the options get visible when the user focuses the text field
 	 */
@@ -58,7 +58,7 @@ export interface SoComboboxProps extends Pick<ComboboxProps, 'name' | 'disabled'
 	/**
 	 * Emits the selected value on change
 	 */
-	onChange?(value: SoComboboxItem): void;
+	onChange?(value: V): void;
 }
 
 /**
@@ -84,8 +84,8 @@ export const SoCombobox = ({
 		query === ''
 			? options
 			: options.filter((option) => {
-					return option.label.toLowerCase().includes(query.toLowerCase());
-			  });
+				return option.label.toLowerCase().includes(query.toLowerCase());
+			});
 
 	/**
 	 * Handles user input in the text field

--- a/ui/src/components/combobox/Combobox.tsx
+++ b/ui/src/components/combobox/Combobox.tsx
@@ -94,7 +94,7 @@ export const SoCombobox = ({
 	const inputDisplayValue = (option: SoComboboxItem) => option?.label || value.label;
 
 	return (
-		<Combobox {...props}>
+		<Combobox value={value} {...props}>
 			{({ open }) => (
 				<>
 					<Combobox.Label

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -7,5 +7,8 @@ export { Badge } from './components/badge';
 export { BaseContainer } from './components/containers';
 export { Tooltip } from './components/tooltip';
 export { Typography } from './components/typography';
+export { SoCombobox } from './components/combobox';
+export { SoSelect } from './components/select';
+
 export * from './lib/index';
 export * from './react-daisyui';

--- a/website/src/app/[lang]/[country]/(website)/layout.tsx
+++ b/website/src/app/[lang]/[country]/(website)/layout.tsx
@@ -2,7 +2,7 @@ import { DefaultLayoutProps } from '@/app/[lang]/[country]';
 import { ThemeProvider } from '@/app/[lang]/[country]/(website)/theme-provider';
 import Footer from '@/components/footer/footer';
 import Navbar from '@/components/navbar/navbar';
-import { countries, websiteLanguages } from '@/i18n';
+import { countries, websiteLanguages, supportedWebsiteLanguages } from '@/i18n';
 import { PropsWithChildren } from 'react';
 
 export const generateStaticParams = () =>
@@ -12,9 +12,9 @@ export default function Layout({ children, params }: PropsWithChildren<DefaultLa
 	return (
 		<ThemeProvider>
 			<div className="mx-auto">
-				<Navbar lang={params.lang} country={params.country} />
+				<Navbar lang={params.lang} country={params.country} supportedLanguages={supportedWebsiteLanguages}/>
 				<main>{children}</main>
-				<Footer params={params} />
+				<Footer params={params} supportedLanguages={supportedWebsiteLanguages} supportedCountries={countries}/>
 			</div>
 		</ThemeProvider>
 	);

--- a/website/src/components/footer/footer-client.tsx
+++ b/website/src/components/footer/footer-client.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { DefaultLayoutProps } from '@/app/[lang]/[country]';
+import { Language } from '@socialincome/shared/src/types';
+import { SoCombobox, SoSelect } from '@socialincome/ui';
+import { onLanguageChange } from '@/components/navbar/language-switcher';
+import { ValidCountry } from '@/i18n';
+import { useState } from 'react';
+
+type FooterClientProps = {
+	supportedTranslatedLanguages: { code: Language, translation: string }[];
+	supportedTranslatedCountries: { code: ValidCountry, translation: string }[];
+} & DefaultLayoutProps;
+
+type CountryOption = {
+	label: string, 
+	code: ValidCountry
+};
+
+function onCountryChange(country: ValidCountry, router: AppRouterInstance, searchParams: ReadonlyURLSearchParams) {
+	const pathSegments = window.location.pathname.split('/');
+	pathSegments[2] = country;
+	const current = new URLSearchParams(Array.from(searchParams.entries()));
+	router.push(pathSegments.join('/') + '?' + current.toString());
+}
+
+export function FooterClient({ params, supportedTranslatedLanguages, supportedTranslatedCountries }: FooterClientProps) {
+	const router = useRouter();
+	const searchParams = useSearchParams();
+
+	const languageOptions = supportedTranslatedLanguages.reduce((obj, current) => ({ ...obj, [current.code]: { label: current.translation, value: current.code } }), {});
+	const initialLanguage = params.lang;
+
+	const countriesOptions = supportedTranslatedCountries.map((country) => {
+		return {
+			label: country.translation,
+			code: country.code,
+		}
+	}
+	);
+	const initialCountry = countriesOptions.find((candidateCountry) => candidateCountry.code === params.country);
+	const [selectedCountry, setSelectedCountry] = useState(initialCountry);
+
+	return (
+		<>
+			<div>
+				<SoSelect block={true} selected={initialLanguage} options={languageOptions} onChange={(l: Language) => onLanguageChange(l, router, searchParams)} />
+			</div>
+			<div>
+				<SoCombobox block={true} options={countriesOptions} value={selectedCountry} onChange={(c: CountryOption) => { setSelectedCountry(c); onCountryChange(c.code, router, searchParams) } } />
+			</div>
+		</>
+
+	)
+}
+
+

--- a/website/src/components/footer/footer.tsx
+++ b/website/src/components/footer/footer.tsx
@@ -1,34 +1,160 @@
 import { DefaultLayoutProps } from '@/app/[lang]/[country]';
+import { Language } from '@socialincome/shared/src/types';
+import { Translator } from '@socialincome/shared/src/utils/i18n';
+
+import { FooterClient } from '@/components/footer/footer-client';
 import { BaseContainer, Typography } from '@socialincome/ui';
-
-import { SiFacebook, SiInstagram } from '@icons-pack/react-simple-icons';
+import { SILogo } from '@/components/logos/si-logo';
+import { SiFacebook, SiInstagram, SiLinkedin, SiTwitter } from '@icons-pack/react-simple-icons';
+import { EnvelopeIcon, EnvelopeOpenIcon, InformationCircleIcon, ShieldCheckIcon, UserCircleIcon, UserGroupIcon, BriefcaseIcon, SwatchIcon } from '@heroicons/react/24/solid';
+import { IconType } from '@icons-pack/react-simple-icons/types';
 import Link from 'next/link';
+import { ValidCountry } from '@/i18n';
 
-export default async function Footer({ params }: DefaultLayoutProps) {
+type FooterLinkProps = {
+	label: string;
+	url: string;
+	Icon?: IconType;
+};
+
+function FooterLink({ label, url, Icon }: FooterLinkProps) {
 	return (
-		<BaseContainer>
-			<div className="grid grid-cols-4 py-8">
-				<div className="flex flex-col space-y-2">
-					<Typography size="lg" weight="medium">
-						Follow us
-					</Typography>
-					<Link
-						href="https://www.instagram.com/so_income/"
-						target="_blank"
-						className="link link-hover inline-flex items-center space-x-2"
-					>
-						<SiInstagram className="h-4 w-4" />
-						<Typography size="sm">Instagram</Typography>
-					</Link>
-					<Link
-						href="https://www.facebook.com/socialincome.org"
-						target="_blank"
-						className="link link-hover inline-flex items-center space-x-2"
-					>
-						<SiFacebook className="h-4 w-4" />
-						<Typography size="sm">Facebook</Typography>
-					</Link>
+		<Link
+			href={url}
+			target="_blank"
+			className="group inline-flex items-center space-x-4"
+		>
+			{Icon && <Icon className="h-4 w-4 fill-neutral-600 group-hover:fill-base-content" />}
+			<Typography size='s' className="text-neutral-600 group-hover:text-base-content">{label}</Typography>
+		</Link>
+
+	)
+}
+
+type FooterProps = {
+	supportedLanguages: Language[],
+	supportedCountries: ValidCountry[],
+} & DefaultLayoutProps;
+
+export default async function Footer({ params, supportedLanguages, supportedCountries }: FooterProps) {
+	const translator = await Translator.getInstance({
+		language: params.lang,
+		namespaces: ['common', 'website-common', 'website-me', 'countries'],
+	});
+
+	const supportedTranslatedLanguages = supportedLanguages.map((lang) => { return { translation: translator.t(`languages.${lang}`), code: lang } });
+
+	const supportedTranslatedCountries = supportedCountries.map((country) => { return { translation: translator.t(`${country.toUpperCase()}`), code: country } });
+
+	return (
+		<BaseContainer className="bg-stone-300">
+			<div className="flex flex-row mb-5 md:mb-10 pt-14 pl-3">
+				<div className="basis-1/2 flex items-center">
+					<SILogo className="h-4 fill-zinc-900" />
 				</div>
+				<div className="invisible md:visible basis-1/2 flex items-center gap-x-1">
+					<FooterClient params={params} supportedTranslatedLanguages={supportedTranslatedLanguages} supportedTranslatedCountries={supportedTranslatedCountries} />
+				</div>
+			</div>
+			<div>
+				<hr className="my-3 border-neutral-400"></hr>
+			</div>
+			<div className="grid grid-cols-2 md:grid-cols-4 py-8 mx-6">
+				<div className="flex flex-col space-y-2 mb-8">
+					<Typography className="mb3" size="lg" weight="medium">
+						Connect
+					</Typography>
+					<FooterLink
+						Icon={EnvelopeIcon}
+						label="Email"
+						url="mailto:hello@socialincome.org" />
+					<FooterLink
+						Icon={SiInstagram}
+						label="Instagram"
+						url="https://www.instagram.com/so_income/" />
+					<FooterLink
+						Icon={SiTwitter}
+						label="Twitter"
+						url="https://twitter.com/so_income" />
+					<FooterLink
+						Icon={SiFacebook}
+						label="Facebook"
+						url="https://facebook.com/socialincome.org" />
+					<FooterLink
+						Icon={SiLinkedin}
+						label="Linkedin"
+						url="https://www.linkedin.com/company/socialincome" />
+					<FooterLink
+						Icon={EnvelopeOpenIcon}
+						label="Newsletter"
+						url={`/${params.lang}/${params.country}/updates`} />
+				</div>
+				<div className="flex flex-col space-y-2 mb-8">
+					<Typography className="mb-3" size="lg" weight="medium">
+						Resources
+					</Typography>
+					<FooterLink
+						Icon={InformationCircleIcon}
+						label="FAQ"
+						url={`/${params.lang}/${params.country}/faq`} />
+					<FooterLink
+						Icon={UserCircleIcon}
+						label="Account"
+						url={`/${params.lang}/${params.country}/login`} />
+					<FooterLink
+						Icon={ShieldCheckIcon}
+						label="Privacy Policy"
+						url={`/${params.lang}/${params.country}/privacy`} />
+					<FooterLink
+						Icon={BriefcaseIcon}
+						label="Terms of Use"
+						url={`/${params.lang}/${params.country}/terms-use`} />
+					<FooterLink
+						Icon={UserGroupIcon}
+						label="Terms for contributions"
+						url={`/${params.lang}/${params.country}/terms-contributions`} />
+					<FooterLink
+						Icon={SwatchIcon}
+						label="The Arts"
+						url={`/${params.lang}/${params.country}/arts`} />
+				</div>
+				<div className="flex flex-col space-y-2 mb-8">
+					<Typography className="mb-3" size="lg" weight="medium">
+						Our Work
+					</Typography>
+					<FooterLink
+						label="How It Works"
+						url={`/${params.lang}/${params.country}/our-work#process`} />
+					<FooterLink
+						label="Contributors"
+						url={`/${params.lang}/${params.country}/our-work#contributors`} />
+					<FooterLink
+						label="Recipients"
+						url={`/${params.lang}/${params.country}/our-work#recipients`} />
+					<FooterLink
+						label="What's Next"
+						url={`/${params.lang}/${params.country}/our-work#next`} />
+				</div>
+				<div className="flex flex-col space-y-2 mb-8">
+					<Typography className="mb-3" size="lg" weight="medium">
+						About us
+					</Typography>
+					<FooterLink
+						label="Our Mission"
+						url={`/${params.lang}/${params.country}/about-us#about-us-1`} />
+					<FooterLink
+						label="Why Contribute?"
+						url={`/${params.lang}/${params.country}/about-us#motivations`} />
+					<FooterLink
+						label="Team"
+						url={`/${params.lang}/${params.country}/about-us#about-us-3`} />
+					<FooterLink
+						label="Contact"
+						url={`/${params.lang}/${params.country}/about-us#about-us-4`} />
+				</div>
+			</div>
+			<div className="mx-6 md:invisible">
+				<FooterClient params={params} supportedTranslatedLanguages={supportedTranslatedLanguages} supportedTranslatedCountries={supportedTranslatedCountries} />
 			</div>
 		</BaseContainer>
 	);

--- a/website/src/components/navbar/language-switcher.tsx
+++ b/website/src/components/navbar/language-switcher.tsx
@@ -3,7 +3,8 @@
 import { LanguageIcon } from '@heroicons/react/24/solid';
 import { Language } from '@socialincome/shared/src/types';
 import { Dropdown, Menu, Theme, Typography } from '@socialincome/ui';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context';
+import { useRouter, useSearchParams, ReadonlyURLSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
 
 type LanguageSwitcherProps = {
@@ -15,16 +16,17 @@ type LanguageSwitcherProps = {
 	}[];
 };
 
+export function onLanguageChange(lang: Language, router: AppRouterInstance, searchParams: ReadonlyURLSearchParams) {
+	const pathSegments = window.location.pathname.split('/');
+	pathSegments[1] = lang;
+	const current = new URLSearchParams(Array.from(searchParams.entries()));
+	router.push(pathSegments.join('/') + '?' + current.toString());
+}
+
 function LanguageSwitcherComponent({ languages, mobile, currentLanguage }: LanguageSwitcherProps) {
 	const router = useRouter();
 	const searchParams = useSearchParams();
 
-	const onLanguageChange = (lang: Language) => {
-		const pathSegments = window.location.pathname.split('/');
-		pathSegments[1] = lang;
-		const current = new URLSearchParams(Array.from(searchParams.entries()));
-		router.push(pathSegments.join('/') + '?' + current.toString());
-	};
 	if (mobile) {
 		return (
 			<Menu.Details
@@ -37,7 +39,7 @@ function LanguageSwitcherComponent({ languages, mobile, currentLanguage }: Langu
 			>
 				{languages.map((lang, index) => (
 					<Menu.Item key={index}>
-						<a onClick={() => onLanguageChange(lang.code)}>{lang.translation}</a>
+						<a onClick={() => onLanguageChange(lang.code, router, searchParams)}>{lang.translation}</a>
 					</Menu.Item>
 				))}
 			</Menu.Details>
@@ -51,7 +53,7 @@ function LanguageSwitcherComponent({ languages, mobile, currentLanguage }: Langu
 				<Theme dataTheme="siDefault">
 					<Dropdown.Menu className="z-40 min-w-[6rem]">
 						{languages.map((lang, index) => (
-							<Dropdown.Item key={index} onClick={() => onLanguageChange(lang.code)}>
+							<Dropdown.Item key={index} onClick={() => onLanguageChange(lang.code, router, searchParams)}>
 								{lang.translation}
 							</Dropdown.Item>
 						))}

--- a/website/src/components/navbar/navbar-client.tsx
+++ b/website/src/components/navbar/navbar-client.tsx
@@ -1,6 +1,4 @@
 'use client';
-
-import { DefaultParams } from '@/app/[lang]/[country]';
 import { SILogo } from '@/components/logos/si-logo';
 import { LanguageSwitcher } from '@/components/navbar/language-switcher';
 import { Disclosure } from '@headlessui/react';

--- a/website/src/components/navbar/navbar.tsx
+++ b/website/src/components/navbar/navbar.tsx
@@ -3,13 +3,16 @@ import NavbarClient from '@/components/navbar/navbar-client';
 import { Language } from '@socialincome/shared/src/types';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
 
-export default async function Navbar({ lang, country }: DefaultParams) {
+export type NavbarProps = {
+	supportedLanguages: Language[] 
+} & DefaultParams;
+
+export default async function Navbar({ lang, country, supportedLanguages }: NavbarProps) {
 	const translator = await Translator.getInstance({
 		language: lang,
 		namespaces: ['common', 'website-common', 'website-me'],
 	});
 
-	const languages: Language[] = ['en', 'de'];
 	const aboutUs = translator.t('navigation.about-us');
 	const aboutUsHref = `/${lang}/${country}/about-us`;
 	const ourWork = translator.t('navigation.our-work');
@@ -30,7 +33,7 @@ export default async function Navbar({ lang, country }: DefaultParams) {
 				payments: translator.t('tabs.contributions'),
 				signOut: translator.t('sign-out'),
 			}}
-			languages={languages.map((lang) => ({ code: lang, translation: translator.t(`languages.${lang}`) }))}
+			languages={supportedLanguages.map((lang) => ({ code: lang, translation: translator.t(`languages.${lang}`) }))}
 			sections={[
 				{ title: ourWork, href: ourWorkHref },
 				{

--- a/website/src/i18n.ts
+++ b/website/src/i18n.ts
@@ -9,6 +9,7 @@ export type ValidCountry = (typeof countries)[number];
 export const defaultLanguage = 'en';
 export type WebsiteLanguage = Extract<Language, 'en' | 'de' | 'kri'>;
 export const websiteLanguages: WebsiteLanguage[] = ['en', 'de', 'kri'];
+export const supportedWebsiteLanguages : WebsiteLanguage[] = ['en', 'de'];
 
 const findBestLocale = (request: NextRequest) => {
 	const options = langParser.parse(request.headers.get('Accept-Language') || 'en');


### PR DESCRIPTION
- This PR introduces two new components : `Footer` (server-side component), `FooterClient` (client-side component). These components are added to the default layout of the website to create the footer section.
- This PR refactors some _language switching_ logic happening in the navbar component to **share it with the footer components**. 

I still need some help before moving from draft to final P.R : 
- [ ] Code Formatting + Linting
- [ ] Footer items translations
While items of the footer are translated for the old website, I don't see those translations available in the assets. 
- [ ] Combobox display bug for small viewports
- [x] Icons validation
I'm using icons from `heroicons`, and they don't match the previous icons (cf screenshot)

