### PR TITLE
feature(website): dummy surveys for mobile app in demo mode

### DIFF
--- a/shared/locales/en/website-survey.json
+++ b/shared/locales/en/website-survey.json
@@ -1,4 +1,12 @@
 {
+	"titleOnboarding": "Onboarding Survey",
+	"titleCheckin": "Check-in Survey",
+	"titleOffboarding": "Offboarding Survey",
+	"titleFollowup": "Follow-up Survey",
+	"select": "Select",
+	"save": "Save",
+	"freetext": "Enter your answer",
+	"demo": "In demo mode the survey can't be saved",
 	"survey": {
 		"login": {
 			"message": "Please enter your phone number and the access token which we sent you.",

--- a/website/src/app/[lang]/[region]/(website)/survey/checkin/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/survey/checkin/page.tsx
@@ -1,314 +1,305 @@
+import { DefaultPageProps } from '@/app/[lang]/[region]';
+import { getMetadata } from '@/metadata';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
-import {
-  BaseContainer,
-  Typography
-} from "@socialincome/ui";
-import { DefaultPageProps } from "@/app/[lang]/[region]";
-import { getMetadata } from "@/metadata";
+import { BaseContainer, Typography } from '@socialincome/ui';
 
 export async function generateMetadata({ params }: DefaultPageProps) {
-  return getMetadata(params.lang, 'website-survey');
+	return getMetadata(params.lang, 'website-survey');
 }
 
 export default async function Page({ params: { lang } }: DefaultPageProps) {
-  const translator = await Translator.getInstance({
-    language: lang,
-    namespaces: ['website-survey'],
-  });
+	const translator = await Translator.getInstance({
+		language: lang,
+		namespaces: ['website-survey'],
+	});
 
-  return (
-    <BaseContainer className="mx-auto flex max-w-2xl flex-col pt-8 pb-16 space-y-10">
-      <Typography size="5xl" weight="bold">
-        {translator.t('titleCheckin')}
-      </Typography>
+	return (
+		<BaseContainer className="mx-auto flex max-w-2xl flex-col space-y-10 pb-16 pt-8">
+			<Typography size="5xl" weight="bold">
+				{translator.t('titleCheckin')}
+			</Typography>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.spendingTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.spendingChoices.education")}</option>
-          <option value="">{translator.t("survey.questions.spendingChoices.food")}</option>
-          <option value="">{translator.t("survey.questions.spendingChoices.housing")}</option>
-          <option value="">{translator.t("survey.questions.spendingChoices.healthCare")}</option>
-          <option value="">{translator.t("survey.questions.spendingChoices.mobility")}</option>
-          <option value="">{translator.t("survey.questions.spendingChoices.saving")}</option>
-          <option value="">{translator.t("survey.questions.spendingChoices.investment")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.spendingTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.spendingChoices.education')}</option>
+					<option value="">{translator.t('survey.questions.spendingChoices.food')}</option>
+					<option value="">{translator.t('survey.questions.spendingChoices.housing')}</option>
+					<option value="">{translator.t('survey.questions.spendingChoices.healthCare')}</option>
+					<option value="">{translator.t('survey.questions.spendingChoices.mobility')}</option>
+					<option value="">{translator.t('survey.questions.spendingChoices.saving')}</option>
+					<option value="">{translator.t('survey.questions.spendingChoices.investment')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.plannedAchievementRemainingTitleV1")}
-        </Typography>
-        <input
-          type="text"
-          className="w-full p-2 border border-gray-300 rounded"
-          placeholder={translator.t("freetext")}
-        />
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.plannedAchievementRemainingTitleV1')}
+				</Typography>
+				<input
+					type="text"
+					className="w-full rounded border border-gray-300 p-2"
+					placeholder={translator.t('freetext')}
+				/>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.livingLocationTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaUrbanFreetown")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaRural")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.easternProvince")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.northernProvince")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.southernProvince")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.northWestProvince")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.livingLocationTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.westernAreaUrbanFreetown')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.westernAreaRural')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.easternProvince')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.northernProvince')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.southernProvince')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.northWestProvince')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.maritalStatusTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.married")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.widowed")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.divorced")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.separated")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.neverMarried")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.maritalStatusTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.married')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.widowed')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.divorced')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.separated')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.neverMarried')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.hasDependentsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.hasDependentsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.nrDependentsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.1-2")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.3-4")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.5-7")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.8-10")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.10-")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.nrDependentsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.1-2')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.3-4')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.5-7')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.8-10')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.10-')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.attendingSchoolV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.attendingSchoolV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.employmentStatusTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.employed")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.selfEmployed")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.notEmployed")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.retired")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.employmentStatusTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.employed')}</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.selfEmployed')}</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.notEmployed')}</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.retired')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.notEmployedTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.notEmployedTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.disabilityTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.disabilityTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.skippingMealsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.skippingMealsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.skippingMealsLastWeekTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.skippingMealsLastWeekTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.skippingMealsLastWeek3MealsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.skippingMealsLastWeek3MealsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.unexpectedExpensesCoveredTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.unexpectedExpensesCoveredTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.savingsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.savingsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.debtPersonalTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.debtPersonalTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.debtPersonalRepayTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.debtPersonalRepayTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.debtHouseholdTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.debtHouseholdTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.debtHouseholdWhoRepaysTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.debtHouseholdWhoRepaysTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.otherSupportTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.otherSupportTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="text-center pt-12">
-        <button
-          className="w-full p-4 bg-gray-400 text-white font-bold rounded cursor-not-allowed"
-          disabled
-        >
-          {translator.t("save")}
-        </button>
-        <p className="mt-2 text-gray-600">
-          {translator.t("demo")}
-        </p>
-      </div>
-
-    </BaseContainer>
-  );
+			<div className="pt-12 text-center">
+				<button className="w-full cursor-not-allowed rounded bg-gray-400 p-4 font-bold text-white" disabled>
+					{translator.t('save')}
+				</button>
+				<p className="mt-2 text-gray-600">{translator.t('demo')}</p>
+			</div>
+		</BaseContainer>
+	);
 }

