### PR TITLE
Remove gradle plugin "com.google.firebase.crashlytics" to fix the Android build

### DIFF
--- a/recipients_app/android/app/build.gradle
+++ b/recipients_app/android/app/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
     id "com.google.gms.google-services"
-    id "com.google.firebase.crashlytics"
 }
 
 def localProperties = new Properties()


### PR DESCRIPTION
This fixes the CodeMagic build error

```
Where:
Build file '/Users/builder/clone/recipients_app/android/app/build.gradle' line: 6

What went wrong:
Plugin [id: 'com.google.firebase.crashlytics'] was not found in any of the following sources:
```