### PR TITLE
[Mobile App] Resolve incorrect payment calculations for past and future payments (#869)

### DIFF
--- a/recipients_app/lib/view/pages/payments_page.dart
+++ b/recipients_app/lib/view/pages/payments_page.dart
@@ -144,6 +144,9 @@ class _PaymentsPageState extends State<PaymentsPage> {
     var total = 0;
 
     for (final mappedPayment in mappedPayments) {
+      final paymentStatus = mappedPayment.payment.status;
+      if (paymentStatus != PaymentStatus.paid && paymentStatus != PaymentStatus.confirmed) continue;
+
       // some of the users still have SLL from begining of the program,
       // we will change it to SLE
       final factor = (mappedPayment.payment.currency == "SLL") ? 1000 : 1;
@@ -154,10 +157,17 @@ class _PaymentsPageState extends State<PaymentsPage> {
   }
 
   String _calculateFuturePayments(List<MappedPayment> mappedPayments) {
+    final paidOrConfirmedPayments = mappedPayments.where(
+      (payment) {
+        final paymentStatus = payment.payment.status;
+        return paymentStatus == PaymentStatus.paid || paymentStatus == PaymentStatus.confirmed;
+      },
+    ).toList();
+
     // due to problem that payment amount can change we need to calculate
     // the future payments without calculation of previous payments
-    final futurePayments = (kProgramDurationMonths - mappedPayments.length) * kCurrentPaymentAmount;
+    final futurePayments = (kProgramDurationMonths - paidOrConfirmedPayments.length) * kCurrentPaymentAmount;
 
-    return "${mappedPayments.firstOrNull?.payment.currency ?? "SLE"} $futurePayments";
+    return "${paidOrConfirmedPayments.firstOrNull?.payment.currency ?? "SLE"} $futurePayments";
   }
 }


### PR DESCRIPTION
This Merge Request resolves the issue of incorrect calculations for past and future payments, as described in #869.
Previously, all payments were counted regardless of their status, leading to inaccurate totals.

### Changes
* Past Payments
  Only payments with the status paid and confirmed are considered.
* Future Payments:
  Deductions from the total amount are now only applied for payments with the status paid and confirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the payment summary calculations so that only verified payments are included. This update ensures that past and future payment totals, as well as currency details, are now displayed more accurately for a clearer financial overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->