--- a/website/src/app/[lang]/[region]/(website)/survey/checkin/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/survey/checkin/page.tsx
@@ -1,0 +1,314 @@
+import { Translator } from '@socialincome/shared/src/utils/i18n';
+import {
+  BaseContainer,
+  Typography
+} from "@socialincome/ui";
+import { DefaultPageProps } from "@/app/[lang]/[region]";
+import { getMetadata } from "@/metadata";
+
+export async function generateMetadata({ params }: DefaultPageProps) {
+  return getMetadata(params.lang, 'website-survey');
+}
+
+export default async function Page({ params: { lang } }: DefaultPageProps) {
+  const translator = await Translator.getInstance({
+    language: lang,
+    namespaces: ['website-survey'],
+  });
+
+  return (
+    <BaseContainer className="mx-auto flex max-w-2xl flex-col pt-8 pb-16 space-y-10">
+      <Typography size="5xl" weight="bold">
+        {translator.t('titleCheckin')}
+      </Typography>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.spendingTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.spendingChoices.education")}</option>
+          <option value="">{translator.t("survey.questions.spendingChoices.food")}</option>
+          <option value="">{translator.t("survey.questions.spendingChoices.housing")}</option>
+          <option value="">{translator.t("survey.questions.spendingChoices.healthCare")}</option>
+          <option value="">{translator.t("survey.questions.spendingChoices.mobility")}</option>
+          <option value="">{translator.t("survey.questions.spendingChoices.saving")}</option>
+          <option value="">{translator.t("survey.questions.spendingChoices.investment")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.plannedAchievementRemainingTitleV1")}
+        </Typography>
+        <input
+          type="text"
+          className="w-full p-2 border border-gray-300 rounded"
+          placeholder={translator.t("freetext")}
+        />
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.livingLocationTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaUrbanFreetown")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaRural")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.easternProvince")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.northernProvince")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.southernProvince")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.northWestProvince")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.maritalStatusTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.married")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.widowed")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.divorced")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.separated")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.neverMarried")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.hasDependentsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.nrDependentsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.1-2")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.3-4")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.5-7")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.8-10")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.10-")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.attendingSchoolV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.employmentStatusTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.employed")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.selfEmployed")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.notEmployed")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.retired")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.notEmployedTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.disabilityTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.skippingMealsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.skippingMealsLastWeekTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.skippingMealsLastWeek3MealsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.unexpectedExpensesCoveredTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.savingsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.debtPersonalTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.debtPersonalRepayTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.debtHouseholdTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.debtHouseholdWhoRepaysTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.otherSupportTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="text-center pt-12">
+        <button
+          className="w-full p-4 bg-gray-400 text-white font-bold rounded cursor-not-allowed"
+          disabled
+        >
+          {translator.t("save")}
+        </button>
+        <p className="mt-2 text-gray-600">
+          {translator.t("demo")}
+        </p>
+      </div>
+
+    </BaseContainer>
+  );
+}

