### PR TITLE
feature(general): update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,5 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-/ui/ rene@socialincome.org
-.github/workflows/ui.yml rene@socialincome.org
-
 firebase.json andras@socialincome.org michael@socialincome.org
 firestore.rules andras@socialincome.org michael@socialincome.org
 package.json andras@socialincome.org michael@socialincome.org
@@ -10,8 +7,10 @@ storage.rules andras@socialincome.org michael@socialincome.org
 
 admin/ andras@socialincome.org michael@socialincome.org sandino@socialincome.org
 functions/ andras@socialincome.org michael@socialincome.org sandino@socialincome.org
-shared/ andras@socialincome.org michael@socialincome.org sandino@socialincome.org
+shared/ andras@socialincome.org michael@socialincome.org sandino@socialincome.org dev@socialincome.org
 recipients_app/ verena@socialincome.org mikolaj@socialincome.org sandino@socialincome.org
-website/ andras@socialincome.org michael@socialincome.org sandino@socialincome.org
+website/ andras@socialincome.org michael@socialincome.org sandino@socialincome.org dev@socialincome.org
+ui/ andras@socialincome.org michael@socialincome.org sandino@socialincome.org
+.github/workflows/ui.yml andras@socialincome.org michael@socialincome.org sandino@socialincome.org
 
 *.md sandino@socialincome.org andras@socialincome.org michael@socialincome.org


### PR DESCRIPTION
As discussed in #791 with @renestalder: he requested to be replaced as code owner. I added instead the three regular code owners until further notice. Additionally, I have added our private GitHub dev account (account used for this PR) as a code owner for the website and shared folder, enabling quicker fixes, such as typos and similar issues.