### PR TITLE
feature(functions): support twint (bugfix)

### DIFF
--- a/shared/src/types/user.ts
+++ b/shared/src/types/user.ts
@@ -53,8 +53,8 @@ export type User = {
 export const splitName = (name: string | undefined | null) => {
 	if (!name) {
 		return {
-			firstname: undefined,
-			lastname: undefined,
+			firstname: '',
+			lastname: '',
 		};
 	}
 	const stripeNames = name.trim().split(' ');


### PR DESCRIPTION
To fix:
`Error: Value for argument "data" is not a valid Firestore document. Cannot use "undefined" as a Firestore value (found in field "personal.name"). If you want to ignore undefined values,`