### PR TITLE
Web: Footer Update

### DIFF
--- a/website/src/components/footer/footer.tsx
+++ b/website/src/components/footer/footer.tsx
@@ -37,7 +37,6 @@ export default async function Footer({ lang, region }: DefaultParams) {
 							{translator.t('navigation.follow-us')}
 						</Typography>
 						<FooterLink label="Instagram" url="https://www.instagram.com/so_income" target="_blank" />
-						<FooterLink label="X" url="https://twitter.com/so_income" target="_blank" />
 						<FooterLink label="Facebook" url="https://facebook.com/socialincome.org" target="_blank" />
 						<FooterLink label="Linkedin" url="https://www.linkedin.com/company/socialincome" target="_blank" />
 						<FooterLink label="GitHub" url="https://github.com/socialincome-san/public" target="_blank" />


### PR DESCRIPTION
Deleting X as a social network in the footer, as we are no longer posting actively on this platform. Might also solve https://github.com/socialincome-san/public/issues/1106 (as it seems only an issue on production, not localhost)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the "X" (formerly Twitter) social media link from the footer's "follow us" section. All other social media and navigation links remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->