### PR TITLE
feat: add somaha logo to footer

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ node = "24"
 java = "23"
 
 [tasks.install]
-run = "npm install"
+run = "npm ci"
 
 [tasks.db]
 run = "npm run db:up"

--- a/website/src/components/app-shells/website/footer.tsx
+++ b/website/src/components/app-shells/website/footer.tsx
@@ -29,33 +29,50 @@ const IconMap: Record<NonNullable<Exclude<MenuItem['icon'], ''>>, React.Componen
 
 export const Footer = async ({ lang, region }: Props) => {
 	const result = await services.storyblok.getStoryWithFallback<ISbStoryData<Layout>>(`${NEW_WEBSITE_SLUG}/layout`, lang);
-	const footerMenu = result.success ? result.data.content.footerMenu : [];
-	const copyrightNotice = result.success ? result.data.content.copyrightNotice : undefined;
-	const supportedByLabel = result.success ? result.data.content.supportedByLabel : undefined;
-	const supportedByLogo = result.success ? result.data.content.supportedByLogo : undefined;
-	const supportedByUrl = result.success ? result.data.content.supportedByUrl : undefined;
-	const supportedByHref = supportedByUrl ? resolveStoryblokLink(supportedByUrl, lang, region) : undefined;
-	const hasSupportedByLink = Boolean(supportedByHref && supportedByHref !== '#');
-	const showSupportedBy = Boolean(supportedByLabel && supportedByLogo?.filename);
+	const layoutContent = result.success ? result.data.content : undefined;
+	const footerMenu = layoutContent?.footerMenu ?? [];
+	const copyrightNotice = layoutContent?.copyrightNotice;
+	const supportedByLogo = layoutContent?.supportedByLogo;
+	const supportedByLink = layoutContent?.supportedByUrl;
+	const supportedByDetails =
+		layoutContent?.supportedByLabel && supportedByLogo?.filename
+			? {
+					label: layoutContent.supportedByLabel,
+					logoFilename: supportedByLogo.filename,
+					logoAlt: supportedByLogo.alt ?? '',
+				}
+			: null;
+	const supportedByHref = supportedByLink ? resolveStoryblokLink(supportedByLink, lang, region) : undefined;
+	const supportedByLinkProps =
+		supportedByHref && supportedByHref !== '#'
+			? {
+					href: supportedByHref,
+					target: supportedByLink?.target,
+					rel: supportedByLink?.target === '_blank' ? 'noopener noreferrer' : undefined,
+				}
+			: null;
+	const supportedByLogoNode = supportedByDetails ? (
+		<NextImage src={supportedByDetails.logoFilename} alt={supportedByDetails.logoAlt} width={120} height={22} />
+	) : null;
 
 	return (
 		<div className="bg-primary max-w-content mx-auto grid w-full grid-cols-1 gap-4 rounded-t-3xl px-8 pt-10 pb-8 text-white sm:px-16 sm:pt-14 lg:mb-10 lg:grid-cols-[334px_auto] lg:rounded-3xl">
 			<div className="flex flex-col">
 				<SocialIncomeLogo width={222} height={22} />
-				{showSupportedBy && (
+				{supportedByDetails && (
 					<div className="mt-8 flex flex-col gap-2 lg:mt-auto">
-						<p className="text-xs leading-normal font-medium text-white/50">{supportedByLabel}</p>
-						{hasSupportedByLink ? (
+						<p className="text-xs leading-normal font-medium text-white/50">{supportedByDetails.label}</p>
+						{supportedByLinkProps ? (
 							<NextLink
-								href={supportedByHref!}
-								target={supportedByUrl?.target ?? undefined}
-								rel={supportedByUrl?.target === '_blank' ? 'noopener noreferrer' : undefined}
+								href={supportedByLinkProps.href}
+								target={supportedByLinkProps.target}
+								rel={supportedByLinkProps.rel}
 								className="w-fit"
 							>
-								<NextImage src={supportedByLogo.filename} alt={supportedByLogo.alt ?? ''} width={120} height={22} />
+								{supportedByLogoNode}
 							</NextLink>
 						) : (
-							<NextImage src={supportedByLogo.filename} alt={supportedByLogo.alt ?? ''} width={120} height={22} />
+							supportedByLogoNode
 						)}
 					</div>
 				)}

--- a/website/src/components/app-shells/website/footer.tsx
+++ b/website/src/components/app-shells/website/footer.tsx
@@ -11,6 +11,7 @@ import { resolveStoryblokLink } from '@/lib/services/storyblok/storyblok.utils';
 import { NEW_WEBSITE_SLUG } from '@/lib/utils/const';
 import { now } from '@/lib/utils/now';
 import { ISbStoryData } from '@storyblok/js';
+import NextImage from 'next/image';
 import NextLink from 'next/link';
 
 type Props = {
@@ -30,11 +31,34 @@ export const Footer = async ({ lang, region }: Props) => {
 	const result = await services.storyblok.getStoryWithFallback<ISbStoryData<Layout>>(`${NEW_WEBSITE_SLUG}/layout`, lang);
 	const footerMenu = result.success ? result.data.content.footerMenu : [];
 	const copyrightNotice = result.success ? result.data.content.copyrightNotice : undefined;
+	const supportedByLabel = result.success ? result.data.content.supportedByLabel : undefined;
+	const supportedByLogo = result.success ? result.data.content.supportedByLogo : undefined;
+	const supportedByUrl = result.success ? result.data.content.supportedByUrl : undefined;
+	const supportedByHref = supportedByUrl ? resolveStoryblokLink(supportedByUrl, lang, region) : undefined;
+	const hasSupportedByLink = Boolean(supportedByHref && supportedByHref !== '#');
+	const showSupportedBy = Boolean(supportedByLabel && supportedByLogo?.filename);
 
 	return (
 		<div className="bg-primary max-w-content mx-auto grid w-full grid-cols-1 gap-4 rounded-t-3xl px-8 pt-10 pb-8 text-white sm:px-16 sm:pt-14 lg:mb-10 lg:grid-cols-[334px_auto] lg:rounded-3xl">
-			<div>
+			<div className="flex flex-col">
 				<SocialIncomeLogo width={222} height={22} />
+				{showSupportedBy && (
+					<div className="mt-8 flex flex-col gap-2 lg:mt-auto">
+						<p className="text-xs leading-normal font-medium text-white/50">{supportedByLabel}</p>
+						{hasSupportedByLink ? (
+							<NextLink
+								href={supportedByHref!}
+								target={supportedByUrl?.target ?? undefined}
+								rel={supportedByUrl?.target === '_blank' ? 'noopener noreferrer' : undefined}
+								className="w-fit"
+							>
+								<NextImage src={supportedByLogo.filename} alt={supportedByLogo.alt ?? ''} width={120} height={22} />
+							</NextLink>
+						) : (
+							<NextImage src={supportedByLogo.filename} alt={supportedByLogo.alt ?? ''} width={120} height={22} />
+						)}
+					</div>
+				)}
 			</div>
 			<div className="mt-8 lg:mt-16">
 				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">

--- a/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
+++ b/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
@@ -99,6 +99,16 @@ export interface CountryGrid {
   [k: string]: unknown;
 }
 
+export interface Document {
+  title?: string;
+  file: StoryblokAsset;
+  language?: string;
+  downloadButtonName: string;
+  component: "document";
+  _uid: string;
+  [k: string]: unknown;
+}
+
 export interface DonationsTotal {
   heading: string;
   images?: StoryblokMultiasset;
@@ -108,22 +118,12 @@ export interface DonationsTotal {
   [k: string]: unknown;
 }
 
-export interface Download {
-  title: string;
-  file: Exclude<StoryblokMultilink, {linktype?: "email"} | {linktype?: "asset"}>;
-  language?: string;
-  linkName: string;
-  component: "download";
-  _uid: string;
-  [k: string]: unknown;
-}
-
 export interface Downloads {
   heading?: string;
   tableHeaderLabelFilename: string;
   tableHeaderLabelInfo: string;
   tableHeaderLabelLink: string;
-  files: Download[];
+  documents: (ISbStoryData<Document> | string)[];
   component: "downloads";
   _uid: string;
   [k: string]: unknown;
@@ -228,6 +228,9 @@ export interface Layout {
   menu: (MenuItem | DropdownItem)[];
   footerMenu: MenuItemGroup[];
   copyrightNotice?: string;
+  supportedByLabel?: string;
+  supportedByLogo?: StoryblokAsset;
+  supportedByUrl?: Exclude<StoryblokMultilink, {linktype?: "email"} | {linktype?: "asset"}>;
   component: "layout";
   _uid: string;
   [k: string]: unknown;
@@ -303,7 +306,6 @@ export interface Page {
     | CampaignGrid
     | CountryGrid
     | DonationsTotal
-    | Download
     | Downloads
     | FaqSelection
     | FocusGrid
@@ -350,16 +352,21 @@ export interface Person {
 export interface Program {
   id: string;
   title: string;
-  heroImage: StoryblokAsset;
   description: string;
+  primaryImage: StoryblokAsset;
+  secondaryImage: StoryblokAsset;
+  tertiaryImage: StoryblokAsset;
   component: "program";
   _uid: string;
   [k: string]: unknown;
 }
 
 export interface ProgramGrid {
+  heading?: string;
+  description?: string;
   showAllPrograms?: boolean;
   programs?: (ISbStoryData<Program> | string)[];
+  button?: Button[];
   component: "programGrid";
   _uid: string;
   [k: string]: unknown;
@@ -461,6 +468,7 @@ export type ContentType =
   | ArticleType
   | Campaign
   | Country
+  | Document
   | Faq
   | Focus
   | Layout

--- a/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
+++ b/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
@@ -99,16 +99,6 @@ export interface CountryGrid {
   [k: string]: unknown;
 }
 
-export interface Document {
-  title?: string;
-  file: StoryblokAsset;
-  language?: string;
-  downloadButtonName: string;
-  component: "document";
-  _uid: string;
-  [k: string]: unknown;
-}
-
 export interface DonationsTotal {
   heading: string;
   images?: StoryblokMultiasset;
@@ -118,12 +108,22 @@ export interface DonationsTotal {
   [k: string]: unknown;
 }
 
+export interface Download {
+  title: string;
+  file: Exclude<StoryblokMultilink, {linktype?: "email"} | {linktype?: "asset"}>;
+  language?: string;
+  linkName: string;
+  component: "download";
+  _uid: string;
+  [k: string]: unknown;
+}
+
 export interface Downloads {
   heading?: string;
   tableHeaderLabelFilename: string;
   tableHeaderLabelInfo: string;
   tableHeaderLabelLink: string;
-  documents: (ISbStoryData<Document> | string)[];
+  files: Download[];
   component: "downloads";
   _uid: string;
   [k: string]: unknown;
@@ -306,6 +306,7 @@ export interface Page {
     | CampaignGrid
     | CountryGrid
     | DonationsTotal
+    | Download
     | Downloads
     | FaqSelection
     | FocusGrid
@@ -352,6 +353,7 @@ export interface Person {
 export interface Program {
   id: string;
   title: string;
+  heroImage: StoryblokAsset;
   description: string;
   primaryImage: StoryblokAsset;
   secondaryImage: StoryblokAsset;
@@ -362,11 +364,8 @@ export interface Program {
 }
 
 export interface ProgramGrid {
-  heading?: string;
-  description?: string;
   showAllPrograms?: boolean;
   programs?: (ISbStoryData<Program> | string)[];
-  button?: Button[];
   component: "programGrid";
   _uid: string;
   [k: string]: unknown;
@@ -468,7 +467,6 @@ export type ContentType =
   | ArticleType
   | Campaign
   | Country
-  | Document
   | Faq
   | Focus
   | Layout


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dynamic "Supported By" block in the website footer that displays partner labels and logos and resolves partner links per language/region, opening external links appropriately.

* **Chores**
  * Switched installation step to use npm ci for more reliable installs.
  * Added local dev SSL-related dependencies to the dev setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->