### PR TITLE
docs: add permission to readme

### DIFF
--- a/website/infra/README.md
+++ b/website/infra/README.md
@@ -60,6 +60,13 @@ gcloud projects add-iam-policy-binding social-income-staging \
   --role="roles/vpcaccess.admin"
 ```
 
+```
+gcloud projects add-iam-policy-binding social-income-staging \
+  --member="serviceAccount:terraform-deployer@social-income-staging.iam.gserviceaccount.com" \
+  --role="roles/cloudscheduler.admin" \
+  --condition=None
+```
+
 ## Step 2: Create state bucket and assign roles
 
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated infrastructure setup docs to include an additional IAM binding during initial bootstrap that grants Cloud Scheduler Admin permissions to the deployer service account, added alongside the existing VPC access binding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->