### PR TITLE
Web: Improve thumbnail rendering

### DIFF
--- a/website/src/components/storyblok/ThumbnailImage.tsx
+++ b/website/src/components/storyblok/ThumbnailImage.tsx
@@ -7,17 +7,18 @@ const DEFAULT_HEIGHT = 15;
 const DEFAULT_WIDTH = 25;
 
 export function ThumbnailImage({ thumbnail }: { thumbnail?: StoryblokImage }) {
-	if (!thumbnail) {
-		return null;
-	}
-	let imageDimensions = getDimensionsFromStoryblokImageUrl(thumbnail.filename);
+	if (!thumbnail) return null;
+
+	const imageDimensions = getDimensionsFromStoryblokImageUrl(thumbnail.filename);
 	return (
-		<Image
-			className="my-auto flex h-14 w-20 p-0"
-			src={thumbnail.filename}
-			alt={thumbnail.alt || `Thumbnail-${thumbnail.id}`}
-			width={imageDimensions.width ?? DEFAULT_WIDTH}
-			height={imageDimensions.height ?? DEFAULT_HEIGHT}
-		/>
+		<div className="h-20 w-20 shrink-0 flex items-center justify-center overflow-hidden">
+			<Image
+				src={thumbnail.filename}
+				alt={thumbnail.alt || `Thumbnail-${thumbnail.id}`}
+				width={imageDimensions.width ?? DEFAULT_WIDTH}
+				height={imageDimensions.height ?? DEFAULT_HEIGHT}
+				className="h-full w-full object-contain"
+			/>
+		</div>
 	);
 }


### PR DESCRIPTION
This PR wraps the thumbnail image in a fixed-size container and applies object-contain to preserve its original aspect ratio. This resolves the issue where reference thumbnails appeared stretched when their dimensions didn’t match the container.