### PR TITLE
feature(website): refined navbar

### DIFF
--- a/shared/locales/en/website-common.json
+++ b/shared/locales/en/website-common.json
@@ -7,7 +7,7 @@
 		"faq": "FAQ",
 		"finances": "Finances",
 		"how-it-works": "How It Works",
-		"my-profile": "My Profile",
+		"my-profile": "Login",
 		"our-work": "Our Work",
 		"our-work-description": "Learn what we do and stand for",
 		"contributors-description": "Learn about the people donating",

--- a/shared/locales/en/website-common.json
+++ b/shared/locales/en/website-common.json
@@ -7,7 +7,7 @@
 		"faq": "FAQ",
 		"finances": "Finances",
 		"how-it-works": "How It Works",
-		"my-profile": "Login",
+		"my-profile": "My Profile",
 		"our-work": "Our Work",
 		"our-work-description": "Learn what we do and stand for",
 		"contributors-description": "Learn about the people donating",

--- a/website/src/components/logos/si-icon.tsx
+++ b/website/src/components/logos/si-icon.tsx
@@ -2,24 +2,24 @@ import classNames from 'classnames';
 import { HTMLAttributes } from 'react';
 
 export function SIIcon({ className, ...props }: HTMLAttributes<SVGElement>) {
-  return (
-    <svg
-      version="1.1"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlSpace="preserve"
-      fill="currentColor"
-      aria-hidden={true}
-      aria-labelledby="si-icon"
-      viewBox="0 0 816 815.8"
-      className={classNames('text-si-yellow', className)}
-      {...props}
-    >
-      <title id="si-icon">Social Income Icon</title>
-      <g>
-        <path id="Pfad_185" className="st0" d="M714.1,663.9h102v-512h-102V663.9z"/>
-        <path id="Pfad_186" className="st0" d="M366.4,631.9l92.8,43.3l216.3-463.8l-92.8-43.3L366.4,631.9z"/>
-        <path id="Pfad_187" className="st0" d="M0,596.7l65.8,78.4l392-329l-65.7-78.3L0,596.7z"/>
-      </g>
-    </svg>
-  );
+	return (
+		<svg
+			version="1.1"
+			xmlns="http://www.w3.org/2000/svg"
+			xmlSpace="preserve"
+			fill="currentColor"
+			aria-hidden={true}
+			aria-labelledby="si-icon"
+			viewBox="0 0 816 815.8"
+			className={classNames('text-si-yellow', className)}
+			{...props}
+		>
+			<title id="si-icon">Social Income Icon</title>
+			<g>
+				<path id="Pfad_185" className="st0" d="M714.1,663.9h102v-512h-102V663.9z" />
+				<path id="Pfad_186" className="st0" d="M366.4,631.9l92.8,43.3l216.3-463.8l-92.8-43.3L366.4,631.9z" />
+				<path id="Pfad_187" className="st0" d="M0,596.7l65.8,78.4l392-329l-65.7-78.3L0,596.7z" />
+			</g>
+		</svg>
+	);
 }

--- a/website/src/components/logos/si-icon.tsx
+++ b/website/src/components/logos/si-icon.tsx
@@ -1,0 +1,25 @@
+import classNames from 'classnames';
+import { HTMLAttributes } from 'react';
+
+export function SIIcon({ className, ...props }: HTMLAttributes<SVGElement>) {
+  return (
+    <svg
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlSpace="preserve"
+      fill="currentColor"
+      aria-hidden={true}
+      aria-labelledby="si-icon"
+      viewBox="0 0 816 815.8"
+      className={classNames('text-si-yellow', className)}
+      {...props}
+    >
+      <title id="si-icon">Social Income Icon</title>
+      <g>
+        <path id="Pfad_185" className="st0" d="M714.1,663.9h102v-512h-102V663.9z"/>
+        <path id="Pfad_186" className="st0" d="M366.4,631.9l92.8,43.3l216.3-463.8l-92.8-43.3L366.4,631.9z"/>
+        <path id="Pfad_187" className="st0" d="M0,596.7l65.8,78.4l392-329l-65.7-78.3L0,596.7z"/>
+      </g>
+    </svg>
+  );
+}

