### PR TITLE
MOBILE APP: Use new "v1/auth/verify-otp" API instead of Cloud Function

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -105,7 +105,7 @@ workflows:
           flutter build appbundle --release \
             --flavor stage \
             -t lib/main_stage.dart \
-            --dart-define=SURVEY_BASE_URL=$SURVEY_BASE_URL \
+            --dart-define=BASE_URL=$BASE_URL \
             --dart-define=SENTRY_URL=$SENTRY_URL \
             --dart-define=TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID \
             --dart-define=TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN \
@@ -226,7 +226,7 @@ workflows:
           flutter build appbundle --release \
             --flavor prod \
             -t lib/main_prod.dart \
-            --dart-define=SURVEY_BASE_URL=$SURVEY_BASE_URL \
+            --dart-define=BASE_URL=$BASE_URL \
             --dart-define=SENTRY_URL=$SENTRY_URL \
             --dart-define=TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID \
             --dart-define=TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN \
@@ -357,7 +357,7 @@ workflows:
           flutter build ipa --release \
             --flavor stage \
             -t lib/main_stage.dart \
-            --dart-define=SURVEY_BASE_URL=$SURVEY_BASE_URL \
+            --dart-define=BASE_URL=$BASE_URL \
             --dart-define=SENTRY_URL=$SENTRY_URL \
             --dart-define=TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID \
             --dart-define=TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN \
@@ -500,7 +500,7 @@ workflows:
           flutter build ipa --release \
             --flavor stage \
             -t lib/main_stage.dart \
-            --dart-define=SURVEY_BASE_URL=$SURVEY_BASE_URL \
+            --dart-define=BASE_URL=$BASE_URL \
             --dart-define=SENTRY_URL=$SENTRY_URL \
             --dart-define=TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID \
             --dart-define=TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN \
@@ -634,7 +634,7 @@ workflows:
           flutter build ipa --release \
             --flavor prod \
             -t lib/main_prod.dart \
-            --dart-define=SURVEY_BASE_URL=$SURVEY_BASE_URL \
+            --dart-define=BASE_URL=$BASE_URL \
             --dart-define=SENTRY_URL=$SENTRY_URL \
             --dart-define=TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID \
             --dart-define=TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN \

