### PR TITLE
Website: Add a toggle feature to sort open-source contributors

### DIFF
--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -27,3 +27,4 @@ export * from './components/table';
 export * from './components/tabs';
 export * from './components/tooltip';
 export * from './components/typography';
+export * from './components/toggle-group';

--- a/website/src/app/[lang]/[region]/(website)/open-source/(components)/contributors-client.tsx
+++ b/website/src/app/[lang]/[region]/(website)/open-source/(components)/contributors-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Avatar, AvatarFallback, AvatarImage, Button, Typography } from '@socialincome/ui';
+import { ToggleGroup, ToggleGroupItem } from '@socialincome/ui';
 import { useState } from 'react';
 
 type ContributorProp = {
@@ -8,6 +9,13 @@ type ContributorProp = {
 	commits: number;
 	avatarUrl: string;
 };
+
+interface Contributor {
+	id: number;
+	name: string;
+	avatarUrl: string;
+	commits: number;
+}
 
 function Contributor({ name, commits, avatarUrl }: ContributorProp) {
 	return (
@@ -29,17 +37,30 @@ function Contributor({ name, commits, avatarUrl }: ContributorProp) {
 }
 
 export function OpenSourceContributorsClient({
-	contributors,
+	contributorsByCommitCount,
+	contributorsByLatestCommit,
 	heading,
 	totalContributors,
 }: {
-	contributors: Array<{ name: string; commits: number; avatarUrl: string; id: number }>;
+	contributorsByCommitCount: Contributor[];
+	contributorsByLatestCommit: Contributor[];
 	heading: string;
 	totalContributors: number;
 }) {
 	const [showAllContributors, setShowAllContributors] = useState(false);
+	const [selectedToggle, setSelectedToggle] = useState("commit count");
+	const [contributors, setContributors] = useState(contributorsByCommitCount);
 
 	const displayedContributors = showAllContributors ? contributors : contributors.slice(0, 16);
+
+	const handleToggleChange = (value: string) => {
+		setSelectedToggle(value);
+		if (value === "latest commit") {
+			setContributors(contributorsByLatestCommit);
+		} else {
+			setContributors(contributorsByCommitCount);
+		}
+	};
 
 	return (
 		<section className="flex flex-col justify-self-start">
@@ -49,8 +70,15 @@ export function OpenSourceContributorsClient({
 				</Typography>
 			</section>
 
+			<section className="flex mb-10">
+				<ToggleGroup type="single" value={selectedToggle} onValueChange={handleToggleChange}>
+					<ToggleGroupItem value="commit count">Commit Count</ToggleGroupItem>
+					<ToggleGroupItem value="latest commit">Latest Commit</ToggleGroupItem>
+				</ToggleGroup>
+			</section>
+
 			<section className="flex flex-wrap gap-4">
-				{displayedContributors.map((contributor) => (
+				{displayedContributors.map((contributor: Contributor) => (
 					<Contributor
 						key={contributor.id}
 						name={contributor.name}

--- a/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
+++ b/website/src/app/[lang]/[region]/(website)/open-source/(sections)/contributors.tsx
@@ -1,11 +1,33 @@
 import { DefaultParams } from '@/app/[lang]/[region]';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
-import { OpenSourceContributorsClient } from '../(components)/contributors-client';
+import { getCommits } from '../(components)/get-commits';
 import { getContributors } from '../(components)/get-contributors';
+import { OpenSourceContributorsClient } from '../(components)/contributors-client';
 
 type Metadata = {
 	heading: string;
 };
+
+interface GitHubCommit {
+	author: {
+		id: number;
+		login: string;
+		avatar_url: string;
+	};
+	commit: {
+		author: {
+			date: string;
+		};
+	};
+}
+
+interface CombinedContributor {
+	id: number;
+	name: string;
+	avatarUrl: string;
+	commits: number;
+	latestCommitDate: Date;
+}
 
 export async function OpenSourceContributors({ lang }: DefaultParams) {
 	const translator = await Translator.getInstance({
@@ -17,10 +39,49 @@ export async function OpenSourceContributors({ lang }: DefaultParams) {
 	const heading = metadata.heading;
 
 	const contributors = await getContributors();
-	const totalContributors = contributors.length;
+	const { totalCommitsData } = await getCommits();
+
+	// Collect the latest commit date for each contributor
+	const latestCommitDates = new Map<number, Date>();
+	totalCommitsData.forEach((commit: GitHubCommit) => {
+		if (commit.author?.id && commit.commit?.author?.date) {
+			const contributorId = commit.author.id;
+			const commitDate = new Date(commit.commit.author.date);
+			const existingDate = latestCommitDates.get(contributorId);
+			if (!existingDate || commitDate > existingDate) {
+				latestCommitDates.set(contributorId, commitDate);
+			}
+		}
+	});
+
+	// Combine contributors' data with their latest commit dates
+	const combinedContributors = contributors
+		.filter((contributor) => latestCommitDates.has(contributor.id))
+		.map((contributor) => ({
+			id: contributor.id,
+			name: contributor.name,
+			avatarUrl: contributor.avatarUrl,
+			commits: contributor.commits,
+			latestCommitDate: latestCommitDates.get(contributor.id) || new Date(0),
+		}));
+
+	const totalContributors = combinedContributors.length;
+
+	const contributorsByCommitCount = [...combinedContributors].sort(
+		(a: CombinedContributor, b: CombinedContributor) => b.commits - a.commits
+	);
+
+	const contributorsByLatestCommit = [...combinedContributors].sort(
+		(a: CombinedContributor, b: CombinedContributor) => b.latestCommitDate.getTime() - a.latestCommitDate.getTime()
+	);
 
 	return (
-		<OpenSourceContributorsClient contributors={contributors} heading={heading} totalContributors={totalContributors} />
+		<OpenSourceContributorsClient
+			contributorsByCommitCount={contributorsByCommitCount}
+			contributorsByLatestCommit={contributorsByLatestCommit}
+			heading={heading}
+			totalContributors={totalContributors}
+		/>
 	);
 }
 


### PR DESCRIPTION
Add a toggle feature to the 'contributors' section to allow sorting the list of contributors by the number of commits or latest commits.