### PR TITLE
feature(website): badge for highlighting active campaign on landing page

### DIFF
--- a/shared/locales/de/website-donate.json
+++ b/shared/locales/de/website-donate.json
@@ -96,6 +96,8 @@
 		"about-si-title": "Über Social Income",
 		"about-si-text-1": "Social Income ist eine NGO mit Sitz in der Schweiz, die bedingungslose Geldüberweisungen per Mobiltelefon an Menschen in multidimensionaler Armut in Westafrika bereitstellt.",
 		"about-si-text-2": "Seit 2020 führt Social Income ein zeitlich unbegrenztes Programm für ein universelles Grundeinkommen in Sierra Leone durch.",
-		"more-faq": "<a href='/faq' target=\"_blank\">Mehr Fragen</a>"
+		"more-faq": "<a href='/faq' target=\"_blank\">Mehr Fragen</a>",
+		"badge-highlight": "Aktuelle Kampagne"
+
 	}
 }

--- a/shared/locales/de/website-donate.json
+++ b/shared/locales/de/website-donate.json
@@ -98,6 +98,5 @@
 		"about-si-text-2": "Seit 2020 führt Social Income ein zeitlich unbegrenztes Programm für ein universelles Grundeinkommen in Sierra Leone durch.",
 		"more-faq": "<a href='/faq' target=\"_blank\">Mehr Fragen</a>",
 		"badge-highlight": "Aktuelle Kampagne"
-
 	}
 }

--- a/shared/locales/en/website-donate.json
+++ b/shared/locales/en/website-donate.json
@@ -96,6 +96,7 @@
 		"about-si-title": "About Social Income",
 		"about-si-text-1": "Social Income is a nonprofit organization based in Switzerland that provides unconditional cash transfers via mobile phone to people living in multidimensional poverty in West Africa.",
 		"about-si-text-2": "Since 2020, Social Income has been running an open-ended universal basic income program in Sierra Leone.",
-		"more-faq": "<a href='/faq' target=\"_blank\">More questions</a>"
+		"more-faq": "<a href='/faq' target=\"_blank\">More questions</a>",
+		"badge-highlight": "Ongoing Campaign"
 	}
 }

--- a/website/src/app/[lang]/[region]/(website)/(home)/(sections)/active-campaign.tsx
+++ b/website/src/app/[lang]/[region]/(website)/(home)/(sections)/active-campaign.tsx
@@ -2,6 +2,7 @@ import { WebsiteLanguage } from '@/i18n';
 import { BellAlertIcon } from '@heroicons/react/24/solid';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
 import { Badge, BaseContainer, Typography } from '@socialincome/ui';
