### PR TITLE
Web: Footer clean-up 

### DIFF
--- a/shared/locales/de/website-common.json
+++ b/shared/locales/de/website-common.json
@@ -35,8 +35,7 @@
 		"team": "Team",
 		"terms-and-conditions": "Allgemeine Geschäftsbedingungen",
 		"terms-of-use": "Nutzungsbedingungen",
-		"transparency": "Transparenz",
-		"whats-next": "Was als Nächstes kommt"
+		"transparency": "Transparenz"
 	},
 	"cookie-consent-banner": {
 		"text": "Wir verwenden <a href='/legal/privacy' class='underline'>Cookies</a>.",

--- a/shared/locales/de/website-our-work.json
+++ b/shared/locales/de/website-our-work.json
@@ -65,29 +65,5 @@
 			"onikeh": "Social Income hat mir enorm geholfen. Es dient als Quelle, aus der wir zusätzliche Kraft für unser tägliches Leben schöpfen können. Es ist ein grossartiges Gefühl, dass uns Menschen unterstützen und an unsere Träume glauben.",
 			"neneh": "Ich brauche mein monatliches Social Income um in mein kleines Unternehmen zu investieren und um das Mittagessen an der Schule meiner Kinder zu bezahlen. Es macht mich so glücklich, ich könnte weinen."
 		}
-	},
-	"whats-next": {
-		"header": "Was als Nächstes kommt",
-		"title-1": "Wir gehen die Dinge ",
-		"title-2": "Schritt für Schritt an.",
-		"subtitle": "Das langfristige Ziel von Social Income besteht darin, für bedürftige Menschen ein globales System der Wohlstands(um)verteilung zu kreieren – basierend auf freiwilligen Spender:innen aus aller Welt. Das Projekt ist ambitioniert. Für die Skalierung braucht es entsprechend Zeit.",
-		"timeline": {
-			"item-1": {
-				"title": "März 2020",
-				"text": "In der Pilotphase zahlten wir die ersten Beiträge an eine kleine Gemeinschaft in Freetown, Sierra Leone."
-			},
-			"item-2": {
-				"title": "September 2021",
-				"text": "In der Entwicklungsphase erhöhten wir die Anzahl der Empfänger:innen und verbesserten den Zahlungsprozess."
-			},
-			"item-3": {
-				"title": "Januar 2022",
-				"text": "Wir rollen Social Income kontinuierlich für mehr Empfänger:innen aus."
-			},
-			"item-4": {
-				"title": "Fortlaufend: Wirkungsmessung",
-				"text": "Um die Wirksamkeit von Social Income messbar zu machen, haben wir eine Methode und eine Reihe an quantitativen und qualitativen Indikatoren entwickelt. Momentan sammeln wir Daten und optimieren unsere Vorgehensweise mit Hilfe der Empfänger:innen."
-			}
-		}
 	}
 }

--- a/shared/locales/en/website-common.json
+++ b/shared/locales/en/website-common.json
@@ -35,8 +35,7 @@
 		"team": "Team",
 		"terms-and-conditions": "Terms and Conditions",
 		"terms-of-use": "Terms of Use",
-		"transparency": "Transparency",
-		"whats-next": "What's Next"
+		"transparency": "Transparency"
 	},
 	"cookie-consent-banner": {
 		"text": "We use <a href='/legal/privacy' class='underline'>cookies</a>.",

--- a/shared/locales/en/website-our-work.json
+++ b/shared/locales/en/website-our-work.json
@@ -65,29 +65,5 @@
 			"onikeh": "Social Income has helped me immensely. It serves as an extra source of strength to draw from in our everyday lives. It feels amazing to have people support and believe in your dreams.",
 			"neneh": "I use my monthly Social Income to invest in my small business and pay for lunch for my kids at school. It makes me so happy I could cry!"
 		}
-	},
-	"whats-next": {
-		"header": "What's next?",
-		"title-1": "We take things ",
-		"title-2": "one step at a time.",
-		"subtitle": "Social Income’s long-term goal is to create a global system of wealth redistribution for people in need, with the help of contributors from all around the world. Like any ambitious project, it takes time to scale.",
-		"timeline": {
-			"item-1": {
-				"title": "March 2020",
-				"text": "We started our Pilot Phase and paid out the first installments to a small community in Freetown, Sierra Leone."
-			},
-			"item-2": {
-				"title": "September 2021",
-				"text": "We started our Development Phase and optimized our payment process."
-			},
-			"item-3": {
-				"title": "January 2022",
-				"text": "We reached our Public Phase and have since been continuously rolling out Social Income to more recipients."
-			},
-			"item-4": {
-				"title": "Ongoing: Impact Measurement",
-				"text": "We have established a method and a set of qualitative and quantitative criteria to measure the project’s impact. We are now collecting essential data and refining our method with the help of our recipients."
-			}
-		}
 	}
 }

--- a/shared/locales/fr/website-common.json
+++ b/shared/locales/fr/website-common.json
@@ -35,8 +35,7 @@
 		"team": "Équipe",
 		"terms-and-conditions": "Conditions générales",
 		"terms-of-use": "Conditions d'utilisation",