--- a/website/src/app/[lang]/[region]/(website)/survey/followup/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/survey/followup/page.tsx
@@ -1,0 +1,235 @@
+import { Translator } from '@socialincome/shared/src/utils/i18n';
+import {
+  BaseContainer,
+  Typography
+} from "@socialincome/ui";
+import { DefaultPageProps } from "@/app/[lang]/[region]";
+import { getMetadata } from "@/metadata";
+
+export async function generateMetadata({ params }: DefaultPageProps) {
+  return getMetadata(params.lang, 'website-survey');
+}
+
+export default async function Page({ params: { lang } }: DefaultPageProps) {
+  const translator = await Translator.getInstance({
+    language: lang,
+    namespaces: ['website-survey'],
+  });
+
+  return (
+    <BaseContainer className="mx-auto flex max-w-2xl flex-col pt-8 pb-16 space-y-10">
+      <Typography size="5xl" weight="bold">
+        {translator.t('titleFollowup')}
+      </Typography>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.financialIndependenceTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.longEnoughTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.livingLocationTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaUrbanFreetown")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaRural")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.easternProvince")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.northernProvince")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.southernProvince")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.northWestProvince")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.maritalStatusTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.married")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.widowed")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.divorced")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.separated")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.neverMarried")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.hasDependentsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.nrDependentsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.1-2")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.3-4")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.5-7")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.8-10")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.10-")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.attendingSchoolV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.employmentStatusTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.employed")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.selfEmployed")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.notEmployed")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.retired")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.notEmployedTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.disabilityTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.skippingMealsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.skippingMealsLastWeekTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.skippingMealsLastWeek3MealsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.unexpectedExpensesCoveredTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.savingsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+
+    </BaseContainer>
+  );
+}

