### PR TITLE
workaround for Storyblok initialization

### DIFF
--- a/website/src/app/[lang]/[region]/(website)/journal/[slug]/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/journal/[slug]/page.tsx
@@ -7,6 +7,7 @@ import {
 import { StoryblokArticleCard } from '@/app/[lang]/[region]/(website)/journal/StoryblokArticle';
 import StoryblokAuthorImage from '@/app/[lang]/[region]/(website)/journal/StoryblokAuthorImage';
 import { StoryblokImageWithCaption } from '@/app/[lang]/[region]/(website)/journal/StoryblokImageWithCaption';
+import { storyblokInitializationWorkaround } from '@/storyblok-init';
 import { StoryblokArticle, StoryblokAuthor, StoryblokTag } from '@socialincome/shared/src/storyblok/journal';
 import { LanguageCode } from '@socialincome/shared/src/types/language';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
@@ -17,6 +18,7 @@ import Link from 'next/link';
 import { render } from 'storyblok-rich-text-react-renderer';
 
 export const revalidate = 900;
+storyblokInitializationWorkaround();
 
 function renderWrapper(articleData: StoryblokArticle) {
 	return render(articleData.content, {

--- a/website/src/app/[lang]/[region]/(website)/journal/author/[slug]/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/journal/author/[slug]/page.tsx
@@ -1,11 +1,13 @@
 import { getArticlesByAuthor, getAuthor } from '@/app/[lang]/[region]/(website)/journal/StoryblokApi';
 import { StoryblokArticleCard } from '@/app/[lang]/[region]/(website)/journal/StoryblokArticle';
 import StoryblokAuthorImage from '@/app/[lang]/[region]/(website)/journal/StoryblokAuthorImage';
+import { storyblokInitializationWorkaround } from '@/storyblok-init';
 import { LanguageCode } from '@socialincome/shared/src/types/language';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
 import { BaseContainer, Typography } from '@socialincome/ui';
 
 export const revalidate = 900;
+storyblokInitializationWorkaround();
 
 export default async function Page(props: { params: Promise<{ slug: string; lang: LanguageCode; region: string }> }) {
 	const { slug, lang, region } = await props.params;

--- a/website/src/app/[lang]/[region]/(website)/journal/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/journal/page.tsx
@@ -2,11 +2,13 @@ import { DefaultPageProps } from '@/app/[lang]/[region]';
 import { getAuthors, getOverviewArticles, getTags } from '@/app/[lang]/[region]/(website)/journal/StoryblokApi';
 import { StoryblokArticleCard } from '@/app/[lang]/[region]/(website)/journal/StoryblokArticle';
 import StoryblokAuthorImage from '@/app/[lang]/[region]/(website)/journal/StoryblokAuthorImage';
+import { storyblokInitializationWorkaround } from '@/storyblok-init';
 import { Translator } from '@socialincome/shared/src/utils/i18n';
 import { Badge, BaseContainer, Typography } from '@socialincome/ui';
 import Link from 'next/link';
 
 export const revalidate = 900;
+storyblokInitializationWorkaround();
 
 export default async function Page({ params }: DefaultPageProps) {
 	const { lang, region } = await params;

--- a/website/src/app/[lang]/[region]/(website)/journal/tag/[slug]/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/journal/tag/[slug]/page.tsx
@@ -1,9 +1,11 @@
 import { DefaultParams } from '@/app/[lang]/[region]';
 import { getArticlesByTag, getTag } from '@/app/[lang]/[region]/(website)/journal/StoryblokApi';
 import { StoryblokArticleCard } from '@/app/[lang]/[region]/(website)/journal/StoryblokArticle';
+import { storyblokInitializationWorkaround } from '@/storyblok-init';
 import { BaseContainer, Typography } from '@socialincome/ui';
 
 export const revalidate = 900;
+storyblokInitializationWorkaround();
 
 interface PageParams extends DefaultParams {
 	slug: string;

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import { ContextProviders } from '@/components/providers/context-providers';
 import { getMetadata } from '@/metadata';
-import { apiPlugin, storyblokInit } from '@storyblok/react';
+import { storyblokInitializationWorkaround } from '@/storyblok-init';
 import type { Viewport } from 'next';
 import { PropsWithChildren } from 'react';
 import './globals.css';
@@ -11,13 +11,7 @@ export const viewport: Viewport = {
 	themeColor: '#3373BB',
 };
 
-storyblokInit({
-	accessToken: process.env.STORYBLOK_PREVIEW_TOKEN,
-	apiOptions: {
-		cache: { type: 'none' },
-	},
-	use: [apiPlugin],
-});
+storyblokInitializationWorkaround();
 
 export default function RootLayout({ children }: PropsWithChildren) {
 	return (

--- a/website/src/storyblok-init.ts
+++ b/website/src/storyblok-init.ts
@@ -1,0 +1,19 @@
+import { apiPlugin, storyblokInit } from '@storyblok/react';
+
+/**
+ *
+ *
+ * Current we are facing the following issues:
+ * https://github.com/vercel/next.js/issues/68882
+ * https://github.com/storyblok/storyblok-react/issues/952.
+ * Therefore we initiate storyblok on every page that it needs the api access
+ * */
+export function storyblokInitializationWorkaround() {
+	storyblokInit({
+		accessToken: process.env.STORYBLOK_PREVIEW_TOKEN,
+		apiOptions: {
+			cache: { type: 'none' },
+		},
+		use: [apiPlugin],
+	});
+}


### PR DESCRIPTION
Sometimes the Storyblok api crashes. The bug can be reproduced at the UI, by navigating between Storyblok components on our pages. e.g clicking on a tag or the author of an article.


The bug is described on the following issues:

https://github.com/storyblok/storyblok-react/issues/952
https://github.com/vercel/next.js/issues/68882
