### PR TITLE
Website: Add a toggle feature to sort open-source contributors

### DIFF
--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -27,3 +27,4 @@ export * from './components/table';
 export * from './components/tabs';
 export * from './components/tooltip';
 export * from './components/typography';
+export * from './components/toggle-group';

--- a/website/src/app/[lang]/[region]/(website)/open-source/(components)/contributors-client.tsx
+++ b/website/src/app/[lang]/[region]/(website)/open-source/(components)/contributors-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Avatar, AvatarFallback, AvatarImage, Button, Typography } from '@socialincome/ui';
+import { ToggleGroup, ToggleGroupItem } from '@socialincome/ui';
 import { useState } from 'react';
 
 type ContributorProp = {
@@ -8,6 +9,13 @@ type ContributorProp = {
 	commits: number;
 	avatarUrl: string;
 };
+
+interface Contributor {
+	id: number;
+	name: string;
+	avatarUrl: string;
+	commits: number;
+}
 
 function Contributor({ name, commits, avatarUrl }: ContributorProp) {
 	return (
@@ -29,17 +37,30 @@ function Contributor({ name, commits, avatarUrl }: ContributorProp) {
 }
 
 export function OpenSourceContributorsClient({
-	contributors,
+	ContributorsByCommitCount,
+	ContributorsByLatestCommit,
 	heading,
 	totalContributors,
 }: {
-	contributors: Array<{ name: string; commits: number; avatarUrl: string; id: number }>;
+	ContributorsByCommitCount: Contributor[];
+	ContributorsByLatestCommit: Contributor[];
 	heading: string;
 	totalContributors: number;
 }) {
 	const [showAllContributors, setShowAllContributors] = useState(false);
+	const [selectedToggle, setSelectedToggle] = useState("commit count");
+	const [contributors, setContributors] = useState(ContributorsByCommitCount);
 
 	const displayedContributors = showAllContributors ? contributors : contributors.slice(0, 16);
+
+	const handleToggleChange = (value: string) => {
+		setSelectedToggle(value);
+		if (value === "latest commit") {
+			setContributors(ContributorsByLatestCommit);
+		} else {
+			setContributors(ContributorsByCommitCount);
+		}
+	};
 
 	return (
 		<section className="flex flex-col justify-self-start">
@@ -49,8 +70,15 @@ export function OpenSourceContributorsClient({
 				</Typography>
 			</section>
 
+			<section className="flex mb-10">
+				<ToggleGroup type="single" value={selectedToggle} onValueChange={handleToggleChange}>
+					<ToggleGroupItem value="commit count">Commit Count</ToggleGroupItem>
+					<ToggleGroupItem value="latest commit">Latest Commit</ToggleGroupItem>
+				</ToggleGroup>
+			</section>
+
 			<section className="flex flex-wrap gap-4">
-				{displayedContributors.map((contributor) => (
+				{displayedContributors.map((contributor: Contributor) => (
 					<Contributor
 						key={contributor.id}
 						name={contributor.name}

--- a/website/src/app/[lang]/[region]/(website)/open-source/(components)/contributors-client.tsx
+++ b/website/src/app/[lang]/[region]/(website)/open-source/(components)/contributors-client.tsx
@@ -37,28 +37,28 @@ function Contributor({ name, commits, avatarUrl }: ContributorProp) {
 }
 
 export function OpenSourceContributorsClient({
-	ContributorsByCommitCount,
-	ContributorsByLatestCommit,
+	contributorsByCommitCount,
+	contributorsByLatestCommit,
 	heading,
 	totalContributors,
 }: {
-	ContributorsByCommitCount: Contributor[];
-	ContributorsByLatestCommit: Contributor[];
+	contributorsByCommitCount: Contributor[];
+	contributorsByLatestCommit: Contributor[];
 	heading: string;
 	totalContributors: number;
 }) {
 	const [showAllContributors, setShowAllContributors] = useState(false);
 	const [selectedToggle, setSelectedToggle] = useState("commit count");
-	const [contributors, setContributors] = useState(ContributorsByCommitCount);
+	const [contributors, setContributors] = useState(contributorsByCommitCount);
 
 	const displayedContributors = showAllContributors ? contributors : contributors.slice(0, 16);
 
 	const handleToggleChange = (value: string) => {
 		setSelectedToggle(value);
 		if (value === "latest commit") {
-			setContributors(ContributorsByLatestCommit);
+			setContributors(contributorsByLatestCommit);
 		} else {
-			setContributors(ContributorsByCommitCount);
+			setContributors(contributorsByCommitCount);
 		}
 	};
 

--- a/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
+++ b/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
@@ -48,25 +48,23 @@ export async function OpenSourceContributors({ lang }: DefaultParams) {
 		if (commit.author?.id && commit.commit?.author?.date) {
 			const contributorId = commit.author.id;
 			const commitDate = new Date(commit.commit.author.date);
-			if (!latestCommitDates.has(contributorId) || commitDate > latestCommitDates.get(contributorId)) {
+			const existingDate = latestCommitDates.get(contributorId);
+			if (!existingDate || commitDate > existingDate) {
 				latestCommitDates.set(contributorId, commitDate);
 			}
 		}
 	});
 
 	// Combine contributors' data with their latest commit dates
-	const combinedContributors: CombinedContributor[] = [];
-	contributors.forEach((contributor) => {
-		if (latestCommitDates.has(contributor.id)) {
-			combinedContributors.push({
-				id: contributor.id,
-				name: contributor.name,
-				avatarUrl: contributor.avatarUrl,
-				commits: contributor.commits,
-				latestCommitDate: latestCommitDates.get(contributor.id),
-			});
-		}
-	});
+	const combinedContributors = contributors
+		.filter((contributor) => latestCommitDates.has(contributor.id))
+		.map((contributor) => ({
+			id: contributor.id,
+			name: contributor.name,
+			avatarUrl: contributor.avatarUrl,
+			commits: contributor.commits,
+			latestCommitDate: latestCommitDates.get(contributor.id) || new Date(0),
+		}));
 
 	const totalContributors = combinedContributors.length;
 

--- a/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
+++ b/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
@@ -1,6 +1,5 @@
 import { DefaultParams } from '@/app/[lang]/[region]';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
-import { ToggleGroup, ToggleGroupItem } from '@socialincome/ui';
 import { getCommits } from '../(components)/get-commits';
 import { getContributors } from '../(components)/get-contributors';
 import { OpenSourceContributorsClient } from '../(components)/contributors-client';

--- a/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
+++ b/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
@@ -41,7 +41,6 @@ export async function OpenSourceContributors({ lang }: DefaultParams) {
 
 	const contributors = await getContributors();
 	const { totalCommitsData } = await getCommits();
-	const totalContributors = contributors.length;
 
 	// Collect the latest commit date for each contributor
 	const latestCommitDates = new Map<number, Date>();
@@ -68,6 +67,8 @@ export async function OpenSourceContributors({ lang }: DefaultParams) {
 			});
 		}
 	});
+
+	const totalContributors = combinedContributors.length;
 
 	const contributorsByCommitCount = [...combinedContributors].sort(
 		(a: CombinedContributor, b: CombinedContributor) => b.commits - a.commits

--- a/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
+++ b/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
@@ -1,11 +1,34 @@
 import { DefaultParams } from '@/app/[lang]/[region]';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
-import { OpenSourceContributorsClient } from '../(components)/contributors-client';
+import { ToggleGroup, ToggleGroupItem } from '@socialincome/ui';
+import { getCommits } from '../(components)/get-commits';
 import { getContributors } from '../(components)/get-contributors';
+import { OpenSourceContributorsClient } from '../(components)/contributors-client';
 
 type Metadata = {
 	heading: string;
 };
+
+interface GitHubCommit {
+	author: {
+		id: number;
+		login: string;
+		avatar_url: string;
+	};
+	commit: {
+		author: {
+			date: string;
+		};
+	};
+}
+
+interface CombinedContributor {
+	id: number;
+	name: string;
+	avatarUrl: string;
+	commits: number;
+	latestCommitDate: Date;
+}
 
 export async function OpenSourceContributors({ lang }: DefaultParams) {
 	const translator = await Translator.getInstance({
@@ -17,10 +40,50 @@ export async function OpenSourceContributors({ lang }: DefaultParams) {
 	const heading = metadata.heading;
 
 	const contributors = await getContributors();
+	const { totalCommitsData } = await getCommits();
 	const totalContributors = contributors.length;
 
+	// Collect the latest commit date for each contributor
+	const latestCommitDates = new Map<number, Date>();
+	totalCommitsData.forEach((commit: GitHubCommit) => {
+		if (commit.author && commit.author.id && commit.commit.author.date) {
+			const contributorId = commit.author.id;
+			const commitDate = new Date(commit.commit.author.date);
+			if (!latestCommitDates.has(contributorId) || commitDate > latestCommitDates.get(contributorId)) {
+				latestCommitDates.set(contributorId, commitDate);
+			}
+		}
+	});
+
+	// Combine contributors' data with their latest commit dates
+	const combinedContributors: CombinedContributor[] = [];
+	contributors.forEach((contributor) => {
+		if (latestCommitDates.has(contributor.id)) {
+			combinedContributors.push({
+				id: contributor.id,
+				name: contributor.name,
+				avatarUrl: contributor.avatarUrl,
+				commits: contributor.commits,
+				latestCommitDate: latestCommitDates.get(contributor.id),
+			});
+		}
+	});
+
+	const ContributorsByCommitCount = [...combinedContributors].sort(
+		(a: CombinedContributor, b: CombinedContributor) => b.commits - a.commits
+	);
+
+	const ContributorsByLatestCommit = [...combinedContributors].sort(
+		(a: CombinedContributor, b: CombinedContributor) => b.latestCommitDate.getTime() - a.latestCommitDate.getTime()
+	);
+
 	return (
-		<OpenSourceContributorsClient contributors={contributors} heading={heading} totalContributors={totalContributors} />
+		<OpenSourceContributorsClient
+			ContributorsByCommitCount={ContributorsByCommitCount}
+			ContributorsByLatestCommit={ContributorsByLatestCommit}
+			heading={heading}
+			totalContributors={totalContributors}
+		/>
 	);
 }
 

--- a/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
+++ b/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
@@ -46,7 +46,7 @@ export async function OpenSourceContributors({ lang }: DefaultParams) {
 	// Collect the latest commit date for each contributor
 	const latestCommitDates = new Map<number, Date>();
 	totalCommitsData.forEach((commit: GitHubCommit) => {
-		if (commit.author && commit.author.id && commit.commit.author.date) {
+		if (commit.author?.id && commit.commit?.author?.date) {
 			const contributorId = commit.author.id;
 			const commitDate = new Date(commit.commit.author.date);
 			if (!latestCommitDates.has(contributorId) || commitDate > latestCommitDates.get(contributorId)) {

--- a/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
+++ b/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
@@ -69,18 +69,18 @@ export async function OpenSourceContributors({ lang }: DefaultParams) {
 		}
 	});
 
-	const ContributorsByCommitCount = [...combinedContributors].sort(
+	const contributorsByCommitCount = [...combinedContributors].sort(
 		(a: CombinedContributor, b: CombinedContributor) => b.commits - a.commits
 	);
 
-	const ContributorsByLatestCommit = [...combinedContributors].sort(
+	const contributorsByLatestCommit = [...combinedContributors].sort(
 		(a: CombinedContributor, b: CombinedContributor) => b.latestCommitDate.getTime() - a.latestCommitDate.getTime()
 	);
 
 	return (
 		<OpenSourceContributorsClient
-			ContributorsByCommitCount={ContributorsByCommitCount}
-			ContributorsByLatestCommit={ContributorsByLatestCommit}
+			contributorsByCommitCount={contributorsByCommitCount}
+			contributorsByLatestCommit={contributorsByLatestCommit}
 			heading={heading}
 			totalContributors={totalContributors}
 		/>


### PR DESCRIPTION
Add a toogle feature to the 'contributors' section to allow visitors sort the list of contributors by the Number of commits or Lastest commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced Open Source Contributors section with toggle functionality.
  - Added ability to view contributors by commit count and latest commit.
  - Integrated a new toggle group component for improved user interaction.

- **Improvements**
  - Refined commit data retrieval to support multiple pages.
  - Added type safety for contributor and commit interfaces.
  - Implemented a more dynamic contributor sorting mechanism based on commit activity.
  
- **Technical Updates**
  - Expanded export capabilities for the toggle group component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->