### PR TITLE
implement autoplay for testimonial carousel

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -78,6 +78,7 @@
 		"date-fns": "^4.1.0",
 		"dotenv-cli": "^11.0.0",
 		"embla-carousel-react": "^8.6.0",
+		"embla-carousel-autoplay": "^8.6.0",
 		"firebase": "^12.0.0",
 		"firebase-admin": "^13.7.0",
 		"i18next": "^25.0.0",

--- a/website/src/components/content-blocks/testimonial-carousel.tsx
+++ b/website/src/components/content-blocks/testimonial-carousel.tsx
@@ -9,7 +9,8 @@ import type {
 } from '@/generated/storyblok/types/109655/storyblok-components';
 import { cn } from '@/lib/utils/cn';
 import { storyblokEditable, type SbBlokData } from '@storyblok/react';
-import { useEffect, useState } from 'react';
+import Autoplay from 'embla-carousel-autoplay';
+import { useEffect, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
 
 type Props = {
@@ -22,11 +23,16 @@ type TestimonialWithImage = StoryblokTestimonial & {
 	};
 };
 
+const AUTOPLAY_DELAY_MS = 4000;
+
 export const TestimonialCarouselBlock = ({ blok }: Props) => {
 	const entries = blok.testimonials.filter((entry): entry is TestimonialWithImage => Boolean(entry.image?.filename));
+	const autoplayEnabled = Boolean(blok.autoplay);
 
 	const [api, setApi] = useState<CarouselApi>();
 	const [activeIndex, setActiveIndex] = useState(0);
+	const [remainingMs, setRemainingMs] = useState(AUTOPLAY_DELAY_MS);
+	const autoplayPlugin = useRef(Autoplay({ delay: AUTOPLAY_DELAY_MS, stopOnInteraction: false }));
 
 	useEffect(() => {
 		if (!api) {
@@ -47,6 +53,47 @@ export const TestimonialCarouselBlock = ({ blok }: Props) => {
 		};
 	}, [api]);
 
+	const handleSelectTestimonialItem = (index: number) => {
+		if (!api) {
+			return;
+		}
+
+		api.scrollTo(index);
+
+		if (autoplayEnabled) {
+			const autoplay = api.plugins().autoplay;
+			autoplay?.reset();
+			if (autoplay && !autoplay.isPlaying()) {
+				autoplay.play();
+			}
+		}
+
+		setRemainingMs(AUTOPLAY_DELAY_MS);
+	};
+
+	useEffect(() => {
+		if (!api || !autoplayEnabled) {
+			return;
+		}
+
+		let animationFrameId: number | null = null;
+
+		const updateRemainingDelay = () => {
+			const autoplay = api.plugins().autoplay;
+			const nextDelay = autoplay?.timeUntilNext();
+			setRemainingMs(nextDelay ?? AUTOPLAY_DELAY_MS);
+			animationFrameId = window.requestAnimationFrame(updateRemainingDelay);
+		};
+
+		updateRemainingDelay();
+
+		return () => {
+			if (animationFrameId !== null) {
+				window.cancelAnimationFrame(animationFrameId);
+			}
+		};
+	}, [api, autoplayEnabled]);
+
 	if (entries.length === 0) {
 		return null;
 	}
@@ -65,6 +112,7 @@ export const TestimonialCarouselBlock = ({ blok }: Props) => {
 						align: 'center',
 						loop: true,
 					}}
+					plugins={autoplayEnabled ? [autoplayPlugin.current] : []}
 				>
 					<CarouselContent>
 						{entries.map((entry, index) => (
@@ -80,10 +128,24 @@ export const TestimonialCarouselBlock = ({ blok }: Props) => {
 						<button
 							key={`${entry.name}-${index}`}
 							type="button"
-							onClick={() => api?.scrollTo(index)}
-							className={cn('h-1.5 w-16 rounded-full transition', index === activeIndex ? 'bg-primary' : 'bg-primary/25')}
+							onClick={() => handleSelectTestimonialItem(index)}
+							className={cn('bg-primary/25·relative·h-1.5·w-16·overflow-hidden·rounded-full')}
 							aria-label={`Show testimonial ${index + 1}`}
-						/>
+						>
+							<span
+								className="bg-primary absolute inset-0 origin-left transition-transform duration-100"
+								style={{
+									transform: `scaleX(${
+										index === activeIndex
+											? autoplayEnabled
+												? Math.min(Math.max(1 - remainingMs / AUTOPLAY_DELAY_MS, 0), 1)
+												: 1
+											: 0
+									})`,
+								}}
+								aria-hidden="true"
+							/>
+						</button>
 					))}
 				</div>
 			</div>

--- a/website/src/components/content-blocks/testimonial-carousel.tsx
+++ b/website/src/components/content-blocks/testimonial-carousel.tsx
@@ -31,8 +31,8 @@ export const TestimonialCarouselBlock = ({ blok }: Props) => {
 
 	const [api, setApi] = useState<CarouselApi>();
 	const [activeIndex, setActiveIndex] = useState(0);
-	const [remainingMs, setRemainingMs] = useState(AUTOPLAY_DELAY_MS);
 	const autoplayPlugin = useRef(Autoplay({ delay: AUTOPLAY_DELAY_MS, stopOnInteraction: false }));
+	const progressBarRefs = useRef<(HTMLSpanElement | null)[]>([]);
 
 	useEffect(() => {
 		if (!api) {
@@ -67,8 +67,6 @@ export const TestimonialCarouselBlock = ({ blok }: Props) => {
 				autoplay.play();
 			}
 		}
-
-		setRemainingMs(AUTOPLAY_DELAY_MS);
 	};
 
 	useEffect(() => {
@@ -78,19 +76,42 @@ export const TestimonialCarouselBlock = ({ blok }: Props) => {
 
 		let animationFrameId: number | null = null;
 
+		const restartProgressAnimation = () => {
+			cancelProgressAnimation();
+			updateRemainingDelay();
+		};
+
+		const cancelProgressAnimation = () => {
+			if (animationFrameId !== null) {
+				window.cancelAnimationFrame(animationFrameId);
+				animationFrameId = null;
+			}
+		};
+
 		const updateRemainingDelay = () => {
 			const autoplay = api.plugins().autoplay;
-			const nextDelay = autoplay?.timeUntilNext();
-			setRemainingMs(nextDelay ?? AUTOPLAY_DELAY_MS);
+
+			const nextDelay = autoplay.timeUntilNext() ?? AUTOPLAY_DELAY_MS;
+			const progress = Math.min(Math.max(1 - nextDelay / AUTOPLAY_DELAY_MS, 0), 1);
+			const selectedIndex = api.selectedScrollSnap();
+
+			progressBarRefs.current.forEach((progressBar, index) => {
+				if (progressBar) {
+					progressBar.style.transform = `scaleX(${index === selectedIndex ? progress : 0})`;
+				}
+			});
+
 			animationFrameId = window.requestAnimationFrame(updateRemainingDelay);
 		};
 
 		updateRemainingDelay();
+		api.on('autoplay:stop', cancelProgressAnimation);
+		api.on('autoplay:play', updateRemainingDelay);
 
 		return () => {
-			if (animationFrameId !== null) {
-				window.cancelAnimationFrame(animationFrameId);
-			}
+			cancelProgressAnimation();
+			api.off('autoplay:stop', cancelProgressAnimation);
+			api.off('autoplay:play', restartProgressAnimation);
 		};
 	}, [api, autoplayEnabled]);
 
@@ -133,15 +154,12 @@ export const TestimonialCarouselBlock = ({ blok }: Props) => {
 							aria-label={`Show testimonial ${index + 1}`}
 						>
 							<span
+								ref={(element) => {
+									progressBarRefs.current[index] = element;
+								}}
 								className="bg-primary absolute inset-0 origin-left transition-transform duration-100"
 								style={{
-									transform: `scaleX(${
-										index === activeIndex
-											? autoplayEnabled
-												? Math.min(Math.max(1 - remainingMs / AUTOPLAY_DELAY_MS, 0), 1)
-												: 1
-											: 0
-									})`,
+									transform: `scaleX(${index === activeIndex && !autoplayEnabled ? 1 : 0})`,
 								}}
 								aria-hidden="true"
 							/>

--- a/website/src/components/content-blocks/testimonial-carousel.tsx
+++ b/website/src/components/content-blocks/testimonial-carousel.tsx
@@ -78,7 +78,7 @@ export const TestimonialCarouselBlock = ({ blok }: Props) => {
 
 		const restartProgressAnimation = () => {
 			cancelProgressAnimation();
-			updateRemainingDelay();
+			aimateProgressBar();
 		};
 
 		const cancelProgressAnimation = () => {
@@ -88,7 +88,7 @@ export const TestimonialCarouselBlock = ({ blok }: Props) => {
 			}
 		};
 
-		const updateRemainingDelay = () => {
+		const aimateProgressBar = () => {
 			const autoplay = api.plugins().autoplay;
 
 			const nextDelay = autoplay.timeUntilNext() ?? AUTOPLAY_DELAY_MS;
@@ -101,12 +101,12 @@ export const TestimonialCarouselBlock = ({ blok }: Props) => {
 				}
 			});
 
-			animationFrameId = window.requestAnimationFrame(updateRemainingDelay);
+			animationFrameId = window.requestAnimationFrame(aimateProgressBar);
 		};
 
-		updateRemainingDelay();
+		aimateProgressBar();
 		api.on('autoplay:stop', cancelProgressAnimation);
-		api.on('autoplay:play', updateRemainingDelay);
+		api.on('autoplay:play', aimateProgressBar);
 
 		return () => {
 			cancelProgressAnimation();

--- a/website/src/components/content-blocks/testimonial-carousel.tsx
+++ b/website/src/components/content-blocks/testimonial-carousel.tsx
@@ -129,7 +129,7 @@ export const TestimonialCarouselBlock = ({ blok }: Props) => {
 							key={`${entry.name}-${index}`}
 							type="button"
 							onClick={() => handleSelectTestimonialItem(index)}
-							className={cn('bg-primary/25·relative·h-1.5·w-16·overflow-hidden·rounded-full')}
+							className={cn('bg-primary/25 relative h-1.5 w-16 overflow-hidden rounded-full')}
 							aria-label={`Show testimonial ${index + 1}`}
 						>
 							<span

--- a/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
+++ b/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
@@ -425,6 +425,7 @@ export interface Testimonial {
 export interface TestimonialCarousel {
   testimonials: Testimonial[];
   heading?: string;
+  autoplay?: boolean;
   component: "testimonialCarousel";
   _uid: string;
   [k: string]: unknown;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Testimonial carousel autoplay is now configurable and can be enabled or disabled.
  * Clicking an indicator navigates to that slide and resets/continues the autoplay timer.
  * Active indicator now shows a progress-bar visual reflecting time remaining before auto-advance, with smooth animated progress when autoplay is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->