### PR TITLE
fix: show operators in program settings dialog

### DIFF
--- a/website/src/lib/services/program/program-read.service.ts
+++ b/website/src/lib/services/program/program-read.service.ts
@@ -352,11 +352,38 @@ export class ProgramReadService extends BaseService {
 				return this.resultFail(accessibleProgramsResult.error);
 			}
 
+			const hasReadAccess = accessibleProgramsResult.data.some((access) => access.programId === programId);
+			if (!hasReadAccess) {
+				return this.resultFail('Permission denied');
+			}
+
 			const hasOperatorAccess = accessibleProgramsResult.data.some(
 				(access) => access.programId === programId && access.permission === ProgramPermission.operator,
 			);
 			if (!hasOperatorAccess) {
-				return this.resultFail('Permission denied');
+				const programOrganizations = await this.db.programAccess.findMany({
+					where: { programId },
+					select: {
+						organization: {
+							select: {
+								id: true,
+								name: true,
+							},
+						},
+					},
+					orderBy: {
+						organization: {
+							name: 'asc',
+						},
+					},
+				});
+
+				return this.resultOk(
+					programOrganizations.map(({ organization }) => ({
+						id: organization.id,
+						name: organization.name,
+					})),
+				);
 			}
 
 			const organizations = await this.db.organization.findMany({

--- a/website/test/e2e/projects/portal/program/overview.e2e.ts
+++ b/website/test/e2e/projects/portal/program/overview.e2e.ts
@@ -1,3 +1,4 @@
+import { prisma } from '@/lib/database/prisma';
 import { seedDatabase } from '@/lib/database/seed/run-seed';
 import { expect, Page, test } from '@playwright/test';
 import { expectToHaveScreenshot, selectMultiOptionsByTestId, selectOptionByTestId } from '../../../utils';
@@ -62,6 +63,47 @@ test('program settings dialog for program-si-core-sl updates all editable values
 	await expect(dialog.getByTestId('form-item-operatorOrganizations')).toContainText('Social Income SL');
 
 	await expectToHaveScreenshot(page);
+});
+
+test('program settings dialog shows owner and operator for owner-only active organization', async ({ page }) => {
+	const programId = 'program-si-core-sl';
+	const programAccesses = await prisma.programAccess.findMany({
+		where: { programId },
+		select: {
+			permission: true,
+			organizationId: true,
+			organization: {
+				select: {
+					name: true,
+				},
+			},
+		},
+	});
+	const ownerAccess = programAccesses.find((access) => access.permission === 'owner');
+	const operatorAccess = programAccesses.find((access) => access.permission === 'operator');
+	expect(ownerAccess).toBeDefined();
+	expect(operatorAccess).toBeDefined();
+
+	const portalUser = await prisma.user.findFirst({
+		where: { contact: { email: 'power@portal.test' } },
+		select: { id: true },
+	});
+	expect(portalUser).toBeDefined();
+
+	if (!ownerAccess || !operatorAccess || !portalUser) {
+		throw new Error('Seeded owner/operator program accesses or portal user missing');
+	}
+
+	await prisma.user.update({
+		where: { id: portalUser.id },
+		data: { activeOrganizationId: ownerAccess.organizationId },
+	});
+
+	const dialog = await openProgramSettingsDialog(page, programId);
+
+	await expect(dialog.getByRole('heading', { name: 'View program settings' })).toBeVisible();
+	await expect(dialog.getByTestId('form-item-ownerOrganizations')).toContainText(ownerAccess.organization.name);
+	await expect(dialog.getByTestId('form-item-operatorOrganizations')).toContainText(operatorAccess.organization.name);
 });
 
 test('program settings dialog can delete a newly created program and redirects to portal', async ({ page }) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced access control validation when retrieving program settings organization options, ensuring proper permission verification before displaying organization data.

* **Tests**
  * Added end-to-end test to verify program settings dialog correctly displays organization information based on user access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->