### PR TITLE
feat: only import the last month of exchange-rates

### DIFF
--- a/firestore_to_postgres/src/exchange-rate/exchange-rate.transformer.ts
+++ b/firestore_to_postgres/src/exchange-rate/exchange-rate.transformer.ts
@@ -5,12 +5,14 @@ import { FirestoreExchangeRate } from './exchange-rate.types';
 export class ExchangeRateTransformer extends BaseTransformer<FirestoreExchangeRate, Prisma.ExchangeRateCreateInput> {
 	transform = async (input: FirestoreExchangeRate[]): Promise<Prisma.ExchangeRateCreateInput[]> => {
 		const transformed: Prisma.ExchangeRateCreateInput[] = [];
-		const oneYearAgo = new Date();
-		oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+		const oneMonthAgo = new Date();
+		oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
 
 		for (const entry of input) {
 			const timestamp = new Date(entry.timestamp * 1000);
-			if (timestamp < oneYearAgo) continue;
+			if (timestamp < oneMonthAgo) {
+				continue;
+			}
 
 			const baseId = entry.id;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exchange rate processing now focuses on the last month, providing fresher and more relevant rates.
  * Older rates (beyond one month) are no longer ingested, reducing noise from outdated data.
  * Faster syncs/imports due to a smaller time window.

* **Chores**
  * Updated internal date cutoff logic to align with the new one‑month recency window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->