### PR TITLE
[Mobile App] Fix missing aab publishing

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -181,6 +181,7 @@ workflows:
 
     artifacts:
       - recipients_app/build/**/outputs/apk/prod/**/*.apk
+      - recipients_app/build/**/outputs/apk/prod/**/*.aab
       - recipients_app/build/**/outputs/**/mapping.txt
 
     publishing:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Android production workflow to support App Bundle (AAB) outputs alongside APKs, expanding the available artifact options for distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->