--- a/website/src/components/navbar/navbar-client.tsx
+++ b/website/src/components/navbar/navbar-client.tsx
@@ -108,7 +108,7 @@ export function NavbarClient(
 									<div key={index}>
 										{_.isEmpty(section.links) && section.href ? (
 											<Link href={section.href} key={index}>
-												<Button variant="ghost" className="py-6 text-gray-800 hover:text-black">
+												<Button variant="ghost" className="py-6 text-secondary-foreground">
 													<Typography size="xl" weight="medium">
 														{section.title}
 													</Typography>
@@ -118,14 +118,14 @@ export function NavbarClient(
 											<HoverCard key={index} openDelay={0} closeDelay={200}>
 												<HoverCardTrigger asChild>
 													<Button variant="ghost" className="flex items-center space-x-2 py-6">
-														<Typography size="xl" weight="medium" className="text-gray-800 hover:text-black">
+														<Typography size="xl" weight="medium" className="text-secondary-foreground">
 															{section.title}
 														</Typography>
 														{(section.links?.length ?? 0) > 0 && <ChevronDownIcon className="h-4 w-4" />}
 													</Button>
 												</HoverCardTrigger>
 												<HoverCardContent asChild alignOffset={20} className="bg-popover w-56 p-0">
-													<ul className="divide-y divide-gray-100">
+													<ul className="divide-y divide-muted">
 														{section.links?.map((link, index) => (
 															<li key={index} className="hover:bg-accent py-2 pl-10">
 																<Link href={link.href}>
@@ -133,7 +133,7 @@ export function NavbarClient(
 																		size="xl"
 																		weight="medium"
 																		lineHeight="loose"
-																		className="text-gray-700 hover:text-black"
+																		className="text-secondary-foreground"
 																	>
 																		{link.title}
 																	</Typography>
@@ -177,7 +177,7 @@ export function NavbarClient(
 
 				{/*Mobile menu*/}
 				<CollapsibleContent className="border-b md:hidden">
-					<Accordion type="single" collapsible className="mb-0 flex w-full flex-col divide-y divide-gray-200">
+					<Accordion type="single" collapsible className="mb-0 flex w-full flex-col divide-y divide-border">
 						{navigation.map((section, index) => (
 							<div key={index}>
 								{_.isEmpty(section.links) && section.href ? (
@@ -192,7 +192,7 @@ export function NavbarClient(
 									// Accordion section
 									<AccordionItem
 										value={`value-${index}`}
-										className="divide-y divide-gray-200 border-none text-lg font-medium"
+										className="divide-y divide-border border-none text-lg font-medium"
 									>
 										<AccordionTrigger className=" hover:bg-accent pl-5 pr-8 pt-4 hover:no-underline md:pl-0">
 											{section.title}

--- a/website/src/components/navbar/navbar-client.tsx
+++ b/website/src/components/navbar/navbar-client.tsx
@@ -2,11 +2,11 @@
 
 import { DefaultParams } from '@/app/[lang]/[region]';
 import { I18nDialog } from '@/components/i18n-dialog';
-import { SILogo } from '@/components/logos/si-logo';
 import { SIIcon } from '@/components/logos/si-icon';
+import { SILogo } from '@/components/logos/si-logo';
 import { WebsiteCurrency } from '@/i18n';
 import { UserCircleIcon } from '@heroicons/react/24/outline';
-import { Bars3Icon, GlobeEuropeAfricaIcon, LanguageIcon, XMarkIcon, ChevronDownIcon } from '@heroicons/react/24/solid';
+import { Bars3Icon, ChevronDownIcon, GlobeEuropeAfricaIcon, LanguageIcon, XMarkIcon } from '@heroicons/react/24/solid';
 import { LanguageCode } from '@socialincome/shared/src/types/language';
 import {
 	Accordion,
@@ -87,18 +87,18 @@ export function NavbarClient(
 	);
 
 	return (
-		<nav className="min-h-navbar flex flex-col justify-start pt-4 py-8">
+		<nav className="min-h-navbar flex flex-col justify-start py-8 pt-4">
 			<Collapsible
 				open={isOpen}
 				onOpenChange={setIsOpen}
 				className="mx-auto flex w-screen max-w-6xl flex-col space-y-4 md:px-5"
 			>
-				<div className="flex flex-row items-center justify-between md:grid-cols-4 px-5 md:px-0">
+				<div className="flex flex-row items-center justify-between px-5 md:grid-cols-4 md:px-0">
 					<Link href={`/${lang}/${region}`}>
 						{/* Large Screen Logo */}
-						<SILogo className="hidden lg:block h-6" />
+						<SILogo className="hidden h-6 lg:block" />
 						{/* Small Screen Icon */}
-						<SIIcon className="block lg:hidden h-11" />
+						<SIIcon className="block h-11 lg:hidden" />
 					</Link>
 					{/*Desktop menu*/}
 					{showNavigation && (
@@ -108,7 +108,7 @@ export function NavbarClient(
 									<div key={index}>
 										{_.isEmpty(section.links) && section.href ? (
 											<Link href={section.href} key={index}>
-												<Button variant="ghost" className="text-gray-800 hover:text-black py-6">
+												<Button variant="ghost" className="py-6 text-gray-800 hover:text-black">
 													<Typography size="xl" weight="medium">
 														{section.title}
 													</Typography>
@@ -121,17 +121,20 @@ export function NavbarClient(
 														<Typography size="xl" weight="medium" className="text-gray-800 hover:text-black">
 															{section.title}
 														</Typography>
-														{(section.links?.length ?? 0) > 0 && (
-															<ChevronDownIcon className="h-4 w-4" />
-														)}
+														{(section.links?.length ?? 0) > 0 && <ChevronDownIcon className="h-4 w-4" />}
 													</Button>
 												</HoverCardTrigger>
 												<HoverCardContent asChild alignOffset={20} className="bg-popover w-56 p-0">
-													<ul  className="divide-y divide-gray-100">
+													<ul className="divide-y divide-gray-100">
 														{section.links?.map((link, index) => (
-															<li key={index} className="pl-10 py-2 hover:bg-accent">
+															<li key={index} className="hover:bg-accent py-2 pl-10">
 																<Link href={link.href}>
-																	<Typography size="xl" weight="medium" lineHeight="loose" className="text-gray-700 hover:text-black">
+																	<Typography
+																		size="xl"
+																		weight="medium"
+																		lineHeight="loose"
+																		className="text-gray-700 hover:text-black"
+																	>
 																		{link.title}
 																	</Typography>
 																</Link>
@@ -174,21 +177,29 @@ export function NavbarClient(
 
 				{/*Mobile menu*/}
 				<CollapsibleContent className="border-b md:hidden">
-					<Accordion type="single" collapsible className="divide-y divide-gray-200 mb-0 flex w-full flex-col">
+					<Accordion type="single" collapsible className="mb-0 flex w-full flex-col divide-y divide-gray-200">
 						{navigation.map((section, index) => (
 							<div key={index}>
 								{_.isEmpty(section.links) && section.href ? (
 									// Entire section is a link with hover effect
-									<Link href={section.href} className="flex flex-1 items-center justify-between py-4 text-lg font-medium px-5 md:px-0 hover:bg-accent">
+									<Link
+										href={section.href}
+										className="hover:bg-accent flex flex-1 items-center justify-between px-5 py-4 text-lg font-medium md:px-0"
+									>
 										<span>{section.title}</span>
 									</Link>
 								) : (
 									// Accordion section
-									<AccordionItem value={`value-${index}`} className="divide-y divide-gray-200 border-none text-lg font-medium">
-										<AccordionTrigger className=" pt-4 pr-8 pl-5 md:pl-0 hover:bg-accent hover:no-underline">{section.title}</AccordionTrigger>
+									<AccordionItem
+										value={`value-${index}`}
+										className="divide-y divide-gray-200 border-none text-lg font-medium"
+									>
+										<AccordionTrigger className=" hover:bg-accent pl-5 pr-8 pt-4 hover:no-underline md:pl-0">
+											{section.title}
+										</AccordionTrigger>
 										{section.links?.map((link, index2) => (
-											<AccordionContent key={index2} className="px-10 md:px-0 text-lg pt-2 hover:bg-accent">
-												<Link href={link.href} className="block mt-2">
+											<AccordionContent key={index2} className="hover:bg-accent px-10 pt-2 text-lg md:px-0">
+												<Link href={link.href} className="mt-2 block">
 													{link.title}
 												</Link>
 											</AccordionContent>
@@ -198,7 +209,7 @@ export function NavbarClient(
 							</div>
 						))}
 						<Link href={`/${lang}/${region}/me`} className="block">
-							<div className="flex flex-1 items-center justify-between px-5 md:px-0 py-4 text-lg font-medium hover:bg-accent">
+							<div className="hover:bg-accent flex flex-1 items-center justify-between px-5 py-4 text-lg font-medium md:px-0">
 								{translations.myProfile}
 							</div>
 						</Link>

--- a/website/src/components/navbar/navbar-client.tsx
+++ b/website/src/components/navbar/navbar-client.tsx
@@ -2,11 +2,11 @@
 
 import { DefaultParams } from '@/app/[lang]/[region]';
 import { I18nDialog } from '@/components/i18n-dialog';
-import { SILogo } from '@/components/logos/si-logo';
 import { SIIcon } from '@/components/logos/si-icon';
+import { SILogo } from '@/components/logos/si-logo';
 import { WebsiteCurrency } from '@/i18n';
 import { UserCircleIcon } from '@heroicons/react/24/outline';
-import { Bars3Icon, GlobeEuropeAfricaIcon, LanguageIcon, XMarkIcon, ChevronDownIcon } from '@heroicons/react/24/solid';
+import { Bars3Icon, ChevronDownIcon, GlobeEuropeAfricaIcon, LanguageIcon, XMarkIcon } from '@heroicons/react/24/solid';
 import { LanguageCode } from '@socialincome/shared/src/types/language';
 import {
 	Accordion,
@@ -87,7 +87,7 @@ export function NavbarClient(
 	);
 
 	return (
-		<nav className="min-h-navbar flex flex-col justify-start pt-4 py-8">
+		<nav className="min-h-navbar flex flex-col justify-start py-8 pt-4">
 			<Collapsible
 				open={isOpen}
 				onOpenChange={setIsOpen}
@@ -96,9 +96,9 @@ export function NavbarClient(
 				<div className="flex flex-row items-center justify-between md:grid-cols-4">
 					<Link href={`/${lang}/${region}`}>
 						{/* Large Screen Logo */}
-						<SILogo className="hidden lg:block h-6" />
+						<SILogo className="hidden h-6 lg:block" />
 						{/* Small Screen Icon */}
-						<SIIcon className="block lg:hidden h-11" />
+						<SIIcon className="block h-11 lg:hidden" />
 					</Link>
 					{/*Desktop menu*/}
 					{showNavigation && (
@@ -121,17 +121,20 @@ export function NavbarClient(
 														<Typography size="xl" weight="medium" className="text-gray-800 hover:text-black">
 															{section.title}
 														</Typography>
-														{(section.links?.length ?? 0) > 0 && (
-															<ChevronDownIcon className="h-4 w-4" />
-														)}
+														{(section.links?.length ?? 0) > 0 && <ChevronDownIcon className="h-4 w-4" />}
 													</Button>
 												</HoverCardTrigger>
 												<HoverCardContent asChild alignOffset={20} className="bg-popover w-72 p-0">
-													<ul  className="divide-y divide-gray-100">
+													<ul className="divide-y divide-gray-100">
 														{section.links?.map((link, index) => (
-															<li key={index} className="pl-10 py-3 hover:bg-accent rounded">
+															<li key={index} className="hover:bg-accent rounded py-3 pl-10">
 																<Link href={link.href}>
-																	<Typography size="xl" weight="medium" lineHeight="loose" className="text-gray-700 hover:text-black">
+																	<Typography
+																		size="xl"
+																		weight="medium"
+																		lineHeight="loose"
+																		className="text-gray-700 hover:text-black"
+																	>
 																		{link.title}
 																	</Typography>
 																</Link>
@@ -174,7 +177,7 @@ export function NavbarClient(
 
 				{/*Mobile menu*/}
 				<CollapsibleContent className="border-b md:hidden">
-					<Accordion type="single" collapsible className="divide-y divide-gray-200 mb-0 flex w-full flex-col">
+					<Accordion type="single" collapsible className="mb-0 flex w-full flex-col divide-y divide-gray-200">
 						{navigation.map((section, index) => (
 							<div key={index}>
 								{_.isEmpty(section.links) && section.href ? (
@@ -182,7 +185,10 @@ export function NavbarClient(
 										<Link href={section.href}>{section.title}</Link>
 									</div>
 								) : (
-									<AccordionItem value={`value-${index}`} className="hover:underline-none border-none text-lg font-medium">
+									<AccordionItem
+										value={`value-${index}`}
+										className="hover:underline-none border-none text-lg font-medium"
+									>
 										<AccordionTrigger className="py-3 pr-2">{section.title}</AccordionTrigger>
 										{section.links?.map((link, index2) => (
 											<AccordionContent key={index2} className="text-lg">

--- a/website/src/components/navbar/navbar-client.tsx
+++ b/website/src/components/navbar/navbar-client.tsx
@@ -3,9 +3,10 @@
 import { DefaultParams } from '@/app/[lang]/[region]';
 import { I18nDialog } from '@/components/i18n-dialog';
 import { SILogo } from '@/components/logos/si-logo';
+import { SIIcon } from '@/components/logos/si-icon';
 import { WebsiteCurrency } from '@/i18n';
 import { UserCircleIcon } from '@heroicons/react/24/outline';
-import { Bars3Icon, GlobeEuropeAfricaIcon, LanguageIcon, XMarkIcon } from '@heroicons/react/24/solid';
+import { Bars3Icon, GlobeEuropeAfricaIcon, LanguageIcon, XMarkIcon, ChevronDownIcon } from '@heroicons/react/24/solid';
 import { LanguageCode } from '@socialincome/shared/src/types/language';
 import {
 	Accordion,
@@ -79,14 +80,14 @@ export function NavbarClient(
 			}}
 		>
 			<Button variant="ghost" className="flex max-w-md space-x-2">
-				<LanguageIcon className="h-4 w-4" />
-				<GlobeEuropeAfricaIcon className="h-4 w-4" />
+				<LanguageIcon className="h-6 w-6" />
+				<GlobeEuropeAfricaIcon className="h-6 w-6" />
 			</Button>
 		</I18nDialog>
 	);
 
 	return (
-		<nav className="min-h-navbar flex flex-col justify-start pt-4">
+		<nav className="min-h-navbar flex flex-col justify-start pt-4 py-8">
 			<Collapsible
 				open={isOpen}
 				onOpenChange={setIsOpen}
@@ -94,7 +95,10 @@ export function NavbarClient(
 			>
 				<div className="flex flex-row items-center justify-between md:grid-cols-4">
 					<Link href={`/${lang}/${region}`}>
-						<SILogo className="h-6" />
+						{/* Large Screen Logo */}
+						<SILogo className="hidden lg:block h-6" />
+						{/* Small Screen Icon */}
+						<SIIcon className="block lg:hidden h-11" />
 					</Link>
 					{/*Desktop menu*/}
 					{showNavigation && (
@@ -104,8 +108,8 @@ export function NavbarClient(
 									<div key={index}>
 										{_.isEmpty(section.links) && section.href ? (
 											<Link href={section.href} key={index}>
-												<Button variant="ghost">
-													<Typography size="md" weight="medium">
+												<Button variant="ghost" className="text-gray-800 hover:text-black">
+													<Typography size="xl" weight="medium">
 														{section.title}
 													</Typography>
 												</Button>
@@ -113,18 +117,21 @@ export function NavbarClient(
 										) : (
 											<HoverCard key={index} openDelay={0} closeDelay={200}>
 												<HoverCardTrigger asChild>
-													<Button variant="ghost">
-														<Typography size="md" weight="medium">
+													<Button variant="ghost" className="flex items-center space-x-2">
+														<Typography size="xl" weight="medium" className="text-gray-800 hover:text-black">
 															{section.title}
 														</Typography>
+														{(section.links?.length ?? 0) > 0 && (
+															<ChevronDownIcon className="h-4 w-4" />
+														)}
 													</Button>
 												</HoverCardTrigger>
-												<HoverCardContent asChild alignOffset={20} className="bg-popover w-72">
-													<ul>
+												<HoverCardContent asChild alignOffset={20} className="bg-popover w-72 p-0">
+													<ul  className="divide-y divide-gray-100">
 														{section.links?.map((link, index) => (
-															<li key={index} className="hover:bg-accent rounded p-2">
+															<li key={index} className="pl-10 py-3 hover:bg-accent rounded">
 																<Link href={link.href}>
-																	<Typography size="md" weight="medium" lineHeight="loose">
+																	<Typography size="xl" weight="medium" lineHeight="loose" className="text-gray-700 hover:text-black">
 																		{link.title}
 																	</Typography>
 																</Link>
@@ -144,7 +151,7 @@ export function NavbarClient(
 						{showNavigation && (
 							<Link href={`/${lang}/${region}/me`}>
 								<Button variant="ghost" className="cursor-pointer">
-									<UserCircleIcon className="h-5 w-5" />
+									<UserCircleIcon className="h-6 w-6" />
 								</Button>
 							</Link>
 						)}
@@ -155,9 +162,9 @@ export function NavbarClient(
 							<CollapsibleTrigger asChild>
 								<Button variant="ghost" size="icon" className="w-9 p-0">
 									{isOpen ? (
-										<XMarkIcon className="block h-5 w-5" aria-hidden="true" />
+										<XMarkIcon className="block h-6 w-6" aria-hidden="true" />
 									) : (
-										<Bars3Icon className="block h-5 w-5" aria-hidden="true" />
+										<Bars3Icon className="block h-6 w-6" aria-hidden="true" />
 									)}
 								</Button>
 							</CollapsibleTrigger>
@@ -167,18 +174,18 @@ export function NavbarClient(
 
 				{/*Mobile menu*/}
 				<CollapsibleContent className="border-b md:hidden">
-					<Accordion type="single" collapsible className="border-border mb-4 flex w-full flex-col">
+					<Accordion type="single" collapsible className="divide-y divide-gray-200 mb-0 flex w-full flex-col">
 						{navigation.map((section, index) => (
 							<div key={index}>
 								{_.isEmpty(section.links) && section.href ? (
-									<div className="flex flex-1 items-center justify-between py-1.5 font-medium">
+									<div className="flex flex-1 items-center justify-between py-3 text-lg font-medium">
 										<Link href={section.href}>{section.title}</Link>
 									</div>
 								) : (
-									<AccordionItem value={`value-${index}`} className="hover:underline-none border-none">
-										<AccordionTrigger className="py-1.5">{section.title}</AccordionTrigger>
+									<AccordionItem value={`value-${index}`} className="hover:underline-none border-none text-lg font-medium">
+										<AccordionTrigger className="py-3 pr-2">{section.title}</AccordionTrigger>
 										{section.links?.map((link, index2) => (
-											<AccordionContent key={index2}>
+											<AccordionContent key={index2} className="text-lg">
 												<Link href={link.href}>{link.title}</Link>
 											</AccordionContent>
 										))}
@@ -186,7 +193,7 @@ export function NavbarClient(
 								)}
 							</div>
 						))}
-						<div className="flex flex-1 items-center justify-between py-1.5 font-medium">
+						<div className="flex flex-1 items-center justify-between py-3 text-lg font-medium">
 							<Link href={`/${lang}/${region}/me`}>{translations.myProfile}</Link>
 						</div>
 					</Accordion>

--- a/website/src/components/navbar/navbar-client.tsx
+++ b/website/src/components/navbar/navbar-client.tsx
@@ -2,11 +2,11 @@
 
 import { DefaultParams } from '@/app/[lang]/[region]';
 import { I18nDialog } from '@/components/i18n-dialog';
-import { SIIcon } from '@/components/logos/si-icon';
 import { SILogo } from '@/components/logos/si-logo';
+import { SIIcon } from '@/components/logos/si-icon';
 import { WebsiteCurrency } from '@/i18n';
 import { UserCircleIcon } from '@heroicons/react/24/outline';
-import { Bars3Icon, ChevronDownIcon, GlobeEuropeAfricaIcon, LanguageIcon, XMarkIcon } from '@heroicons/react/24/solid';
+import { Bars3Icon, GlobeEuropeAfricaIcon, LanguageIcon, XMarkIcon, ChevronDownIcon } from '@heroicons/react/24/solid';
 import { LanguageCode } from '@socialincome/shared/src/types/language';
 import {
 	Accordion,
@@ -79,7 +79,7 @@ export function NavbarClient(
 				currency: translations.currency,
 			}}
 		>
-			<Button variant="ghost" className="flex max-w-md space-x-2">
+			<Button variant="ghost" className="flex max-w-md space-x-2 py-6">
 				<LanguageIcon className="h-6 w-6" />
 				<GlobeEuropeAfricaIcon className="h-6 w-6" />
 			</Button>
@@ -87,18 +87,18 @@ export function NavbarClient(
 	);
 
 	return (
-		<nav className="min-h-navbar flex flex-col justify-start py-8 pt-4">
+		<nav className="min-h-navbar flex flex-col justify-start pt-4 py-8">
 			<Collapsible
 				open={isOpen}
 				onOpenChange={setIsOpen}
-				className="mx-auto flex w-screen max-w-6xl flex-col space-y-4 px-3 md:px-5"
+				className="mx-auto flex w-screen max-w-6xl flex-col space-y-4 md:px-5"
 			>
-				<div className="flex flex-row items-center justify-between md:grid-cols-4">
+				<div className="flex flex-row items-center justify-between md:grid-cols-4 px-5 md:px-0">
 					<Link href={`/${lang}/${region}`}>
 						{/* Large Screen Logo */}
-						<SILogo className="hidden h-6 lg:block" />
+						<SILogo className="hidden lg:block h-6" />
 						{/* Small Screen Icon */}
-						<SIIcon className="block h-11 lg:hidden" />
+						<SIIcon className="block lg:hidden h-11" />
 					</Link>
 					{/*Desktop menu*/}
 					{showNavigation && (
@@ -108,7 +108,7 @@ export function NavbarClient(
 									<div key={index}>
 										{_.isEmpty(section.links) && section.href ? (
 											<Link href={section.href} key={index}>
-												<Button variant="ghost" className="text-gray-800 hover:text-black">
+												<Button variant="ghost" className="text-gray-800 hover:text-black py-6">
 													<Typography size="xl" weight="medium">
 														{section.title}
 													</Typography>
@@ -117,24 +117,21 @@ export function NavbarClient(
 										) : (
 											<HoverCard key={index} openDelay={0} closeDelay={200}>
 												<HoverCardTrigger asChild>
-													<Button variant="ghost" className="flex items-center space-x-2">
+													<Button variant="ghost" className="flex items-center space-x-2 py-6">
 														<Typography size="xl" weight="medium" className="text-gray-800 hover:text-black">
 															{section.title}
 														</Typography>
-														{(section.links?.length ?? 0) > 0 && <ChevronDownIcon className="h-4 w-4" />}
+														{(section.links?.length ?? 0) > 0 && (
+															<ChevronDownIcon className="h-4 w-4" />
+														)}
 													</Button>
 												</HoverCardTrigger>
-												<HoverCardContent asChild alignOffset={20} className="bg-popover w-72 p-0">
-													<ul className="divide-y divide-gray-100">
+												<HoverCardContent asChild alignOffset={20} className="bg-popover w-56 p-0">
+													<ul  className="divide-y divide-gray-100">
 														{section.links?.map((link, index) => (
-															<li key={index} className="hover:bg-accent rounded py-3 pl-10">
+															<li key={index} className="pl-10 py-2 hover:bg-accent">
 																<Link href={link.href}>
-																	<Typography
-																		size="xl"
-																		weight="medium"
-																		lineHeight="loose"
-																		className="text-gray-700 hover:text-black"
-																	>
+																	<Typography size="xl" weight="medium" lineHeight="loose" className="text-gray-700 hover:text-black">
 																		{link.title}
 																	</Typography>
 																</Link>
@@ -153,7 +150,7 @@ export function NavbarClient(
 						{i18nDialog}
 						{showNavigation && (
 							<Link href={`/${lang}/${region}/me`}>
-								<Button variant="ghost" className="cursor-pointer">
+								<Button variant="ghost" className="cursor-pointer py-6">
 									<UserCircleIcon className="h-6 w-6" />
 								</Button>
 							</Link>
@@ -163,7 +160,7 @@ export function NavbarClient(
 						{i18nDialog}
 						{showNavigation && (
 							<CollapsibleTrigger asChild>
-								<Button variant="ghost" size="icon" className="w-9 p-0">
+								<Button variant="ghost" size="icon" className="w-11 py-6">
 									{isOpen ? (
 										<XMarkIcon className="block h-6 w-6" aria-hidden="true" />
 									) : (
@@ -177,31 +174,34 @@ export function NavbarClient(
 
 				{/*Mobile menu*/}
 				<CollapsibleContent className="border-b md:hidden">
-					<Accordion type="single" collapsible className="mb-0 flex w-full flex-col divide-y divide-gray-200">
+					<Accordion type="single" collapsible className="divide-y divide-gray-200 mb-0 flex w-full flex-col">
 						{navigation.map((section, index) => (
 							<div key={index}>
 								{_.isEmpty(section.links) && section.href ? (
-									<div className="flex flex-1 items-center justify-between py-3 text-lg font-medium">
-										<Link href={section.href}>{section.title}</Link>
-									</div>
+									// Entire section is a link with hover effect
+									<Link href={section.href} className="flex flex-1 items-center justify-between py-4 text-lg font-medium px-5 md:px-0 hover:bg-accent">
+										<span>{section.title}</span>
+									</Link>
 								) : (
-									<AccordionItem
-										value={`value-${index}`}
-										className="hover:underline-none border-none text-lg font-medium"
-									>
-										<AccordionTrigger className="py-3 pr-2">{section.title}</AccordionTrigger>
+									// Accordion section
+									<AccordionItem value={`value-${index}`} className="divide-y divide-gray-200 border-none text-lg font-medium">
+										<AccordionTrigger className=" pt-4 pr-8 pl-5 md:pl-0 hover:bg-accent hover:no-underline">{section.title}</AccordionTrigger>
 										{section.links?.map((link, index2) => (
-											<AccordionContent key={index2} className="text-lg">
-												<Link href={link.href}>{link.title}</Link>
+											<AccordionContent key={index2} className="px-10 md:px-0 text-lg pt-2 hover:bg-accent">
+												<Link href={link.href} className="block mt-2">
+													{link.title}
+												</Link>
 											</AccordionContent>
 										))}
 									</AccordionItem>
 								)}
 							</div>
 						))}
-						<div className="flex flex-1 items-center justify-between py-3 text-lg font-medium">
-							<Link href={`/${lang}/${region}/me`}>{translations.myProfile}</Link>
-						</div>
+						<Link href={`/${lang}/${region}/me`} className="block">
+							<div className="flex flex-1 items-center justify-between px-5 md:px-0 py-4 text-lg font-medium hover:bg-accent">
+								{translations.myProfile}
+							</div>
+						</Link>
 					</Accordion>
 				</CollapsibleContent>
 			</Collapsible>

--- a/website/src/components/navbar/navbar-client.tsx
+++ b/website/src/components/navbar/navbar-client.tsx
@@ -108,7 +108,7 @@ export function NavbarClient(
 									<div key={index}>
 										{_.isEmpty(section.links) && section.href ? (
 											<Link href={section.href} key={index}>
-												<Button variant="ghost" className="py-6 text-secondary-foreground">
+												<Button variant="ghost" className="text-secondary-foreground py-6">
 													<Typography size="xl" weight="medium">
 														{section.title}
 													</Typography>
@@ -125,7 +125,7 @@ export function NavbarClient(
 													</Button>
 												</HoverCardTrigger>
 												<HoverCardContent asChild alignOffset={20} className="bg-popover w-56 p-0">
-													<ul className="divide-y divide-muted">
+													<ul className="divide-muted divide-y">
 														{section.links?.map((link, index) => (
 															<li key={index} className="hover:bg-accent py-2 pl-10">
 																<Link href={link.href}>
@@ -177,7 +177,7 @@ export function NavbarClient(
 
 				{/*Mobile menu*/}
 				<CollapsibleContent className="border-b md:hidden">
-					<Accordion type="single" collapsible className="mb-0 flex w-full flex-col divide-y divide-border">
+					<Accordion type="single" collapsible className="divide-border mb-0 flex w-full flex-col divide-y">
 						{navigation.map((section, index) => (
 							<div key={index}>
 								{_.isEmpty(section.links) && section.href ? (
@@ -192,7 +192,7 @@ export function NavbarClient(
 									// Accordion section
 									<AccordionItem
 										value={`value-${index}`}
-										className="divide-y divide-border border-none text-lg font-medium"
+										className="divide-border divide-y border-none text-lg font-medium"
 									>
 										<AccordionTrigger className=" hover:bg-accent pl-5 pr-8 pt-4 hover:no-underline md:pl-0">
 											{section.title}


### PR DESCRIPTION
Refined NavBar: Adjusted Logo Sizes and Optimized Whitespace & Text for Mobile/Web Views

Out of scope was the CTA button "Take Action".

**Comparison**
Left: old / Right: new

<img width="1009" alt="Screenshot 2023-11-16 at 19 27 19" src="https://github.com/socialincome-san/public/assets/6095849/2cd330ca-5646-4415-91ef-cf0acc06432b">
<img width="1782" alt="Screenshot 2023-11-16 at 19 28 21" src="https://github.com/socialincome-san/public/assets/6095849/af8d3358-7fa0-4aed-a58c-e702176dbfdd">
<img width="2676" alt="Screenshot 2023-11-16 at 19 29 00" src="https://github.com/socialincome-san/public/assets/6095849/022ced08-245b-4d12-9189-304f2d30ffab">
<img width="2676" alt="Screenshot 2023-11-16 at 19 30 06" src="https://github.com/socialincome-san/public/assets/6095849/5e87c827-fbb7-46c8-a1fc-ec2f8f3f3444">
