### PR TITLE
feat: set default timezone to zurich time

### DIFF
--- a/website/src/components/data-table/elements/date-cell.tsx
+++ b/website/src/components/data-table/elements/date-cell.tsx
@@ -18,6 +18,7 @@ export function DateCell<TData, TValue extends Date | string | null>({
 		hour: '2-digit',
 		minute: '2-digit',
 		second: '2-digit',
+		timeZone: 'Europe/Zurich',
 	},
 }: DateCellProps<TData, TValue>) {
 	const value = ctx.getValue();


### PR DESCRIPTION
set default timezone to Zurich time to prevent hydration mismatch for central european contributors