### PR TITLE
Website: Home page explainer video (fix bug)

### DIFF
--- a/website/src/app/[lang]/[region]/(website)/(home)/(sections)/explainer-video.tsx
+++ b/website/src/app/[lang]/[region]/(website)/(home)/(sections)/explainer-video.tsx
@@ -19,7 +19,7 @@ export async function ExplainerVideo({ lang }: DefaultParams) {
 					</Typography>
 				))}
 			</Typography>
-			<div className="mx-auto mt-16 aspect-video w-96 md:mt-24 md:w-[32rem]">
+			<div className="mx-auto mt-16 aspect-video w-96 max-w-full md:mt-24 md:w-[32rem]">
 				<VimeoVideo videoId={Number(translator.t('id.video-02'))} />
 			</div>
 		</BaseContainer>


### PR DESCRIPTION
## Issue
The video has a fixed `width` (`w-96 = 384px`) and breaks the layout when viewing in mobile screens.

<img src="https://github.com/user-attachments/assets/c1da1f1b-5fa6-4b8c-bf87-38caaaf29af4" width="320" alt=""/>

## Solution
Setting the video’s `max-width` to 100% to prevent overflow regardless of the fixed width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved layout flexibility for the explainer video component, allowing it to scale responsively within its parent container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->