--- a/website/src/app/[lang]/[region]/(website)/survey/followup/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/survey/followup/page.tsx
@@ -1,235 +1,230 @@
+import { DefaultPageProps } from '@/app/[lang]/[region]';
+import { getMetadata } from '@/metadata';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
-import {
-  BaseContainer,
-  Typography
-} from "@socialincome/ui";
-import { DefaultPageProps } from "@/app/[lang]/[region]";
-import { getMetadata } from "@/metadata";
+import { BaseContainer, Typography } from '@socialincome/ui';
 
 export async function generateMetadata({ params }: DefaultPageProps) {
-  return getMetadata(params.lang, 'website-survey');
+	return getMetadata(params.lang, 'website-survey');
 }
 
 export default async function Page({ params: { lang } }: DefaultPageProps) {
-  const translator = await Translator.getInstance({
-    language: lang,
-    namespaces: ['website-survey'],
-  });
+	const translator = await Translator.getInstance({
+		language: lang,
+		namespaces: ['website-survey'],
+	});
 
-  return (
-    <BaseContainer className="mx-auto flex max-w-2xl flex-col pt-8 pb-16 space-y-10">
-      <Typography size="5xl" weight="bold">
-        {translator.t('titleFollowup')}
-      </Typography>
+	return (
+		<BaseContainer className="mx-auto flex max-w-2xl flex-col space-y-10 pb-16 pt-8">
+			<Typography size="5xl" weight="bold">
+				{translator.t('titleFollowup')}
+			</Typography>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.financialIndependenceTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.financialIndependenceTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.longEnoughTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.longEnoughTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.livingLocationTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaUrbanFreetown")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaRural")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.easternProvince")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.northernProvince")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.southernProvince")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.northWestProvince")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.livingLocationTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.westernAreaUrbanFreetown')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.westernAreaRural')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.easternProvince')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.northernProvince')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.southernProvince')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.northWestProvince')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.maritalStatusTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.married")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.widowed")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.divorced")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.separated")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.neverMarried")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.maritalStatusTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.married')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.widowed')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.divorced')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.separated')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.neverMarried')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.hasDependentsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.hasDependentsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.nrDependentsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.1-2")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.3-4")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.5-7")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.8-10")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.10-")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.nrDependentsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.1-2')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.3-4')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.5-7')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.8-10')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.10-')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.attendingSchoolV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.attendingSchoolV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.employmentStatusTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.employed")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.selfEmployed")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.notEmployed")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.retired")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.employmentStatusTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.employed')}</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.selfEmployed')}</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.notEmployed')}</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.retired')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.notEmployedTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.notEmployedTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.disabilityTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.disabilityTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.skippingMealsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.skippingMealsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.skippingMealsLastWeekTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.skippingMealsLastWeekTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.skippingMealsLastWeek3MealsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.skippingMealsLastWeek3MealsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.unexpectedExpensesCoveredTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.unexpectedExpensesCoveredTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.savingsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
-
-
-    </BaseContainer>
-  );
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.savingsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
+		</BaseContainer>
+	);
 }

--- a/website/src/app/[lang]/[region]/(website)/survey/offboarding/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/survey/offboarding/page.tsx
@@ -1,0 +1,306 @@
+import { Translator } from '@socialincome/shared/src/utils/i18n';
+import {
+  BaseContainer,
+  Typography
+} from "@socialincome/ui";
+import { DefaultPageProps } from "@/app/[lang]/[region]";
+import { getMetadata } from "@/metadata";
+
+export async function generateMetadata({ params }: DefaultPageProps) {
+  return getMetadata(params.lang, 'website-survey');
+}
+
+export default async function Page({ params: { lang } }: DefaultPageProps) {
+  const translator = await Translator.getInstance({
+    language: lang,
+    namespaces: ['website-survey'],
+  });
+
+  return (
+    <BaseContainer className="mx-auto flex max-w-2xl flex-col pt-8 pb-16 space-y-10">
+      <Typography size="5xl" weight="bold">
+        {translator.t('titleOffboarding')}
+      </Typography>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.financialIndependenceTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.impactLifeGeneralTitleV1")}
+        </Typography>
+        <input
+          type="text"
+          className="w-full p-2 border border-gray-300 rounded"
+          placeholder={translator.t("freetext")}
+        />
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.achievementsAchievedTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.achievementsNotAchievedCommentTitleV1")}
+        </Typography>
+        <input
+          type="text"
+          className="w-full p-2 border border-gray-300 rounded"
+          placeholder={translator.t("freetext")}
+        />
+      </div>
+
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.happierTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.happierCommentTitleV1")}
+        </Typography>
+        <input
+          type="text"
+          className="w-full p-2 border border-gray-300 rounded"
+          placeholder={translator.t("freetext")}
+        />
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.longEnoughTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.livingLocationTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaUrbanFreetown")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaRural")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.easternProvince")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.northernProvince")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.southernProvince")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.northWestProvince")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.maritalStatusTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.married")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.widowed")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.divorced")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.separated")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.neverMarried")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.hasDependentsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.nrDependentsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.1-2")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.3-4")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.5-7")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.8-10")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.10-")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.attendingSchoolV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.employmentStatusTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.employed")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.selfEmployed")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.notEmployed")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.retired")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.notEmployedTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.disabilityTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.skippingMealsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.skippingMealsLastWeekTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.skippingMealsLastWeek3MealsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.unexpectedExpensesCoveredTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.savingsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="text-center pt-12">
+        <button
+          className="w-full p-4 bg-gray-400 text-white font-bold rounded cursor-not-allowed"
+          disabled
+        >
+          {translator.t("save")}
+        </button>
+        <p className="mt-2 text-gray-600">
+          {translator.t("demo")}
+        </p>
+      </div>
+
+    </BaseContainer>
+  );
+}

