### PR TITLE
Website: Transparency page (fixing bugs)

### DIFF
--- a/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-1.tsx
+++ b/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-1.tsx
@@ -22,6 +22,7 @@ export async function Section1({ params, paymentStats, contributionStats }: Sect
 				contributorCount: contributionStats.totalContributorsCount,
 				value: roundAmount(contributionStats.totalContributionsAmount),
 				currency: params.currency,
+				maximumFractionDigits: 0,
 			},
 		}),
 	];

--- a/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-1.tsx
+++ b/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-1.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, Typography } from '@socialincome/ui';
 import _ from 'lodash';
 import { SectionProps } from './page';
 
-export const roundAmount = (amount: number) => (!Number.isNaN(amount) ? Math.round(amount / 10) * 10 : 0);
+export const roundAmount = (amount: number) => (amount ? Math.round(amount / 10) * 10 : 0);
 
 export async function Section1({ params, paymentStats, contributionStats }: SectionProps) {
 	const translator = await Translator.getInstance({ language: params.lang, namespaces: ['website-finances'] });

--- a/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-1.tsx
+++ b/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-1.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, Typography } from '@socialincome/ui';
 import _ from 'lodash';
 import { SectionProps } from './page';
 
-export const roundAmount = (amount: number) => Math.round(amount / 10) * 10;
+export const roundAmount = (amount: number) => (!isNaN(amount) ? Math.round(amount / 10) * 10 : 0);
 
 export async function Section1({ params, paymentStats, contributionStats }: SectionProps) {
 	const translator = await Translator.getInstance({ language: params.lang, namespaces: ['website-finances'] });

--- a/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-1.tsx
+++ b/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-1.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, Typography } from '@socialincome/ui';
 import _ from 'lodash';
 import { SectionProps } from './page';
 
-export const roundAmount = (amount: number) => (!isNaN(amount) ? Math.round(amount / 10) * 10 : 0);
+export const roundAmount = (amount: number) => (!Number.isNaN(amount) ? Math.round(amount / 10) * 10 : 0);
 
 export async function Section1({ params, paymentStats, contributionStats }: SectionProps) {
 	const translator = await Translator.getInstance({ language: params.lang, namespaces: ['website-finances'] });

--- a/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-2.tsx
+++ b/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-2.tsx
@@ -18,7 +18,11 @@ export async function Section2({ params, contributionStats, expensesStats, payme
 			<InfoCard
 				sectionTitle={translator.t('section-2.donations')}
 				title={translator.t('amount', {
-					context: { value: roundAmount(contributionStats.totalContributionsAmount), currency: params.currency },
+					context: {
+						value: roundAmount(contributionStats.totalContributionsAmount),
+						currency: params.currency,
+						maximumFractionDigits: 0,
+					},
 				})}
 				text={translator.t('section-2.amount-since-march-2020')}
 				firstIcon={<HeartIcon className="h-8 w-8" />}
@@ -30,6 +34,7 @@ export async function Section2({ params, contributionStats, expensesStats, payme
 									context: {
 										value: roundAmount(contributionStats.totalIndividualContributionsAmount),
 										currency: params.currency,
+										maximumFractionDigits: 0,
 									},
 								})}
 							</Typography>
@@ -44,6 +49,7 @@ export async function Section2({ params, contributionStats, expensesStats, payme
 								context: {
 									value: roundAmount(paymentStats.totalPaymentsAmount),
 									currency: params.currency,
+									maximumFractionDigits: 0,
 								},
 							})}
 						</Typography>
@@ -54,6 +60,7 @@ export async function Section2({ params, contributionStats, expensesStats, payme
 										contributionStats.totalIndividualContributionsAmount - paymentStats.totalPaymentsAmount,
 									),
 									currency: params.currency,
+									maximumFractionDigits: 0,
 								},
 							})}
 						</Typography>
@@ -68,6 +75,7 @@ export async function Section2({ params, contributionStats, expensesStats, payme
 									context: {
 										value: roundAmount(contributionStats.totalInstitutionalContributionsAmount),
 										currency: params.currency,
+										maximumFractionDigits: 0,
 									},
 								})}
 							</Typography>
@@ -82,6 +90,7 @@ export async function Section2({ params, contributionStats, expensesStats, payme
 								context: {
 									value: roundAmount(expensesProject),
 									currency: params.currency,
+									maximumFractionDigits: 0,
 								},
 							})}
 						</Typography>
@@ -90,6 +99,7 @@ export async function Section2({ params, contributionStats, expensesStats, payme
 								context: {
 									value: roundAmount(contributionStats.totalInstitutionalContributionsAmount - expensesProject),
 									currency: params.currency,
+									maximumFractionDigits: 0,
 								},
 							})}
 						</Typography>

--- a/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-3.tsx
+++ b/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-3.tsx
@@ -34,9 +34,10 @@ export async function Section3({ params, contributionStats }: SectionProps) {
 								country: translator.t(entry.country),
 								total: translator.t('section-3.country-amount', {
 									context: {
+										contributorsCount: entry.usersCount,
 										value: roundAmount(entry.amount),
 										currency: params.currency,
-										contributorsCount: entry.usersCount,
+										maximumFractionDigits: 0,
 									},
 								}),
 							}}

--- a/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-4.tsx
+++ b/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-4.tsx
@@ -29,6 +29,7 @@ export async function Section4({ params, expensesStats, paymentStats, contributi
 					context: {
 						value: roundAmount(expensesTotal),
 						currency: params.currency,
+						maximumFractionDigits: 0,
 					},
 				})}
 				text={translator.t('section-4.amount-since-march-2020')}
