### PR TITLE
fix: create auth user for firestore users without one

### DIFF
--- a/website/src/app/[lang]/[region]/(website)/me/personal-info/personal-info-form.tsx
+++ b/website/src/app/[lang]/[region]/(website)/me/personal-info/personal-info-form.tsx
@@ -101,7 +101,6 @@ export function PersonalInfoForm({ lang, translations }: PersonalInfoFormProps) 
 				gender: values.gender,
 			},
 			language: values.language,
-			email: values.email,
 			address: {
 				street: values.street,
 				number: values.streetNumber,
@@ -146,6 +145,7 @@ export function PersonalInfoForm({ lang, translations }: PersonalInfoFormProps) 
 				/>
 				<FormField
 					control={form.control}
+					disabled={true}
 					name="email"
 					render={({ field }) => (
 						<FormItem>

--- a/website/src/app/api/user/create/route.ts
+++ b/website/src/app/api/user/create/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: CreateUserRequest & Request) {
 	const authUserId = userDoc.docs[0].get('auth_user_id');
 
 	if (authUserId) {
-		return new Response(null, { status: 400, statusText: 'User already exists' });
+		return new Response(null, { status: 400, statusText: 'Auth user already exists' });
 	}
 
 	const userRecord = await authAdmin.auth.createUser({

--- a/website/src/app/api/user/create/route.ts
+++ b/website/src/app/api/user/create/route.ts
@@ -14,13 +14,10 @@ export async function POST(request: CreateUserRequest & Request) {
 	}
 
 	const authUserId = userDoc.docs[0].get('auth_user_id');
-	console.log('auth user id', authUserId);
 
 	if (authUserId) {
 		return new Response(null, { status: 400, statusText: 'User already exists' });
 	}
-
-	console.log('create auth user');
 
 	const userRecord = await authAdmin.auth.createUser({
 		email: email,

--- a/website/src/app/api/user/create/route.ts
+++ b/website/src/app/api/user/create/route.ts
@@ -1,0 +1,35 @@
+import { authAdmin, firestoreAdmin } from '@/firebase-admin';
+import { rndString } from '@socialincome/shared/src/utils/crypto';
+import { User } from 'firebase/auth';
+
+export type CreateUserRequest = {
+	email: string;
+};
+
+export async function POST(request: CreateUserRequest & Request) {
+	const { email } = await request.json();
+	const userDoc = await firestoreAdmin.collection<User>('users').where('email', '==', email).get();
+	if (userDoc.empty) {
+		return new Response(null, { status: 400, statusText: 'User not found' });
+	}
+
+	const authUserId = userDoc.docs[0].get('auth_user_id');
+	console.log('auth user id', authUserId);
+
+	if (authUserId) {
+		return new Response(null, { status: 400, statusText: 'User already exists' });
+	}
+
+	console.log('create auth user');
+
+	const userRecord = await authAdmin.auth.createUser({
+		email: email,
+		password: await rndString(16),
+	});
+
+	await userDoc.docs[0].ref.update({
+		auth_user_id: userRecord.uid,
+	});
+
+	return new Response(null, { status: 200 });
+}

--- a/website/src/hooks/useEmailLogin.ts
+++ b/website/src/hooks/useEmailLogin.ts
@@ -61,7 +61,6 @@ export const useEmailLogin = ({ lang, onLoginSuccess }: UseEmailAuthenticationPr
 
 		try {
 			if (!(await userExists(email))) {
-				console.log('create user');
 				await fetch('/api/user/create', { method: 'POST', body: JSON.stringify({ email }) });
 			}
 			const { user } = await signInWithEmailLink(auth, email, url);

--- a/website/src/hooks/useEmailLogin.ts
+++ b/website/src/hooks/useEmailLogin.ts
@@ -61,7 +61,8 @@ export const useEmailLogin = ({ lang, onLoginSuccess }: UseEmailAuthenticationPr
 
 		try {
 			if (!(await userExists(email))) {
-				throw new FirebaseError('auth/user-not-found', 'user not found');
+				console.log('create user');
+				await fetch('/api/user/create', { method: 'POST', body: JSON.stringify({ email }) });
 			}
 			const { user } = await signInWithEmailLink(auth, email, url);
 			onLoginSuccess && (await onLoginSuccess(user.uid));


### PR DESCRIPTION
This pull request introduces changes to enhance user account creation and modify the behavior of the `PersonalInfoForm` component. The key updates include adding a new API route for user creation, adjusting the email handling in the form, and integrating the new user creation logic into the email login hook.

### User Account Creation:

* [`website/src/app/api/user/create/route.ts`](diffhunk://#diff-638a3f5293666ff28b1941066e038496ca982af1cd2bf57be4a2c59e2a9215f7R1-R32): Added a new API route to create a user. The route verifies if a user exists in Firestore by email, creates an authentication record if necessary, and updates the Firestore document with the new `auth_user_id`.

* [`website/src/hooks/useEmailLogin.ts`](diffhunk://#diff-a4a359002e0f7397d91ed355446faf120d1ba5eab7649e26cfd66049fd329c57L64-R65): Updated the `useEmailLogin` hook to call the new user creation API if the user does not exist, replacing the previous error-throwing behavior.

### Personal Info Form Updates:

* `website/src/app/[lang]/[region]/(website)/me/personal-info/personal-info-form.tsx`: 
  - Removed the `email` field from the `values` object when submitting the form. ([website/src/app/[lang]/[region]/(website)/me/personal-info/personal-info-form.tsxL104](diffhunk://#diff-9d0feca85ffaa98e667810c3680b86034c371b20a6a613bab2d59e6a785e52ddL104))
  - Made the `email` field in the form read-only by setting the `disabled` property to `true`. ([website/src/app/[lang]/[region]/(website)/me/personal-info/personal-info-form.tsxR148](diffhunk://#diff-9d0feca85ffaa98e667810c3680b86034c371b20a6a613bab2d59e6a785e52ddR148))