### PR TITLE
website(bugfix): fix theme-light card color 

### DIFF
--- a/ui/src/globals.css
+++ b/ui/src/globals.css
@@ -68,11 +68,12 @@
 	.theme-light {
 		--background: 212 59% 40%;
 		--foreground: 20 14.3% 4.1%;
+
 		--muted: 222 100% 98%;
 		--muted-foreground: 0 0% 30%;
 
-		--card: 212 59% 40%;
-		--card-muted: 222 100% 99%;
+		--card: 0 100% 100%;
+		--card-muted: 0 0% 97%;
 		--card-foreground: 206 99% 31%;
 		--card-foreground-muted: 50 33% 45%;
 	}
@@ -104,7 +105,6 @@
 	.theme-light {
 		@apply bg-background text-foreground;
 	}
-
 	.theme-blue {
 		@apply bg-background text-foreground;
 	}

--- a/website/src/app/[lang]/[region]/(blue-theme)/donate/individual/donation-form.tsx
+++ b/website/src/app/[lang]/[region]/(blue-theme)/donate/individual/donation-form.tsx
@@ -206,7 +206,7 @@ export function DonationForm({ amount, translations, lang, region }: DonationFor
 						<CurrencySelector className="h-16 w-full sm:flex-1" currencies={websiteCurrencies} fontSize="lg" />
 					</div>
 					{form.watch('monthlyIncome') > 0 && (
-						<Card className="theme-light">
+						<Card className="theme-light bg-card-muted">
 							<CardHeader>
 								<DonationImpact lang={lang} translations={translations.donationImpact} />
 							</CardHeader>

--- a/website/src/app/[lang]/[region]/(blue-theme)/donate/individual/donation-form.tsx
+++ b/website/src/app/[lang]/[region]/(blue-theme)/donate/individual/donation-form.tsx
@@ -206,7 +206,7 @@ export function DonationForm({ amount, translations, lang, region }: DonationFor
 						<CurrencySelector className="h-16 w-full sm:flex-1" currencies={websiteCurrencies} fontSize="lg" />
 					</div>
 					{form.watch('monthlyIncome') > 0 && (
-						<Card className="theme-light bg-card-muted">
+						<Card className="theme-light">
 							<CardHeader>
 								<DonationImpact lang={lang} translations={translations.donationImpact} />
 							</CardHeader>


### PR DESCRIPTION
Fixes the following issue on the [donation page](https://staging.socialincome.org/en/ch/donate/individual):  
<img width="1386" alt="Screenshot 2024-11-22 at 23 18 54" src="https://github.com/user-attachments/assets/33c5263a-03f2-40ba-8505-5a181b5049ba">

With a background color: 
<img width="1197" alt="Screenshot 2024-11-22 at 23 33 11" src="https://github.com/user-attachments/assets/a90ef293-7c90-442a-9b20-a21eb07117ec">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated color themes for improved visual aesthetics in the application.
	- Enhanced the `.theme-light` and `.theme-blue` classes for better user experience.
  
- **Bug Fixes**
	- Adjusted color variables to ensure consistency across themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->