--- a/website/src/app/[lang]/[region]/(website)/survey/offboarding/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/survey/offboarding/page.tsx
@@ -1,306 +1,296 @@
+import { DefaultPageProps } from '@/app/[lang]/[region]';
+import { getMetadata } from '@/metadata';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
-import {
-  BaseContainer,
-  Typography
-} from "@socialincome/ui";
-import { DefaultPageProps } from "@/app/[lang]/[region]";
-import { getMetadata } from "@/metadata";
+import { BaseContainer, Typography } from '@socialincome/ui';
 
 export async function generateMetadata({ params }: DefaultPageProps) {
-  return getMetadata(params.lang, 'website-survey');
+	return getMetadata(params.lang, 'website-survey');
 }
 
 export default async function Page({ params: { lang } }: DefaultPageProps) {
-  const translator = await Translator.getInstance({
-    language: lang,
-    namespaces: ['website-survey'],
-  });
+	const translator = await Translator.getInstance({
+		language: lang,
+		namespaces: ['website-survey'],
+	});
 
-  return (
-    <BaseContainer className="mx-auto flex max-w-2xl flex-col pt-8 pb-16 space-y-10">
-      <Typography size="5xl" weight="bold">
-        {translator.t('titleOffboarding')}
-      </Typography>
+	return (
+		<BaseContainer className="mx-auto flex max-w-2xl flex-col space-y-10 pb-16 pt-8">
+			<Typography size="5xl" weight="bold">
+				{translator.t('titleOffboarding')}
+			</Typography>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.financialIndependenceTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.financialIndependenceTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.impactLifeGeneralTitleV1")}
-        </Typography>
-        <input
-          type="text"
-          className="w-full p-2 border border-gray-300 rounded"
-          placeholder={translator.t("freetext")}
-        />
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.impactLifeGeneralTitleV1')}
+				</Typography>
+				<input
+					type="text"
+					className="w-full rounded border border-gray-300 p-2"
+					placeholder={translator.t('freetext')}
+				/>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.achievementsAchievedTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.achievementsAchievedTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.achievementsNotAchievedCommentTitleV1")}
-        </Typography>
-        <input
-          type="text"
-          className="w-full p-2 border border-gray-300 rounded"
-          placeholder={translator.t("freetext")}
-        />
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.achievementsNotAchievedCommentTitleV1')}
+				</Typography>
+				<input
+					type="text"
+					className="w-full rounded border border-gray-300 p-2"
+					placeholder={translator.t('freetext')}
+				/>
+			</div>
 
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.happierTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.happierTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.happierCommentTitleV1')}
+				</Typography>
+				<input
+					type="text"
+					className="w-full rounded border border-gray-300 p-2"
+					placeholder={translator.t('freetext')}
+				/>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.happierCommentTitleV1")}
-        </Typography>
-        <input
-          type="text"
-          className="w-full p-2 border border-gray-300 rounded"
-          placeholder={translator.t("freetext")}
-        />
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.longEnoughTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.longEnoughTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.livingLocationTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.westernAreaUrbanFreetown')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.westernAreaRural')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.easternProvince')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.northernProvince')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.southernProvince')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.northWestProvince')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.livingLocationTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaUrbanFreetown")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaRural")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.easternProvince")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.northernProvince")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.southernProvince")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.northWestProvince")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.maritalStatusTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.married')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.widowed')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.divorced')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.separated')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.neverMarried')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.maritalStatusTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.married")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.widowed")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.divorced")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.separated")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.neverMarried")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.hasDependentsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.hasDependentsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.nrDependentsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.1-2')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.3-4')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.5-7')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.8-10')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.10-')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.nrDependentsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.1-2")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.3-4")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.5-7")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.8-10")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.10-")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.attendingSchoolV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.attendingSchoolV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.employmentStatusTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.employed')}</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.selfEmployed')}</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.notEmployed')}</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.retired')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.employmentStatusTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.employed")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.selfEmployed")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.notEmployed")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.retired")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.notEmployedTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.notEmployedTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.disabilityTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.disabilityTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.skippingMealsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.skippingMealsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.skippingMealsLastWeekTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.skippingMealsLastWeekTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.skippingMealsLastWeek3MealsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.skippingMealsLastWeek3MealsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.unexpectedExpensesCoveredTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.unexpectedExpensesCoveredTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.savingsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.savingsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
-
-      <div className="text-center pt-12">
-        <button
-          className="w-full p-4 bg-gray-400 text-white font-bold rounded cursor-not-allowed"
-          disabled
-        >
-          {translator.t("save")}
-        </button>
-        <p className="mt-2 text-gray-600">
-          {translator.t("demo")}
-        </p>
-      </div>
-
-    </BaseContainer>
-  );
+			<div className="pt-12 text-center">
+				<button className="w-full cursor-not-allowed rounded bg-gray-400 p-4 font-bold text-white" disabled>
+					{translator.t('save')}
+				</button>
+				<p className="mt-2 text-gray-600">{translator.t('demo')}</p>
+			</div>
+		</BaseContainer>
+	);
 }