+import Link from 'next/link';
 
 export async function Campaign({ lang }: { lang: WebsiteLanguage }) {
 	const translator = await Translator.getInstance({
@@ -10,13 +11,8 @@ export async function Campaign({ lang }: { lang: WebsiteLanguage }) {
 	});
 
 	return (
-		<BaseContainer className="flex cursor-pointer flex-col items-center justify-center">
-			<a
-				href="https://socialincome.org/campaign/MZmXEVHlDjOOFOMk82jW"
-				target="_blank"
-				rel="noopener noreferrer"
-				className="group"
-			>
+		<BaseContainer className="mb-8 flex flex-col items-center justify-center sm:mb-0">
+			<Link href="https://socialincome.org/campaign/MZmXEVHlDjOOFOMk82jW" className="group">
 				<Badge variant="outline" className="flex-shrink-0">
 					<Typography
 						size="md"
@@ -36,7 +32,7 @@ export async function Campaign({ lang }: { lang: WebsiteLanguage }) {
 						Rebuilding Lives by Ismatu&nbsp;Gwendolyn
 					</Typography>
 				</Badge>
-			</a>
+			</Link>
 		</BaseContainer>
 	);
 }

--- a/website/src/app/[lang]/[region]/(website)/(home)/(sections)/active-campaign.tsx
+++ b/website/src/app/[lang]/[region]/(website)/(home)/(sections)/active-campaign.tsx
@@ -1,27 +1,42 @@
 import { WebsiteLanguage } from '@/i18n';
+import { BellAlertIcon } from '@heroicons/react/24/solid';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
-import { Badge, BaseContainer, Typography } from "@socialincome/ui";
-import { BellAlertIcon } from "@heroicons/react/24/solid";
+import { Badge, BaseContainer, Typography } from '@socialincome/ui';
 
 export async function Campaign({ lang }: { lang: WebsiteLanguage }) {
-  const translator = await Translator.getInstance({
-    language: lang,
-    namespaces: ['website-donate'],
-  });
+	const translator = await Translator.getInstance({
+		language: lang,
+		namespaces: ['website-donate'],
+	});
 
-  return (
-    <BaseContainer className="flex flex-col items-center justify-center cursor-pointer">
-      <a href="https://socialincome.org/campaign/MZmXEVHlDjOOFOMk82jW" target="_blank" rel="noopener noreferrer" className="group">
-        <Badge variant="outline" className="flex-shrink-0">
-          <Typography size="md" color="primary" weight="normal" className="flex items-center p-1 group-hover:text-primary-foreground">
-            <BellAlertIcon className="mx-4 h-8 w-8 sm:h-5 sm:w-5 sm:mx-3" />
-            {translator.t('campaign.badge-highlight')}
-          </Typography>
-          <Typography size="md" color="secondary" weight="medium" className="flex items-center p-1 mr-4 group-hover:text-primary-foreground">
-            Rebuilding Lives by Ismatu&nbsp;Gwendolyn
-          </Typography>
-        </Badge>
-      </a>
-    </BaseContainer>
-  );
+	return (
+		<BaseContainer className="flex cursor-pointer flex-col items-center justify-center">
+			<a
+				href="https://socialincome.org/campaign/MZmXEVHlDjOOFOMk82jW"
+				target="_blank"
+				rel="noopener noreferrer"
+				className="group"
+			>
+				<Badge variant="outline" className="flex-shrink-0">
+					<Typography
+						size="md"
+						color="primary"
+						weight="normal"
+						className="group-hover:text-primary-foreground flex items-center p-1"
+					>
+						<BellAlertIcon className="mx-4 h-8 w-8 sm:mx-3 sm:h-5 sm:w-5" />
+						{translator.t('campaign.badge-highlight')}
+					</Typography>
+					<Typography
+						size="md"
+						color="secondary"
+						weight="medium"
+						className="group-hover:text-primary-foreground mr-4 flex items-center p-1"
+					>
+						Rebuilding Lives by Ismatu&nbsp;Gwendolyn
+					</Typography>
+				</Badge>
+			</a>
+		</BaseContainer>
+	);
 }

--- a/website/src/app/[lang]/[region]/(website)/(home)/(sections)/active-campaign.tsx
+++ b/website/src/app/[lang]/[region]/(website)/(home)/(sections)/active-campaign.tsx
@@ -1,0 +1,27 @@
+import { WebsiteLanguage } from '@/i18n';
+import { Translator } from '@socialincome/shared/src/utils/i18n';
+import { Badge, BaseContainer, Typography } from "@socialincome/ui";
+import { BellAlertIcon } from "@heroicons/react/24/solid";
+
+export async function Campaign({ lang }: { lang: WebsiteLanguage }) {
+  const translator = await Translator.getInstance({
+    language: lang,
+    namespaces: ['website-donate'],
+  });
+
+  return (
+    <BaseContainer className="flex flex-col items-center justify-center cursor-pointer">
+      <a href="https://socialincome.org/campaign/MZmXEVHlDjOOFOMk82jW" target="_blank" rel="noopener noreferrer" className="group">
+        <Badge variant="outline" className="flex-shrink-0">
+          <Typography size="md" color="primary" weight="normal" className="flex items-center p-1 group-hover:text-primary-foreground">
+            <BellAlertIcon className="mx-4 h-8 w-8 sm:h-5 sm:w-5 sm:mx-3" />
+            {translator.t('campaign.badge-highlight')}
+          </Typography>
+          <Typography size="md" color="secondary" weight="medium" className="flex items-center p-1 mr-4 group-hover:text-primary-foreground">
+            Rebuilding Lives by Ismatu&nbsp;Gwendolyn
+          </Typography>
+        </Badge>
+      </a>
+    </BaseContainer>
+  );
+}

--- a/website/src/app/[lang]/[region]/(website)/(home)/(sections)/hero.tsx
+++ b/website/src/app/[lang]/[region]/(website)/(home)/(sections)/hero.tsx
@@ -11,7 +11,7 @@ export async function Hero({ lang, region }: DefaultParams) {
 
 	return (
 		<BaseContainer className="min-h-screen-navbar grid grid-cols-1 content-center items-start gap-x-4 gap-y-8 align-top sm:gap-y-16 lg:grid-cols-2 lg:gap-y-0">
-			<div className="mx-auto w-full max-w-2xl lg:pr-6">
+			<div className="mx-auto w-full max-w-2xl">
 				<Typography size="5xl" weight="bold">
 					{translator.t('section-1.title-1')}
 					<Typography as="span" size="5xl" weight="bold" color="secondary">

--- a/website/src/app/[lang]/[region]/(website)/(home)/(sections)/hero.tsx
+++ b/website/src/app/[lang]/[region]/(website)/(home)/(sections)/hero.tsx
@@ -11,7 +11,7 @@ export async function Hero({ lang, region }: DefaultParams) {
 
 	return (
 		<BaseContainer className="min-h-screen-navbar grid grid-cols-1 content-center items-start gap-x-4 gap-y-8 align-top sm:gap-y-16 lg:grid-cols-2 lg:gap-y-0">
-			<div className="mx-auto w-full max-w-2xl">
+			<div className="mx-auto w-full max-w-2xl lg:pr-6">
 				<Typography size="5xl" weight="bold">
 					{translator.t('section-1.title-1')}
 					<Typography as="span" size="5xl" weight="bold" color="secondary">

--- a/website/src/app/[lang]/[region]/(website)/(home)/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/(home)/page.tsx
@@ -9,12 +9,14 @@ import { WhatWouldChange } from '@/app/[lang]/[region]/(website)/(home)/(section
 import NewsletterPopup from '@/components/newsletter-popup/newsletter-popup';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
 import { Video } from './(sections)/video';
+import { Campaign } from './(sections)/active-campaign';
 
 export default async function Page({ params: { lang, region } }: DefaultPageProps) {
 	const translator = await Translator.getInstance({ language: lang, namespaces: ['website-home', 'website-videos'] });
 	const vimeoVideoId = Number(translator.t('id.video-02'));
 	return (
 		<>
+			<Campaign lang={lang} />
 			<Hero lang={lang} region={region} />
 			<Video lang={lang} />
 			<WhatWouldChange

--- a/website/src/app/[lang]/[region]/(website)/(home)/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/(home)/page.tsx
@@ -8,8 +8,8 @@ import { ThreeApproaches } from '@/app/[lang]/[region]/(website)/(home)/(section
 import { WhatWouldChange } from '@/app/[lang]/[region]/(website)/(home)/(sections)/what-would-change';
 import NewsletterPopup from '@/components/newsletter-popup/newsletter-popup';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
-import { Video } from './(sections)/video';
 import { Campaign } from './(sections)/active-campaign';
+import { Video } from './(sections)/video';
 
 export default async function Page({ params: { lang, region } }: DefaultPageProps) {
 	const translator = await Translator.getInstance({ language: lang, namespaces: ['website-home', 'website-videos'] });

--- a/website/src/components/newsletter-popup/newsletter-popup-client.tsx
+++ b/website/src/components/newsletter-popup/newsletter-popup-client.tsx
@@ -85,6 +85,7 @@ type NewsletterPopupClientProps = {
 
 export const NewsletterPopupClient = ({ delay, lang, translations }: NewsletterPopupClientProps) => {
 	useEffect(() => {
+		if (localStorage.getItem('cookie_consent') === null) return; // Do not show the popup if the user has responded to the cookie consent banner
 		toast.dismiss();
 		const timeout = setTimeout(() => {
 			toast.custom(

--- a/website/src/components/tracking/cookie-consent-banner.tsx
+++ b/website/src/components/tracking/cookie-consent-banner.tsx
@@ -27,7 +27,7 @@ export function CookieConsentBanner({ translations }: CookieConsentBannerClientP
 	if (hideBanner) return null;
 
 	return (
-		<Card className="fixed bottom-12 left-2 right-2 mx-auto max-w-6xl shadow-xl md:left-4 md:right-4">
+		<Card className="fixed bottom-2 left-2 right-2 mx-auto max-w-6xl shadow-xl md:left-4 md:right-4">
 			<CardContent className="flex flex-col space-y-2 p-4">
 				<Typography className="md:col-span-3">
 					<Typography as="span" dangerouslySetInnerHTML={{ __html: translations.text }} />


### PR DESCRIPTION
Issue: We’ve received feedback that potential donors struggle to return to the campaign page, potentially reducing donations. I've addressed this issue promptly.

Solution: introducing a prominently displayed badge on the landing page. For our current campaign—the only one running at present—I hardcoded the URL and name directly into the badge.

Future: Looking ahead, we may automate this process by selecting which campaign to highlight directly from our backend, depending on the active campaign. Also we could display the progress of a campaign. However, this would require further design work and development, and for now, the hardcoded badge serves its purpose.

Note: The badge will be removed once the [campaign](https://socialincome.org/en/ch/campaign/MZmXEVHlDjOOFOMk82jW) ends. (responsibility of @ssandino)