@@ -41,6 +42,7 @@ export async function Section4({ params, expensesStats, paymentStats, contributi
 									context: {
 										value: roundAmount(paymentStats.totalPaymentsAmount),
 										currency: params.currency,
+										maximumFractionDigits: 0,
 										recipientsCount: paymentStats.totalRecipientsCount,
 									},
 								})}
@@ -51,6 +53,7 @@ export async function Section4({ params, expensesStats, paymentStats, contributi
 								context: {
 									value: roundAmount(_.last(paymentStats.totalPaymentsByMonth)?.amount as number),
 									currency: params.currency,
+									maximumFractionDigits: 0,
 									recipientsCount: _.last(paymentStats.totalPaymentsByMonth)?.recipientsCount,
 								},
 							})}
@@ -62,6 +65,7 @@ export async function Section4({ params, expensesStats, paymentStats, contributi
 										contributionStats.totalIndividualContributionsAmount - paymentStats.totalPaymentsAmount,
 									),
 									currency: params.currency,
+									maximumFractionDigits: 0,
 								},
 							})}
 						</Typography>
@@ -76,6 +80,7 @@ export async function Section4({ params, expensesStats, paymentStats, contributi
 									context: {
 										value: roundAmount(_.sum(Object.values(expensesStats.totalExpensesByType))),
 										currency: params.currency,
+										maximumFractionDigits: 0,
 									},
 								})}
 							</Typography>
@@ -85,6 +90,7 @@ export async function Section4({ params, expensesStats, paymentStats, contributi
 								context: {
 									value: roundAmount(expensesStats.totalExpensesByType.donation_fees),
 									currency: params.currency,
+									maximumFractionDigits: 0,
 								},
 							})}
 							<TooltipProvider delayDuration={100}>
@@ -101,6 +107,7 @@ export async function Section4({ params, expensesStats, paymentStats, contributi
 								context: {
 									value: roundAmount(expensesStats.totalExpensesByType.delivery_fees),
 									currency: params.currency,
+									maximumFractionDigits: 0,
 								},
 							})}
 							<TooltipProvider delayDuration={100}>
@@ -117,6 +124,7 @@ export async function Section4({ params, expensesStats, paymentStats, contributi
 								context: {
 									value: roundAmount(expensesStats.totalExpensesByType.exchange_rate_loss),
 									currency: params.currency,
+									maximumFractionDigits: 0,
 								},
 							})}
 							<TooltipProvider delayDuration={100}>
@@ -133,6 +141,7 @@ export async function Section4({ params, expensesStats, paymentStats, contributi
 								context: {
 									value: roundAmount(expensesStats.totalExpensesByType.account_fees),
 									currency: params.currency,
+									maximumFractionDigits: 0,
 								},
 							})}
 							<TooltipProvider delayDuration={100}>
@@ -147,7 +156,11 @@ export async function Section4({ params, expensesStats, paymentStats, contributi
 
 						<Typography as="div" className="flex-inline flex items-center">
 							{translator.t('section-4.staff-costs', {
-								context: { value: roundAmount(expensesStats.totalExpensesByType.staff), currency: params.currency },
+								context: {
+									value: roundAmount(expensesStats.totalExpensesByType.staff),
+									currency: params.currency,
+									maximumFractionDigits: 0,
+								},
 							})}
 							<TooltipProvider delayDuration={100}>
 								<Tooltip>
@@ -163,6 +176,7 @@ export async function Section4({ params, expensesStats, paymentStats, contributi
 								context: {
 									value: roundAmount(expensesStats.totalExpensesByType.fundraising_advertising),
 									currency: params.currency,
+									maximumFractionDigits: 0,
 								},
 							})}
 							<TooltipProvider delayDuration={100}>
@@ -179,6 +193,7 @@ export async function Section4({ params, expensesStats, paymentStats, contributi
 								context: {
 									value: roundAmount(expensesStats.totalExpensesByType.administrative),
 									currency: params.currency,
+									maximumFractionDigits: 0,
 								},
 							})}
 							<TooltipProvider delayDuration={100}>
@@ -197,7 +212,11 @@ export async function Section4({ params, expensesStats, paymentStats, contributi
 			<InfoCard
 				sectionTitle={translator.t('section-4.reserves')}
 				title={translator.t('amount', {
-					context: { value: roundAmount(reservesTotal), currency: params.currency },
+					context: {
+						value: roundAmount(reservesTotal),
+						currency: params.currency,
+						maximumFractionDigits: 0,
+					},
 				})}
 				text={translator.t('section-4.amount-since-march-2020')}
 				firstIcon={<DevicePhoneMobileIcon className="h-8 w-8" />}


### PR DESCRIPTION
Fixes #728

`i18next` currency options inherits number options from `Intl.NumberFormat`
https://www.i18next.com/translation-function/formatting#currency
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat

I have also fixed the rounding function to avoid `NaN` if the value does not exist, we can see it happens on the staging site.
https://staging.socialincome.org/en/int/transparency/finances/usd

<img width="463" alt="Screenshot 2024-12-06 at 14 05 46" src="https://github.com/user-attachments/assets/2e26034d-92a7-420a-a046-7a9b7c51989a">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in amount rounding to prevent issues with invalid inputs.
	- Updated formatting for displayed contributions and financial amounts to show whole numbers without decimals across multiple sections.

- **Bug Fixes**
	- Improved robustness of the financial calculations by ensuring proper handling of falsy values.

- **Documentation**
	- Clarified context properties in translation functions for better numerical output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->