--- a/website/src/app/[lang]/[region]/(website)/survey/onboarding/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/survey/onboarding/page.tsx
@@ -1,295 +1,286 @@
+import { DefaultPageProps } from '@/app/[lang]/[region]';
+import { getMetadata } from '@/metadata';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
-import {
-  BaseContainer,
-  Typography
-} from "@socialincome/ui";
-import { DefaultPageProps } from "@/app/[lang]/[region]";
-import { getMetadata } from "@/metadata";
+import { BaseContainer, Typography } from '@socialincome/ui';
 
 export async function generateMetadata({ params }: DefaultPageProps) {
-  return getMetadata(params.lang, 'website-survey');
+	return getMetadata(params.lang, 'website-survey');
 }
 
 export default async function Page({ params: { lang } }: DefaultPageProps) {
-  const translator = await Translator.getInstance({
-    language: lang,
-    namespaces: ['website-survey'],
-  });
+	const translator = await Translator.getInstance({
+		language: lang,
+		namespaces: ['website-survey'],
+	});
 
-  return (
-    <BaseContainer className="mx-auto flex max-w-2xl flex-col pt-8 pb-16 space-y-10">
-      <Typography size="5xl" weight="bold">
-        {translator.t('titleOnboarding')}
-      </Typography>
+	return (
+		<BaseContainer className="mx-auto flex max-w-2xl flex-col space-y-10 pb-16 pt-8">
+			<Typography size="5xl" weight="bold">
+				{translator.t('titleOnboarding')}
+			</Typography>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.plannedAchievementTitleV1")}
-        </Typography>
-        <input
-          type="text"
-          className="w-full p-2 border border-gray-300 rounded"
-          placeholder={translator.t("freetext")}
-        />
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.plannedAchievementTitleV1')}
+				</Typography>
+				<input
+					type="text"
+					className="w-full rounded border border-gray-300 p-2"
+					placeholder={translator.t('freetext')}
+				/>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.livingLocationTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaUrbanFreetown")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaRural")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.easternProvince")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.northernProvince")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.southernProvince")}</option>
-          <option value="">{translator.t("survey.questions.livingLocationChoices.northWestProvince")}</option>
-        </select>
-      </div>
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.maritalStatusTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.married")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.widowed")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.divorced")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.separated")}</option>
-          <option value="">{translator.t("survey.questions.maritalStatusChoices.neverMarried")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.livingLocationTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.westernAreaUrbanFreetown')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.westernAreaRural')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.easternProvince')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.northernProvince')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.southernProvince')}</option>
+					<option value="">{translator.t('survey.questions.livingLocationChoices.northWestProvince')}</option>
+				</select>
+			</div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.maritalStatusTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.married')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.widowed')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.divorced')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.separated')}</option>
+					<option value="">{translator.t('survey.questions.maritalStatusChoices.neverMarried')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.hasDependentsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.hasDependentsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.nrDependentsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.1-2")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.3-4")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.5-7")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.8-10")}</option>
-          <option value="">{translator.t("survey.questions.nrDependentsChoices.10-")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.nrDependentsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.1-2')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.3-4')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.5-7')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.8-10')}</option>
+					<option value="">{translator.t('survey.questions.nrDependentsChoices.10-')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.attendingSchoolV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.attendingSchoolV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.employmentStatusTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.employed")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.selfEmployed")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.notEmployed")}</option>
-          <option value="">{translator.t("survey.questions.employmentStatusChoices.retired")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.employmentStatusTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.employed')}</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.selfEmployed')}</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.notEmployed')}</option>
+					<option value="">{translator.t('survey.questions.employmentStatusChoices.retired')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.notEmployedTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.notEmployedTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.disabilityTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.disabilityTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.skippingMealsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.skippingMealsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.skippingMealsLastWeekTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.skippingMealsLastWeekTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.skippingMealsLastWeek3MealsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.skippingMealsLastWeek3MealsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.unexpectedExpensesCoveredTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.unexpectedExpensesCoveredTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.savingsTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.savingsTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.debtPersonalTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.debtPersonalTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.debtPersonalRepayTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.debtPersonalRepayTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.debtHouseholdTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.debtHouseholdTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.debtHouseholdWhoRepaysTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.debtHouseholdWhoRepaysTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="space-y-4">
-        <Typography size="2xl" weight="bold">
-          {translator.t("survey.questions.otherSupportTitleV1")}
-        </Typography>
-        <select
-          className="w-full p-2 border border-gray-300 rounded"
-        >
-          <option value="" disabled selected>{translator.t("select")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
-          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
-        </select>
-      </div>
+			<div className="space-y-4">
+				<Typography size="2xl" weight="bold">
+					{translator.t('survey.questions.otherSupportTitleV1')}
+				</Typography>
+				<select className="w-full rounded border border-gray-300 p-2">
+					<option value="" disabled selected>
+						{translator.t('select')}
+					</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.yes')}</option>
+					<option value="">{translator.t('survey.questions.yesNoChoices.no')}</option>
+				</select>
+			</div>
 
-      <div className="text-center pt-12">
-        <button
-          className="w-full p-4 bg-gray-400 text-white font-bold rounded cursor-not-allowed"
-          disabled
-        >
-          {translator.t("save")}
-        </button>
-        <p className="mt-2 text-gray-600">
-          {translator.t("demo")}
-        </p>
-      </div>
-
-    </BaseContainer>
-  );
+			<div className="pt-12 text-center">
+				<button className="w-full cursor-not-allowed rounded bg-gray-400 p-4 font-bold text-white" disabled>
+					{translator.t('save')}
+				</button>
+				<p className="mt-2 text-gray-600">{translator.t('demo')}</p>
+			</div>
+		</BaseContainer>
+	);
 }