-		"transparency": "Transparence",
-		"whats-next": "Suite"
+		"transparency": "Transparence"
 	},
 	"cookie-consent-banner": {
 		"text": "Nous utilisons des <a href='/legal/privacy' class='underline'>cookies</a>.",

--- a/shared/locales/fr/website-our-work.json
+++ b/shared/locales/fr/website-our-work.json
@@ -65,29 +65,5 @@
 			"onikeh": "Social Income m’a énormément aidée. C’est comme une source à laquelle puiser des forces supplémentaires pour notre vie quotidienne. Quelle sensation extraordinaire de savoir que des gens vous soutiennent et croient en vos rêves.",
 			"neneh": "J’investis mon Social Income mensuel dans mon petit commerce et pour payer les repas de mes enfants à l’école. Ça me remplit d’une telle joie que je pourrais me mettre à pleurer!"
 		}
-	},
-	"whats-next": {
-		"header": "Prochainement",
-		"title-1": "Nous progressons, ",
-		"title-2": "pas à pas.",
-		"subtitle": "L’objectif à long terme de Social Income est de créer un système global de (re)distribution des richesses pour les personnes dans le besoin – reposant sur des dons volontaires en provenance du monde entier. Le projet et ambitieux, Il faut du temps pour qu’il se déploie à grande échelle.",
-		"timeline": {
-			"item-1": {
-				"title": "Mars 2020",
-				"text": "Lors de la phase pilote, nous avons versé les premières contributions à une petite communauté de Freetown, en Sierra Leone."
-			},
-			"item-2": {
-				"title": "Septembre 2021",
-				"text": "Dans la phase de développement, nous avons augmenté le nombre de bénéficiaires et amélioré le processus de paiement."
-			},
-			"item-3": {
-				"title": "Janvier 2022",
-				"text": "Nous continuons à développer Social Income au profit d'un plus grand nombre de bénéficiaires."
-			},
-			"item-4": {
-				"title": "En tout temps: mesure de l’impact",
-				"text": "Afin de mesurer l'efficacité de Social Income, nous avons développé une méthode et une série d'indicateurs quantitatifs et qualitatifs. Actuellement, nous recueillons des données et optimisons notre démarche avec l'aide des bénéficiaires."
-			}
-		}
 	}
 }

--- a/shared/locales/it/website-common.json
+++ b/shared/locales/it/website-common.json
@@ -35,8 +35,7 @@
 		"team": "Team",
 		"terms-and-conditions": "Termini e Condizioni",
 		"terms-of-use": "Condizioni di Utilizzo",
-		"transparency": "Transparenza",
-		"whats-next": "In Arrivo"
+		"transparency": "Transparenza"
 	},
 	"cookie-consent-banner": {
 		"text": "Utilizziamo i <a href='/privacy' class='underline'>cookie</a>.",

--- a/shared/locales/it/website-our-work.json
+++ b/shared/locales/it/website-our-work.json
@@ -66,29 +66,5 @@
 			"onikeh": "Social Income mi ha aiutato immensamente. È come avere un’ulteriore fonte di forza da cui attingere nella nostra vita quotidiana. È fantastico avere persone che ti supportano e credono nei tuoi sogni.",
 			"neneh": "Uso il denaro che ricevo mensilmente da Social Income per investire nella mia piccola impresa e per pagare il pranzo per i miei figli a scuola. Mi rende così felice che potrei piangere!"
 		}
-	},
-	"whats-next": {
-		"header": "Qual è la prossima mossa?",
-		"title-1": "Affrontiamo le cose ",
-		"title-2": "un passo alla volta.",
-		"subtitle": "L’obiettivo a lungo termine di Social Income è di creare un sistema di redistribuzione della ricchezza a favore di persone bisognose, con l’aiuto di donatori volontari provenienti da tutto il mondo. Come ogni progetto ambizioso, ci vuole tempo per crescere.",
-		"timeline": {
-			"item-1": {
-				"title": "Marzo 2020",
-				"text": "Abbiamo iniziato la nostra Fase Pilota e pagato i primi contributi a una piccola comunità a Freetown, in Sierra Leone."
-			},
-			"item-2": {
-				"title": "Settembre 2021",
-				"text": "Abbiamo iniziato la nostra Fase di Sviluppo e ottimizzato il processo di pagamento."
-			},
-			"item-3": {
-				"title": "Gennaio 2022",
-				"text": "Abbiamo raggiunto la nostra Fase Pubblica e da allora abbiamo progressivamente offerto i servizi di Social Income a più destinatari."
-			},
-			"item-4": {
-				"title": "Incorsa: Misurazione dell’impatto",
-				"text": "Abbiamo stabilito un metodo e una serie di criteri qualitativi e quantitativi per misurare l'impatto del progetto. Ora stiamo raccogliendo dati essenziali e perfezionando il nostro metodo con l’aiuto dei nostri beneficiari."
-			}
-		}
 	}
 }

--- a/website/src/components/footer/footer.tsx
+++ b/website/src/components/footer/footer.tsx
@@ -64,7 +64,6 @@ export default async function Footer({ lang, region }: DefaultParams) {
 							url={`/${lang}/${region}/our-work#contributors`}
 						/>
 						<FooterLink label={translator.t('navigation.recipients')} url={`/${lang}/${region}/our-work#recipients`} />
-						<FooterLink label={translator.t('navigation.whats-next')} url={`/${lang}/${region}/our-work#whats-next`} />
 					</div>
 					<div className="flex flex-col space-y-1">
 						<Typography size="sm" weight="medium" color="muted-foreground">


### PR DESCRIPTION
Removed the unused “next” section, which was still referenced in the footer and a few outdated JSON entries. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the "What's Next" section and related navigation links from the website in all supported languages (English, German, French, Italian).
  - The "What's Next" link has been removed from the footer under "Our Work."
  - All references to future plans and project milestones have been deleted from the "Our Work" pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->