--- a/recipients_app/.vscode/launch.json.example
+++ b/recipients_app/.vscode/launch.json.example
@@ -3,7 +3,7 @@
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 
-    // This is our example launch config. Set the prefered flavor, SURVEY_BASE_URL and SENTRY_URL
+    // This is our example launch config. Set the prefered flavor, BASE_URL and SENTRY_URL
     "version": "0.2.0",
     "configurations": [
         {
@@ -16,7 +16,7 @@
                 "--flavor",
                 "stage",
                 "--dart-define",
-                "SURVEY_BASE_URL=staging.socialincome.org",
+                "BASE_URL=staging.socialincome.org",
                 "--dart-define",
                 "SENTRY_URL=FILL IN SENTRY URL",
                 "--dart-define",
@@ -39,7 +39,7 @@
                 "--flavor",
                 "stage",
                 "--dart-define",
-                "SURVEY_BASE_URL=staging.socialincome.org",
+                "BASE_URL=staging.socialincome.org",
                 "--dart-define",
                 "SENTRY_URL=FILL IN SENTRY URL",
                 "--dart-define",
@@ -62,7 +62,7 @@
                 "--flavor",
                 "stage",
                 "--dart-define",
-                "SURVEY_BASE_URL=staging.socialincome.org",
+                "BASE_URL=staging.socialincome.org",
                 "--dart-define",
                 "SENTRY_URL=FILL IN SENTRY URL",
                 "--dart-define",

--- a/recipients_app/lib/core/cubits/survey/survey_cubit.dart
+++ b/recipients_app/lib/core/cubits/survey/survey_cubit.dart
@@ -15,7 +15,7 @@ const _kOverdueEndDay = 15;
 const _kOverduePeriodDays = 6;
 const _kEndOfDisplaySurveyDay = 20;
 
-const _kSurveyBaseUrlKey = "SURVEY_BASE_URL";
+const _kBaseUrlKey = "BASE_URL";
 
 class SurveyCubit extends Cubit<SurveyState> {
   final Recipient recipient;
@@ -77,8 +77,13 @@ class SurveyCubit extends Cubit<SurveyState> {
       "pw": survey.accessPassword,
     };
 
+    const baseUrl = String.fromEnvironment(_kBaseUrlKey);
+    if (baseUrl.isEmpty) {
+      throw StateError("BASE_URL environment variable is not configured");
+    }
+
     final uri = Uri.https(
-      const String.fromEnvironment(_kSurveyBaseUrlKey),
+      baseUrl,
       "survey/$recipientId/${survey.id}",
       params,
     );

--- a/recipients_app/lib/data/models/api/verify_otp_request.dart
+++ b/recipients_app/lib/data/models/api/verify_otp_request.dart
@@ -1,0 +1,14 @@
+import "package:dart_mappable/dart_mappable.dart";
+
+part "verify_otp_request.mapper.dart";
+
+@MappableClass()
+class VerifyOtpRequest with VerifyOtpRequestMappable {
+  final String phoneNumber;
+  final String otp;
+
+  const VerifyOtpRequest({
+    required this.phoneNumber,
+    required this.otp,
+  });
+}

--- a/recipients_app/lib/data/models/api/verify_otp_request.mapper.dart
+++ b/recipients_app/lib/data/models/api/verify_otp_request.mapper.dart
@@ -1,0 +1,139 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'verify_otp_request.dart';
+
+class VerifyOtpRequestMapper extends ClassMapperBase<VerifyOtpRequest> {
+  VerifyOtpRequestMapper._();
+
+  static VerifyOtpRequestMapper? _instance;
+  static VerifyOtpRequestMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = VerifyOtpRequestMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'VerifyOtpRequest';
+
+  static String _$phoneNumber(VerifyOtpRequest v) => v.phoneNumber;
+  static const Field<VerifyOtpRequest, String> _f$phoneNumber = Field(
+    'phoneNumber',
+    _$phoneNumber,
+  );
+  static String _$otp(VerifyOtpRequest v) => v.otp;
+  static const Field<VerifyOtpRequest, String> _f$otp = Field('otp', _$otp);
+
+  @override
+  final MappableFields<VerifyOtpRequest> fields = const {
+    #phoneNumber: _f$phoneNumber,
+    #otp: _f$otp,
+  };
+
+  static VerifyOtpRequest _instantiate(DecodingData data) {
+    return VerifyOtpRequest(
+      phoneNumber: data.dec(_f$phoneNumber),
+      otp: data.dec(_f$otp),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static VerifyOtpRequest fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<VerifyOtpRequest>(map);
+  }
+
+  static VerifyOtpRequest fromJson(String json) {
+    return ensureInitialized().decodeJson<VerifyOtpRequest>(json);
+  }
+}
+
+mixin VerifyOtpRequestMappable {
+  String toJson() {
+    return VerifyOtpRequestMapper.ensureInitialized()
+        .encodeJson<VerifyOtpRequest>(this as VerifyOtpRequest);
+  }
+
+  Map<String, dynamic> toMap() {
+    return VerifyOtpRequestMapper.ensureInitialized()
+        .encodeMap<VerifyOtpRequest>(this as VerifyOtpRequest);
+  }
+
+  VerifyOtpRequestCopyWith<VerifyOtpRequest, VerifyOtpRequest, VerifyOtpRequest>
+  get copyWith =>
+      _VerifyOtpRequestCopyWithImpl<VerifyOtpRequest, VerifyOtpRequest>(
+        this as VerifyOtpRequest,
+        $identity,
+        $identity,
+      );
+  @override
+  String toString() {
+    return VerifyOtpRequestMapper.ensureInitialized().stringifyValue(
+      this as VerifyOtpRequest,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return VerifyOtpRequestMapper.ensureInitialized().equalsValue(
+      this as VerifyOtpRequest,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return VerifyOtpRequestMapper.ensureInitialized().hashValue(
+      this as VerifyOtpRequest,
+    );
+  }
+}
+
+extension VerifyOtpRequestValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, VerifyOtpRequest, $Out> {
+  VerifyOtpRequestCopyWith<$R, VerifyOtpRequest, $Out>
+  get $asVerifyOtpRequest =>
+      $base.as((v, t, t2) => _VerifyOtpRequestCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class VerifyOtpRequestCopyWith<$R, $In extends VerifyOtpRequest, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({String? phoneNumber, String? otp});
+  VerifyOtpRequestCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _VerifyOtpRequestCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, VerifyOtpRequest, $Out>
+    implements VerifyOtpRequestCopyWith<$R, VerifyOtpRequest, $Out> {
+  _VerifyOtpRequestCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<VerifyOtpRequest> $mapper =
+      VerifyOtpRequestMapper.ensureInitialized();
+  @override
+  $R call({String? phoneNumber, String? otp}) => $apply(
+    FieldCopyWithData({
+      if (phoneNumber != null) #phoneNumber: phoneNumber,
+      if (otp != null) #otp: otp,
+    }),
+  );
+  @override
+  VerifyOtpRequest $make(CopyWithData data) => VerifyOtpRequest(
+    phoneNumber: data.get(#phoneNumber, or: $value.phoneNumber),
+    otp: data.get(#otp, or: $value.otp),
+  );
+
+  @override
+  VerifyOtpRequestCopyWith<$R2, VerifyOtpRequest, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) => _VerifyOtpRequestCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+

--- a/recipients_app/lib/data/models/api/verify_otp_response.dart
+++ b/recipients_app/lib/data/models/api/verify_otp_response.dart
@@ -1,0 +1,16 @@
+import "package:dart_mappable/dart_mappable.dart";
+
+part "verify_otp_response.mapper.dart";
+
+@MappableClass()
+class VerifyOtpResponse with VerifyOtpResponseMappable {
+  final String customToken;
+  final bool isNewUser;
+  final String uid;
+
+  const VerifyOtpResponse({
+    required this.customToken,
+    required this.isNewUser,
+    required this.uid,
+  });
+}

--- a/recipients_app/lib/data/models/api/verify_otp_response.mapper.dart
+++ b/recipients_app/lib/data/models/api/verify_otp_response.mapper.dart
@@ -1,0 +1,157 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'verify_otp_response.dart';
+
+class VerifyOtpResponseMapper extends ClassMapperBase<VerifyOtpResponse> {
+  VerifyOtpResponseMapper._();
+
+  static VerifyOtpResponseMapper? _instance;
+  static VerifyOtpResponseMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = VerifyOtpResponseMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'VerifyOtpResponse';
+
+  static String _$customToken(VerifyOtpResponse v) => v.customToken;
+  static const Field<VerifyOtpResponse, String> _f$customToken = Field(
+    'customToken',
+    _$customToken,
+  );
+  static bool _$isNewUser(VerifyOtpResponse v) => v.isNewUser;
+  static const Field<VerifyOtpResponse, bool> _f$isNewUser = Field(
+    'isNewUser',
+    _$isNewUser,
+  );
+  static String _$uid(VerifyOtpResponse v) => v.uid;
+  static const Field<VerifyOtpResponse, String> _f$uid = Field('uid', _$uid);
+
+  @override
+  final MappableFields<VerifyOtpResponse> fields = const {
+    #customToken: _f$customToken,
+    #isNewUser: _f$isNewUser,
+    #uid: _f$uid,
+  };
+
+  static VerifyOtpResponse _instantiate(DecodingData data) {
+    return VerifyOtpResponse(
+      customToken: data.dec(_f$customToken),
+      isNewUser: data.dec(_f$isNewUser),
+      uid: data.dec(_f$uid),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static VerifyOtpResponse fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<VerifyOtpResponse>(map);
+  }
+
+  static VerifyOtpResponse fromJson(String json) {
+    return ensureInitialized().decodeJson<VerifyOtpResponse>(json);
+  }
+}
+
+mixin VerifyOtpResponseMappable {
+  String toJson() {
+    return VerifyOtpResponseMapper.ensureInitialized()
+        .encodeJson<VerifyOtpResponse>(this as VerifyOtpResponse);
+  }
+
+  Map<String, dynamic> toMap() {
+    return VerifyOtpResponseMapper.ensureInitialized()
+        .encodeMap<VerifyOtpResponse>(this as VerifyOtpResponse);
+  }
+
+  VerifyOtpResponseCopyWith<
+    VerifyOtpResponse,
+    VerifyOtpResponse,
+    VerifyOtpResponse
+  >
+  get copyWith =>
+      _VerifyOtpResponseCopyWithImpl<VerifyOtpResponse, VerifyOtpResponse>(
+        this as VerifyOtpResponse,
+        $identity,
+        $identity,
+      );
+  @override
+  String toString() {
+    return VerifyOtpResponseMapper.ensureInitialized().stringifyValue(
+      this as VerifyOtpResponse,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return VerifyOtpResponseMapper.ensureInitialized().equalsValue(
+      this as VerifyOtpResponse,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return VerifyOtpResponseMapper.ensureInitialized().hashValue(
+      this as VerifyOtpResponse,
+    );
+  }
+}
+
+extension VerifyOtpResponseValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, VerifyOtpResponse, $Out> {
+  VerifyOtpResponseCopyWith<$R, VerifyOtpResponse, $Out>
+  get $asVerifyOtpResponse => $base.as(
+    (v, t, t2) => _VerifyOtpResponseCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class VerifyOtpResponseCopyWith<
+  $R,
+  $In extends VerifyOtpResponse,
+  $Out
+>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({String? customToken, bool? isNewUser, String? uid});
+  VerifyOtpResponseCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _VerifyOtpResponseCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, VerifyOtpResponse, $Out>
+    implements VerifyOtpResponseCopyWith<$R, VerifyOtpResponse, $Out> {
+  _VerifyOtpResponseCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<VerifyOtpResponse> $mapper =
+      VerifyOtpResponseMapper.ensureInitialized();
+  @override
+  $R call({String? customToken, bool? isNewUser, String? uid}) => $apply(
+    FieldCopyWithData({
+      if (customToken != null) #customToken: customToken,
+      if (isNewUser != null) #isNewUser: isNewUser,
+      if (uid != null) #uid: uid,
+    }),
+  );
+  @override
+  VerifyOtpResponse $make(CopyWithData data) => VerifyOtpResponse(
+    customToken: data.get(#customToken, or: $value.customToken),
+    isNewUser: data.get(#isNewUser, or: $value.isNewUser),
+    uid: data.get(#uid, or: $value.uid),
+  );
+
+  @override
+  VerifyOtpResponseCopyWith<$R2, VerifyOtpResponse, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) => _VerifyOtpResponseCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+

--- a/recipients_app/pubspec.lock
+++ b/recipients_app/pubspec.lock
@@ -297,6 +297,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  dart_mappable:
+    dependency: "direct main"
+    description:
+      name: dart_mappable
+      sha256: "0e219930c9f7b9e0f14ae7c1de931c401875110fd5c67975b6b9492a6d3a531b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.1"
+  dart_mappable_builder:
+    dependency: "direct dev"
+    description:
+      name: dart_mappable_builder
+      sha256: "1116c70d9923e85e78a9339a67934949334a4190c8a6f46e1fbc908341ce424c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.0"
   dart_style:
     dependency: transitive
     description:
@@ -590,13 +606,13 @@ packages:
     source: hosted
     version: "0.15.6"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
-      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -944,10 +960,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "800f12fb87434defa13432ab37e33051b43b290a174e15259563b043cda40c46"
+      sha256: "7b19d6ba131c6eb98bfcbf8d56c1a7002eba438af2e7ae6f8398b2b0f4f381e3"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "3.1.0"
   source_helper:
     dependency: transitive
     description:
@@ -1068,6 +1084,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.0"
+  type_plus:
+    dependency: transitive
+    description:
+      name: type_plus
+      sha256: d5d1019471f0d38b91603adb9b5fd4ce7ab903c879d2fbf1a3f80a630a03fcc9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   typed_data:
     dependency: transitive
     description:

--- a/recipients_app/pubspec.yaml
+++ b/recipients_app/pubspec.yaml
@@ -2,7 +2,7 @@ name: app
 description: Social Income App
 
 publish_to: "none"
-version: 1.1.17+1 # The build number is set in Codemagic automatically.
+version: 1.1.18+1 # The build number is set in Codemagic automatically.
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
@@ -14,6 +14,7 @@ dependencies:
   cloud_firestore: ^6.0.1
   cloud_functions: ^6.0.1
   collection: ^1.19.1
+  dart_mappable: ^4.6.1
   equatable: ^2.0.7
   firebase_analytics: ^12.0.2 # Is required to use Firebase Remote Config.
   firebase_app_check: ^0.4.0+1
@@ -28,6 +29,7 @@ dependencies:
     sdk: flutter
   flutter_native_splash: ^2.4.6
   force_update_helper: ^0.2.1
+  http: ^1.6.0
   intl: ^0.20.2
   # v0.8.0 is not publish on pub.dev but it is released on Github. This version fixes the build error on iOS with the message "Cannot find type 'PhoneNumberKit' in scope".
   intl_phone_number_input:
@@ -50,6 +52,7 @@ dev_dependencies:
   alchemist: ^0.12.1
   bloc_test: ^10.0.0
   build_runner: ^2.6.0
+  dart_mappable_builder: ^4.6.0
 
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
The Cloud Function to verify the OTP token has been deleted in the prod environment. So this PR uses the new API to verify the OTP token and get a custom firebase token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * OTP verification switched from cloud functions to a direct HTTP API.
  * Unified environment variable name for base URL across build configs.

* **New Features**
  * Added typed request/response models for OTP verification.
  * Improved pre-call validation and sign-in flow using the API-provided token.

* **Chores**
  * Version bumped to 1.1.18+1.
  * Added HTTP client and data-mapping dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->