### PR TITLE
fix: set height to zero for hidden form fields to prevent overflow

### DIFF
--- a/website/src/components/dynamic-form/dynamic-form.tsx
+++ b/website/src/components/dynamic-form/dynamic-form.tsx
@@ -149,7 +149,7 @@ const DynamicForm: FC<{
 							{/* TODO: find better solution to hide collapsed content */}
 							<AccordionItem value={`accordion-${option}`} className="[&[data-state=closed]>div]:h-0">
 								<AccordionTrigger>{formSchema.fields[option].label}</AccordionTrigger>
-								<AccordionContent className="flex flex-col gap-6 p-5" forceMount>
+								<AccordionContent className="flex flex-col gap-6 p-5 [&_*[aria-hidden='true']]:!h-0" forceMount>
 									{getOptions(option).map((nestedOption) => (
 										<GenericFormField
 											option={nestedOption}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed accordion collapse behavior to ensure nested content is properly hidden when sections are collapsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->