### PR TITLE
fix: add payment statuses and show logged in user information in qr bill

### DIFF
--- a/shared/locales/de/website-donate.json
+++ b/shared/locales/de/website-donate.json
@@ -29,6 +29,7 @@
 		"confirm-payment": "Zahlung bestätigen",
 		"payment-success": "Danke für deine Spende! Sobald die Zahlung eingangen ist, erscheint diese als bezahlt in deinem Profil.",
 		"login-link": "Zur Profil-Anmeldung",
+		"profile-link": "Zum Profil",
 		"processing": "Zahlung wird bestätigt...",
 		"generating": "QR-Rechnung wird generiert...",
 		"standing-order-qr-info": "Bitte richte in deinem Online-Banking einen Dauerauftrag zur Zahlung an Social Income ein.",

--- a/shared/locales/de/website-me.json
+++ b/shared/locales/de/website-me.json
@@ -33,6 +33,12 @@
 			"raisenow": "Twint",
 			"stripe": "Kreditkarte",
 			"wire-transfer": "Banküberweisung"
+		},
+		"status": {
+			"succeeded": "Bezahlt",
+			"pending": "In Bearbeitung",
+			"failed": "Fehlgeschlagen",
+			"unknown": "Unbekannt"
 		}
 	},
 	"subscriptions": {

--- a/shared/locales/en/website-donate.json
+++ b/shared/locales/en/website-donate.json
@@ -29,6 +29,7 @@
 		"confirm-payment": "Confirm Payment",
 		"payment-success": "Thank you for your donation! Once the payment is received, it will appear as paid in your profile.",
 		"login-link": "Login to your profile",
+		"profile-link": "Go to your profile",
 		"processing": "Processing payment...",
 		"generating": "Generating QR bill...",
 		"standing-order-qr-info": "Please set up a standing order to pay Social Income in your online banking.",

--- a/shared/locales/en/website-me.json
+++ b/shared/locales/en/website-me.json
@@ -33,6 +33,12 @@
 			"raisenow": "Twint",
 			"stripe": "Credit Card",
 			"wire-transfer": "Wire Transfer"
+		},
+		"status": {
+			"succeeded": "Succeeded",
+			"pending": "Pending",
+			"failed": "Failed",
+			"unknown": "Unknown"
 		}
 	},
 	"subscriptions": {

--- a/shared/locales/fr/website-donate.json
+++ b/shared/locales/fr/website-donate.json
@@ -29,6 +29,7 @@
 		"confirm-payment": "Confirmer le paiement",
 		"payment-success": "Merci pour ton don! Une fois le paiement reçu, il apparaîtra comme payé dans ton profil.",
 		"login-link": "Se connecter à ton profil",
+		"profile-link": "Aller à ton profil",
 		"processing": "Traitement du paiement...",
 		"generating": "Génération du QR-bill...",
 		"standing-order-qr-info": "Veuillez configurer un ordre permanent pour payer Social Income dans votre banque en ligne.",

--- a/shared/locales/fr/website-me.json
+++ b/shared/locales/fr/website-me.json
@@ -33,6 +33,12 @@
 			"raisenow": "Twint",
 			"stripe": "Carte de crédit",
 			"wire-transfer": "Virement bancaire"
+		},
+		"status": {
+			"succeeded": "Payé",
+			"pending": "En attente",
+			"failed": "Échoué",
+			"unknown": "Inconnu"
 		}
 	},
 	"subscriptions": {

--- a/shared/locales/it/website-donate.json
+++ b/shared/locales/it/website-donate.json
@@ -32,6 +32,7 @@
 		"confirm-payment": "Conferma il pagamento",
 		"payment-success": "Grazie per il tuo contributo! Una volta ricevuto il pagamento, apparirà come pagato nel tuo profilo.",
 		"login-link": "Accedi al tuo profilo",
+		"profile-link": "Vai al tuo profilo",
 		"processing": "Elaborazione del pagamento...",
 		"generating": "Generazione del QR-bill...",
 		"standing-order-qr-info": "Per favore configura un ordine permanente per pagare Social Income nella tua banca online.",

--- a/shared/locales/it/website-me.json
+++ b/shared/locales/it/website-me.json
@@ -29,6 +29,12 @@
 			"raisenow": "Twint",
 			"stripe": "Carta di credito",
 			"wire-transfer": "Wire Transfer"
+		},
+		"status": {
+			"succeeded": "Pagato",
+			"pending": "In attesa",
+			"failed": "Fallito",
+			"unknown": "Sconosciuto"
 		}
 	},
 	"subscriptions": {

--- a/website/src/app/[lang]/[region]/(blue-theme)/donate/one-time/page.tsx
+++ b/website/src/app/[lang]/[region]/(blue-theme)/donate/one-time/page.tsx
@@ -42,6 +42,7 @@ export default async function Page(props: DefaultPageProps) {
 								confirmPayment: translator.t('bank-transfer.confirm-payment'),
 								paymentSuccess: translator.t('bank-transfer.payment-success'),
 								loginLink: translator.t('bank-transfer.login-link'),
+								profileLink: translator.t('bank-transfer.profile-link'),
 								processing: translator.t('bank-transfer.processing'),
 								generating: translator.t('bank-transfer.generating'),
 								errors: {

--- a/website/src/app/[lang]/[region]/(website)/campaign/[campaignId]/page.tsx
+++ b/website/src/app/[lang]/[region]/(website)/campaign/[campaignId]/page.tsx
@@ -221,6 +221,7 @@ export default async function Page({ params }: CampaignPageProps) {
 														confirmPayment: translator.t('bank-transfer.confirm-payment'),
 														paymentSuccess: translator.t('bank-transfer.payment-success'),
 														loginLink: translator.t('bank-transfer.login-link'),
+														profileLink: translator.t('bank-transfer.profile-link'),
 														processing: translator.t('bank-transfer.processing'),
 														generating: translator.t('bank-transfer.generating'),
 														errors: {

--- a/website/src/app/[lang]/[region]/(website)/me/contributions/contributions-table.tsx
+++ b/website/src/app/[lang]/[region]/(website)/me/contributions/contributions-table.tsx
@@ -60,6 +60,9 @@ export function ContributionsTable({ lang, translations }: ContributionsTablePro
 									})}
 								</Typography>
 							</TableCell>
+							<TableCell>
+								<Typography>{translator?.t(`contributions.status.${contribution.get('status')}`)}</Typography>
+							</TableCell>
 						</TableRow>
 					);
 				})}

