### PR TITLE
fix: add max height to country table

### DIFF
--- a/website/src/components/create-program-wizard/step-1/country-table-body.tsx
+++ b/website/src/components/create-program-wizard/step-1/country-table-body.tsx
@@ -21,7 +21,7 @@ type Props = {
 
 export function CountryTableBody({ rows, value, openIds, onToggleRow }: Props) {
 	return (
-		<div className="overflow-hidden rounded-xl border">
+		<div className="max-h-96 overflow-auto rounded-xl border">
 			<Table className="table-fixed">
 				<TableHeader className="bg-muted/40">
 					<TableRow>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Made the country table scrollable with a maximum height constraint, allowing users to access all country options through scrolling instead of hidden overflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->