### PR TITLE
Set cookie with location of request country

### DIFF
--- a/shared/src/types/country.ts
+++ b/shared/src/types/country.ts
@@ -250,3 +250,5 @@ export const COUNTRY_CODES = [
 	'ZW', // 'Zimbabwe',
 ] as const;
 export type CountryCode = (typeof COUNTRY_CODES)[number];
+
+export const isValidCountryCode = (code: string): code is CountryCode => COUNTRY_CODES.includes(code as CountryCode);

--- a/shared/src/utils/stats/ContributionStatsCalculator.ts
+++ b/shared/src/utils/stats/ContributionStatsCalculator.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { DateTime } from 'luxon';
 import { FirestoreAdmin } from '../../firebase/admin/FirestoreAdmin';
 import { Contribution, CONTRIBUTION_FIRESTORE_PATH, StatusKey } from '../../types/contribution';
+import { CountryCode } from '../../types/country';
 import { Currency } from '../../types/currency';
 import { User, USER_FIRESTORE_PATH } from '../../types/user';
 import { getLatestExchangeRate } from '../exchangeRates';
@@ -30,7 +31,7 @@ export interface ContributionStats {
 type ContributionStatsEntry = {
 	userId: string;
 	isInstitution: boolean;
-	country: string;
+	country: CountryCode;
 	amount: number;
 	paymentFees: number;
 	source: string;

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import { CountryCode } from '@socialincome/shared/src/types/country';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
@@ -8,5 +9,5 @@ export function cn(...inputs: ClassValue[]) {
 /**
  * We use the files from GitHub instead of the package so that donations from new countries are automatically supported.
  */
-export const getFlagImageURL = (country: string) =>
+export const getFlagImageURL = (country: CountryCode) =>
 	`https://raw.githubusercontent.com/lipis/flag-icons/a87d8b256743c9b0df05f20de2c76a7975119045/flags/1x1/${country.toLowerCase()}.svg`;

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { CountryCode } from '@socialincome/shared/src/types/country';
+import { WebsiteRegion } from '@socialincome/website/src/i18n';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
@@ -9,5 +10,5 @@ export function cn(...inputs: ClassValue[]) {
 /**
  * We use the files from GitHub instead of the package so that donations from new countries are automatically supported.
  */
-export const getFlagImageURL = (country: CountryCode) =>
+export const getFlagImageURL = (country: CountryCode | Exclude<WebsiteRegion, 'int'>) =>
 	`https://raw.githubusercontent.com/lipis/flag-icons/a87d8b256743c9b0df05f20de2c76a7975119045/flags/1x1/${country.toLowerCase()}.svg`;

--- a/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-3-cards.tsx
+++ b/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-3-cards.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { CountryCode } from '@socialincome/shared/src/types/country';
 import { Button, Card, CardContent, Typography } from '@socialincome/ui';
 import { getFlagImageURL } from '@socialincome/ui/src/lib/utils';
 import { Children, PropsWithChildren, useState } from 'react';
 
 type CountryCardProps = {
-	country: string;
+	country: CountryCode;
 	translations: {
 		country: string;
 		total: string;

--- a/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-3.tsx
+++ b/website/src/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-3.tsx
@@ -1,4 +1,5 @@
 import { roundAmount } from '@/app/[lang]/[region]/(website)/transparency/finances/[currency]/section-1';
+import { CountryCode } from '@socialincome/shared/src/types/country';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
 import { Typography } from '@socialincome/ui';
 import { SectionProps } from './page';
@@ -10,7 +11,7 @@ export async function Section3({ params, contributionStats }: SectionProps) {
 		namespaces: ['countries', 'website-finances'],
 	});
 	const totalContributionsByCountry = contributionStats.totalContributionsByCountry as {
-		country: string;
+		country: CountryCode;
 		amount: number;
 		usersCount: number;
 	}[];

--- a/website/src/app/[lang]/[region]/index.ts
+++ b/website/src/app/[lang]/[region]/index.ts
@@ -2,10 +2,10 @@ import { WebsiteLanguage, WebsiteRegion } from '@/i18n';
 
 export const LANGUAGE_COOKIE = 'si_lang';
 export const REGION_COOKIE = 'si_region';
+export const COUNTRY_COOKIE = 'si_country';
 export const CURRENCY_COOKIE = 'si_currency';
 
 export interface DefaultParams {
-	country?: string;
 	lang: WebsiteLanguage;
 	region: WebsiteRegion;
 }

--- a/website/src/components/navbar/navbar-client.tsx
+++ b/website/src/components/navbar/navbar-client.tsx
@@ -211,15 +211,15 @@ const MobileNavigation = ({ lang, region, languages, regions, currencies, naviga
 							{translations.myProfile}
 						</NavbarLink>
 						<div className="flex-inline flex items-center">
-							{region && country && (
+							{country && (
 								<Image
+									className="mx-3 rounded-full"
 									src={getFlagImageURL(country)}
 									width={24}
 									height={24}
 									alt=""
 									priority
 									unoptimized
-									className="mx-3 rounded-full"
 								/>
 							)}
 							<Typography as="button" className="text-2xl font-medium" onClick={() => setVisibleSection('i18n')}>
@@ -331,15 +331,15 @@ const DesktopNavigation = ({ lang, region, languages, regions, currencies, navig
 			</div>
 			<div className="group/i18n flex h-full flex-1 shrink-0 basis-1/4 flex-col">
 				<div className="flex flex-row items-baseline justify-end">
-					{region && country && (
+					{country && (
 						<Image
+							className="m-auto mx-2 rounded-full"
 							src={getFlagImageURL(country)}
 							width={20}
 							height={20}
 							alt=""
 							priority
 							unoptimized
-							className="m-auto mx-2 rounded-full"
 						/>
 					)}
 					<Typography size="lg">{languages.find((l) => l.code === lang)?.translation}</Typography>

--- a/website/src/components/navbar/navbar-client.tsx
+++ b/website/src/components/navbar/navbar-client.tsx
@@ -61,6 +61,7 @@ const MobileNavigation = ({ lang, region, languages, regions, currencies, naviga
 		'main' | 'our-work' | 'about-us' | 'transparency' | 'i18n' | null
 	>(null);
 	const { country, language, setLanguage, setRegion, currency, setCurrency } = useI18n();
+	const isIntRegion = region === 'int';
 
 	useEffect(() => {
 		// Prevent scrolling when the navbar is expanded
@@ -211,13 +212,13 @@ const MobileNavigation = ({ lang, region, languages, regions, currencies, naviga
 							{translations.myProfile}
 						</NavbarLink>
 						<div className="flex-inline flex items-center">
-							{country && (
+							{(!isIntRegion || (isIntRegion && country)) && (
 								<Image
 									className="mx-3 rounded-full"
-									src={getFlagImageURL(country)}
+									src={getFlagImageURL(isIntRegion ? country! : region)}
 									width={24}
 									height={24}
-									alt=""
+									alt="Country flag"
 									priority
 									unoptimized
 								/>
@@ -262,6 +263,7 @@ const MobileNavigation = ({ lang, region, languages, regions, currencies, naviga
 
 const DesktopNavigation = ({ lang, region, languages, regions, currencies, navigation, translations }: NavbarProps) => {
 	const { country, currency, setCurrency, setLanguage, setRegion } = useI18n();
+	const isIntRegion = region === 'int';
 
 	const NavbarLink = ({ href, children, className }: { href: string; children: string; className?: string }) => (
 		<Link href={href} className={twMerge('hover:text-accent text-lg', className)}>
@@ -331,17 +333,17 @@ const DesktopNavigation = ({ lang, region, languages, regions, currencies, navig
 			</div>
 			<div className="group/i18n flex h-full flex-1 shrink-0 basis-1/4 flex-col">
 				<div className="flex flex-row items-baseline justify-end">
-					{country && (
+					{(!isIntRegion || (isIntRegion && country)) && (
 						<Image
-							className="m-auto mx-2 rounded-full"
-							src={getFlagImageURL(country)}
-							width={20}
-							height={20}
-							alt=""
+							className="mx-3 rounded-full"
+							src={getFlagImageURL(isIntRegion ? country! : region)}
+							width={24}
+							height={24}
+							alt="Country flag"
 							priority
 							unoptimized
 						/>
-					)}
+					)}{' '}
 					<Typography size="lg">{languages.find((l) => l.code === lang)?.translation}</Typography>
 				</div>
 				<div className="ml-auto mt-6 hidden h-full grid-cols-1 justify-items-start gap-2 text-left opacity-0 group-hover/navbar:grid group-hover/i18n:opacity-100 lg:grid-cols-[repeat(3,auto)] lg:justify-items-end lg:gap-8">

--- a/website/src/components/navbar/navbar-client.tsx
+++ b/website/src/components/navbar/navbar-client.tsx
@@ -335,7 +335,7 @@ const DesktopNavigation = ({ lang, region, languages, regions, currencies, navig
 				<div className="flex flex-row items-baseline justify-end">
 					{(!isIntRegion || (isIntRegion && country)) && (
 						<Image
-							className="mx-3 rounded-full"
+							className="m-auto mx-2 rounded-full"
 							src={getFlagImageURL(isIntRegion ? country! : region)}
 							width={24}
 							height={24}

--- a/website/src/components/navbar/navbar-client.tsx
+++ b/website/src/components/navbar/navbar-client.tsx
@@ -7,7 +7,6 @@ import { SIIcon } from '@/components/logos/si-icon';
 import { SILogo } from '@/components/logos/si-logo';
 import { useI18n } from '@/components/providers/context-providers';
 import { useGlobalStateProvider } from '@/components/providers/global-state-provider';
-import { useGeolocation } from '@/hooks/queries';
 import { WebsiteCurrency, WebsiteLanguage, WebsiteRegion } from '@/i18n';
 import { Bars3Icon, CheckIcon, ChevronLeftIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { Typography } from '@socialincome/ui';
@@ -57,21 +56,11 @@ type NavbarProps = {
 	sections?: NavigationSection[];
 } & DefaultParams;
 
-const MobileNavigation = ({
-	lang,
-	country,
-	region,
-	languages,
-	regions,
-	currencies,
-	navigation,
-	translations,
-}: NavbarProps) => {
-	const isIntRegion = region === 'int';
+const MobileNavigation = ({ lang, region, languages, regions, currencies, navigation, translations }: NavbarProps) => {
 	const [visibleSection, setVisibleSection] = useState<
 		'main' | 'our-work' | 'about-us' | 'transparency' | 'i18n' | null
 	>(null);
-	const { language, setLanguage, setRegion, currency, setCurrency } = useI18n();
+	const { country, language, setLanguage, setRegion, currency, setCurrency } = useI18n();
 
 	useEffect(() => {
 		// Prevent scrolling when the navbar is expanded
@@ -224,7 +213,7 @@ const MobileNavigation = ({
 						<div className="flex-inline flex items-center">
 							{region && country && (
 								<Image
-									src={getFlagImageURL(isIntRegion ? country : region)}
+									src={getFlagImageURL(country)}
 									width={24}
 									height={24}
 									alt=""
@@ -271,18 +260,9 @@ const MobileNavigation = ({
 	);
 };
 
-const DesktopNavigation = ({
-	lang,
-	country,
-	region,
-	languages,
-	regions,
-	currencies,
-	navigation,
-	translations,
-}: NavbarProps) => {
-	const isIntRegion = region === 'int';
-	let { currency, setCurrency, setLanguage, setRegion } = useI18n();
+const DesktopNavigation = ({ lang, region, languages, regions, currencies, navigation, translations }: NavbarProps) => {
+	const { country, currency, setCurrency, setLanguage, setRegion } = useI18n();
+
 	const NavbarLink = ({ href, children, className }: { href: string; children: string; className?: string }) => (
 		<Link href={href} className={twMerge('hover:text-accent text-lg', className)}>
 			{children}
@@ -353,7 +333,7 @@ const DesktopNavigation = ({
 				<div className="flex flex-row items-baseline justify-end">
 					{region && country && (
 						<Image
-							src={getFlagImageURL(isIntRegion ? country : region)}
+							src={getFlagImageURL(country)}
 							width={20}
 							height={20}
 							alt=""
@@ -420,12 +400,11 @@ const DesktopNavigation = ({
 
 export function NavbarClient(props: NavbarProps) {
 	const { backgroundColor } = useGlobalStateProvider();
-	const { geolocation } = useGeolocation();
 
 	return (
 		<nav className={twMerge('theme-blue group/navbar fixed inset-x-0 top-0 z-20 flex flex-col', backgroundColor)}>
-			<DesktopNavigation {...props} country={geolocation?.country} />
-			<MobileNavigation {...props} country={geolocation?.country} />
+			<DesktopNavigation {...props} />
+			<MobileNavigation {...props} />
 		</nav>
 	);
 }

--- a/website/src/components/providers/context-providers.tsx
+++ b/website/src/components/providers/context-providers.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CURRENCY_COOKIE, LANGUAGE_COOKIE, REGION_COOKIE } from '@/app/[lang]/[region]';
+import { COUNTRY_COOKIE, CURRENCY_COOKIE, LANGUAGE_COOKIE, REGION_COOKIE } from '@/app/[lang]/[region]';
 import { ApiProvider } from '@/components/providers/api-provider';
 import { GlobalStateProviderProvider } from '@/components/providers/global-state-provider';
 import { FacebookTracking } from '@/components/tracking/facebook-tracking';
@@ -10,6 +10,7 @@ import { useCookieState } from '@/hooks/useCookieState';
 import { WebsiteCurrency, WebsiteLanguage, WebsiteRegion } from '@/i18n';
 import { initializeAnalytics } from '@firebase/analytics';
 import { DEFAULT_REGION } from '@socialincome/shared/src/firebase';
+import { CountryCode } from '@socialincome/shared/src/types/country';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Analytics } from '@vercel/analytics/react';
 import { ConsentSettings, ConsentStatusString, setConsent } from 'firebase/analytics';
@@ -140,6 +141,8 @@ function FirebaseSDKProviders({ children }: PropsWithChildren) {
 }
 
 type I18nContextType = {
+	country: CountryCode | undefined;
+	setCountry: (country: CountryCode) => void;
 	language: WebsiteLanguage | undefined;
 	setLanguage: (language: WebsiteLanguage) => void;
 	region: WebsiteRegion | undefined;
@@ -189,16 +192,19 @@ function I18nProvider({ children }: PropsWithChildren) {
 	const { value: language, setCookie: setLanguage } = useCookieState<WebsiteLanguage>(LANGUAGE_COOKIE);
 	const { value: region, setCookie: setRegion } = useCookieState<WebsiteRegion>(REGION_COOKIE);
 	const { value: currency, setCookie: setCurrency } = useCookieState<WebsiteCurrency>(CURRENCY_COOKIE);
+	const { value: country, setCookie: setCountry } = useCookieState<CountryCode>(COUNTRY_COOKIE);
 
 	return (
 		<I18nContext.Provider
 			value={{
+				country: country,
+				setCountry: (country) => setCountry(country, { expires: 7 }),
 				language: language,
-				setLanguage: (language) => setLanguage(language, { expires: 365 }),
+				setLanguage: (language) => setLanguage(language, { expires: 7 }),
 				region: region,
-				setRegion: (country) => setRegion(country, { expires: 365 }),
+				setRegion: (country) => setRegion(country, { expires: 7 }),
 				currency: currency,
-				setCurrency: (currency) => setCurrency(currency, { expires: 365 }),
+				setCurrency: (currency) => setCurrency(currency, { expires: 7 }),
 			}}
 		>
 			<Suspense fallback={null}>


### PR DESCRIPTION
Hey @dnhn! Looking at your #986 MR again, I realized that we can already set the country code of the request location as a cookie in the middleware. Doing it like this, it's not necessary anymore to do an extra request to the API endpoint you created because you can directly access the info in the cookie.
What do you think about this approach?

Seems to work as well:

<img width="1431" alt="Screenshot 2024-12-22 at 16 14 00" src="https://github.com/user-attachments/assets/5c6b58f0-bce9-49c3-a22d-aa924a75690d" />