--- a/website/src/app/[lang]/[region]/(website)/survey/onboarding/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/survey/onboarding/page.tsx
@@ -1,0 +1,295 @@
+import { Translator } from '@socialincome/shared/src/utils/i18n';
+import {
+  BaseContainer,
+  Typography
+} from "@socialincome/ui";
+import { DefaultPageProps } from "@/app/[lang]/[region]";
+import { getMetadata } from "@/metadata";
+
+export async function generateMetadata({ params }: DefaultPageProps) {
+  return getMetadata(params.lang, 'website-survey');
+}
+
+export default async function Page({ params: { lang } }: DefaultPageProps) {
+  const translator = await Translator.getInstance({
+    language: lang,
+    namespaces: ['website-survey'],
+  });
+
+  return (
+    <BaseContainer className="mx-auto flex max-w-2xl flex-col pt-8 pb-16 space-y-10">
+      <Typography size="5xl" weight="bold">
+        {translator.t('titleOnboarding')}
+      </Typography>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.plannedAchievementTitleV1")}
+        </Typography>
+        <input
+          type="text"
+          className="w-full p-2 border border-gray-300 rounded"
+          placeholder={translator.t("freetext")}
+        />
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.livingLocationTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaUrbanFreetown")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.westernAreaRural")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.easternProvince")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.northernProvince")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.southernProvince")}</option>
+          <option value="">{translator.t("survey.questions.livingLocationChoices.northWestProvince")}</option>
+        </select>
+      </div>
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.maritalStatusTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.married")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.widowed")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.divorced")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.separated")}</option>
+          <option value="">{translator.t("survey.questions.maritalStatusChoices.neverMarried")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.hasDependentsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.nrDependentsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.1-2")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.3-4")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.5-7")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.8-10")}</option>
+          <option value="">{translator.t("survey.questions.nrDependentsChoices.10-")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.attendingSchoolV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.employmentStatusTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.employed")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.selfEmployed")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.notEmployed")}</option>
+          <option value="">{translator.t("survey.questions.employmentStatusChoices.retired")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.notEmployedTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.disabilityTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.skippingMealsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.skippingMealsLastWeekTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.skippingMealsLastWeek3MealsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.unexpectedExpensesCoveredTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.savingsTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.debtPersonalTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.debtPersonalRepayTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.debtHouseholdTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.debtHouseholdWhoRepaysTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="space-y-4">
+        <Typography size="2xl" weight="bold">
+          {translator.t("survey.questions.otherSupportTitleV1")}
+        </Typography>
+        <select
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="" disabled selected>{translator.t("select")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.yes")}</option>
+          <option value="">{translator.t("survey.questions.yesNoChoices.no")}</option>
+        </select>
+      </div>
+
+      <div className="text-center pt-12">
+        <button
+          className="w-full p-4 bg-gray-400 text-white font-bold rounded cursor-not-allowed"
+          disabled
+        >
+          {translator.t("save")}
+        </button>
+        <p className="mt-2 text-gray-600">
+          {translator.t("demo")}
+        </p>
+      </div>
+
+    </BaseContainer>
+  );
+}


### PR DESCRIPTION
This PR addresses the issue where the mobile app couldn't display any surveys because they were only accessible to recipients. The solution implemented recreates the four surveys and includes a generic link that can be used in demo mode of the mobile app.

Important: The surveys do not need to be functional and are only viewed through the web view of the mobile app. They are intended to provide the look and feel of a survey and display the actual questions used in the recipient surveys. I intentionally used the most basic elements, such as `<input>` and `<select>`, to build the survey page. I did not include follow-up questions or ranking, and the save button is intentionally disabled.

@MDikkii : the links to include in the demo mode are: 
1. Onboarding: .../survey/onboarding
2. Checkin: .../survey/checkin
3. Offboarding:  ...survey/offboarding
4. Followup: .../survey/followup

@mkue thanks for a review, as this should go into the next release of the app