--- a/website/src/app/[lang]/[region]/(website)/me/hooks.ts
+++ b/website/src/app/[lang]/[region]/(website)/me/hooks.ts
@@ -1,7 +1,7 @@
 import { UserContext } from '@/components/providers/user-context-provider';
 import { useApi } from '@/hooks/useApi';
 import { orderBy, Query, QuerySnapshot } from '@firebase/firestore';
-import { CONTRIBUTION_FIRESTORE_PATH, StatusKey } from '@socialincome/shared/src/types/contribution';
+import { CONTRIBUTION_FIRESTORE_PATH } from '@socialincome/shared/src/types/contribution';
 import {
 	DONATION_CERTIFICATE_FIRESTORE_PATH,
 	DonationCertificate,
@@ -9,7 +9,7 @@ import {
 import { Employer, EMPLOYERS_FIRESTORE_PATH } from '@socialincome/shared/src/types/employers';
 import { USER_FIRESTORE_PATH } from '@socialincome/shared/src/types/user';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { addDoc, collection, deleteDoc, doc, getDocs, query, Timestamp, updateDoc, where } from 'firebase/firestore';
+import { addDoc, collection, deleteDoc, doc, getDocs, query, Timestamp, updateDoc } from 'firebase/firestore';
 import { useContext } from 'react';
 import { useFirestore } from 'reactfire';
 import Stripe from 'stripe';
@@ -35,7 +35,6 @@ export const useContributions = () => {
 			getDocs(
 				query(
 					collection(firestore, USER_FIRESTORE_PATH, user.id, CONTRIBUTION_FIRESTORE_PATH),
-					where('status', '==', StatusKey.SUCCEEDED),
 					orderBy('created', 'desc'),
 				),
 			),

--- a/website/src/components/storyblok/StoryblokCampaignDonate.tsx
+++ b/website/src/components/storyblok/StoryblokCampaignDonate.tsx
@@ -45,6 +45,7 @@ export function StoryblokCampaignDonate(props: {
 						confirmPayment: translator.t('bank-transfer.confirm-payment'),
 						paymentSuccess: translator.t('bank-transfer.payment-success'),
 						loginLink: translator.t('bank-transfer.login-link'),
+						profileLink: translator.t('bank-transfer.profile-link'),
 						processing: translator.t('bank-transfer.processing'),
 						generating: translator.t('bank-transfer.generating'),
 						errors: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Go to your profile" link (localized in English, German, French, and Italian) to the bank transfer donation confirmation.
  * Displayed payment status for each contribution in the contributions table, with localized status labels in English, German, French, and Italian.

* **Improvements**
  * Donation form fields (first name, last name, email) are now auto-filled and locked for logged-in users.
  * The "Generate QR Bill" button is always enabled for logged-in users, regardless of form validity.
  * After donation, the confirmation link adapts to show "Go to your profile" for logged-in users and "Log in" for guests.

* **Bug Fixes**
  * All user contributions are now displayed, regardless of payment status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->