### PR TITLE
Clean up CodeMagic: Remove Twilio environment variables, update Xcode to 26.2

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -5,7 +5,7 @@ definitions:
 
   env_versions: &env_versions
     flutter: 3.35.5
-    xcode: 16.4
+    xcode: 26.2
     cocoapods: 1.16.2
     java: 21
 
@@ -106,11 +106,7 @@ workflows:
             --flavor stage \
             -t lib/main_stage.dart \
             --dart-define=BASE_URL=$BASE_URL \
-            --dart-define=SENTRY_URL=$SENTRY_URL \
-            --dart-define=TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID \
-            --dart-define=TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN \
-            --dart-define=TWILIO_NUMBER=$TWILIO_NUMBER \
-            --dart-define=TWILIO_SERVICE_SID=$TWILIO_SERVICE_SID \
+            --dart-define=SENTRY_URL=$SENTRY_URL
         working_directory: recipients_app
       - name: Generate universal APK from AAB
         script: |
@@ -227,11 +223,7 @@ workflows:
             --flavor prod \
             -t lib/main_prod.dart \
             --dart-define=BASE_URL=$BASE_URL \
-            --dart-define=SENTRY_URL=$SENTRY_URL \
-            --dart-define=TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID \
-            --dart-define=TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN \
-            --dart-define=TWILIO_NUMBER=$TWILIO_NUMBER \
-            --dart-define=TWILIO_SERVICE_SID=$TWILIO_SERVICE_SID
+            --dart-define=SENTRY_URL=$SENTRY_URL
         working_directory: recipients_app
 
     artifacts:
@@ -359,10 +351,6 @@ workflows:
             -t lib/main_stage.dart \
             --dart-define=BASE_URL=$BASE_URL \
             --dart-define=SENTRY_URL=$SENTRY_URL \
-            --dart-define=TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID \
-            --dart-define=TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN \
-            --dart-define=TWILIO_NUMBER=$TWILIO_NUMBER \
-            --dart-define=TWILIO_SERVICE_SID=$TWILIO_SERVICE_SID \
             --export-options-plist=$CM_BUILD_DIR/recipients_app/ios/export_options.plist
         working_directory: recipients_app
 
@@ -502,10 +490,6 @@ workflows:
             -t lib/main_stage.dart \
             --dart-define=BASE_URL=$BASE_URL \
             --dart-define=SENTRY_URL=$SENTRY_URL \
-            --dart-define=TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID \
-            --dart-define=TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN \
-            --dart-define=TWILIO_NUMBER=$TWILIO_NUMBER \
-            --dart-define=TWILIO_SERVICE_SID=$TWILIO_SERVICE_SID \
             --export-options-plist=$CM_BUILD_DIR/recipients_app/ios/export_options.plist
         working_directory: recipients_app
 
@@ -636,10 +620,6 @@ workflows:
             -t lib/main_prod.dart \
             --dart-define=BASE_URL=$BASE_URL \
             --dart-define=SENTRY_URL=$SENTRY_URL \
-            --dart-define=TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID \
-            --dart-define=TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN \
-            --dart-define=TWILIO_NUMBER=$TWILIO_NUMBER \
-            --dart-define=TWILIO_SERVICE_SID=$TWILIO_SERVICE_SID \
             --export-options-plist=$CM_BUILD_DIR/recipients_app/ios/export_options.plist
         working_directory: recipients_app
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling versions for iOS and macOS development to current standards for improved compatibility.
  * Simplified build configuration by removing unused credential environment variable definitions across multiple build workflows while preserving essential system monitoring and error tracking integrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->