### PR TITLE
bug(recipients_app): fix payments updates from app to not override fields not used by the app

### DIFF
--- a/recipients_app/lib/data/models/payment/social_income_payment.dart
+++ b/recipients_app/lib/data/models/payment/social_income_payment.dart
@@ -8,7 +8,7 @@ part "social_income_payment.g.dart";
 @JsonSerializable()
 @TimestampConverter()
 class SocialIncomePayment extends Equatable {
-  @JsonKey(defaultValue: "")
+  @JsonKey(defaultValue: "", includeToJson: false)
   final String id;
   final int? amount;
 

--- a/recipients_app/lib/data/models/payment/social_income_payment.g.dart
+++ b/recipients_app/lib/data/models/payment/social_income_payment.g.dart
@@ -23,7 +23,6 @@ SocialIncomePayment _$SocialIncomePaymentFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$SocialIncomePaymentToJson(
         SocialIncomePayment instance) =>
     <String, dynamic>{
-      'id': instance.id,
       'amount': instance.amount,
       'payment_at': _$JsonConverterToJson<Object, Timestamp>(
           instance.paymentAt, const TimestampConverter().toJson),

--- a/recipients_app/lib/data/models/recipient.dart
+++ b/recipients_app/lib/data/models/recipient.dart
@@ -15,7 +15,7 @@ part "recipient.g.dart";
 @DocumentReferenceConverter()
 @DateTimeConverter()
 class Recipient extends Equatable {
-  @JsonKey(name: "user_id", defaultValue: "")
+  @JsonKey(name: "user_id", defaultValue: "", includeToJson: false)
   final String userId;
 
   @JsonKey(name: "communication_mobile_phone")

--- a/recipients_app/lib/data/models/recipient.g.dart
+++ b/recipients_app/lib/data/models/recipient.g.dart
@@ -41,7 +41,6 @@ Recipient _$RecipientFromJson(Map<String, dynamic> json) => Recipient(
     );
 
 Map<String, dynamic> _$RecipientToJson(Recipient instance) => <String, dynamic>{
-      'user_id': instance.userId,
       'communication_mobile_phone': instance.communicationMobilePhone?.toJson(),
       'mobile_money_phone': instance.mobileMoneyPhone?.toJson(),
       'paymentProvider': instance.paymentProvider,

--- a/recipients_app/lib/data/repositories/payment_repository.dart
+++ b/recipients_app/lib/data/repositories/payment_repository.dart
@@ -54,7 +54,7 @@ class PaymentRepository {
         .doc(recipient.userId)
         .collection(paymentCollection)
         .doc(payment.id)
-        .set(updatedPayment.toJson());
+        .update(updatedPayment.toJson());
   }
 
   Future<void> contestPayment({
@@ -74,6 +74,6 @@ class PaymentRepository {
         .doc(recipient.userId)
         .collection(paymentCollection)
         .doc(payment.id)
-        .set(updatedPayment.toJson());
+        .update(updatedPayment.toJson());
   }
 }


### PR DESCRIPTION
It was observed in #638 that recipients app is overriding some important data in firestore during confirming the payments. 

We had `set` method used but `update` should work better for this case. 

Also the `id` which is used by the app internally is not part of the shared contract so we will remove it with excluding it from generated `toJson` method.  