### PR TITLE
feat: add key statistics on country page

### DIFF
--- a/website/src/components/storyblok/country/country-detail.tsx
+++ b/website/src/components/storyblok/country/country-detail.tsx
@@ -8,9 +8,12 @@ import { services } from '@/lib/services/services';
 import { NEW_WEBSITE_SLUG } from '@/lib/utils/const';
 import NextImage from 'next/image';
 import NextLink from 'next/link';
+import { Suspense } from 'react';
 import { CountryDonationsTotal } from './country-donations-total';
 import { CountryPersonCarousel } from './country-person-carousel';
 import { CountryPrograms } from './country-programs';
+import { CountryStatistics } from './country-statistics';
+import { CountryStatisticsSkeleton } from './country-statistics-skeleton';
 import type { CountryStory } from './country.types';
 import { getCountryDescription, getCountryIsoCode, getCountryLocalPartners, getCountryTitle } from './country.utils';
 import { MapBubble } from './map-bubble';
@@ -104,8 +107,12 @@ export const CountryDetail = async ({ country, lang, region, activeProgramsCount
 					/>
 				</div>
 			) : null}
-
 			{donationsBlock ? <CountryDonationsTotal blok={donationsBlock} isoCode={isoCode} lang={lang} region={region} /> : null}
+			{hasIsoCode ? (
+				<Suspense fallback={<CountryStatisticsSkeleton lang={lang} />}>
+					<CountryStatistics countryIsoCode={isoCode} countryName={countryTitle} lang={lang} />
+				</Suspense>
+			) : null}
 			{programsBlock ? <CountryPrograms blok={programsBlock} isoCode={isoCode} lang={lang} region={region} /> : null}
 			{localPartners.length > 0 ? (
 				<div className="max-w-content 2xl:w-site-width ml-[2vw] py-8 pl-6 2xl:mx-auto">

--- a/website/src/components/storyblok/country/country-statistics-skeleton.tsx
+++ b/website/src/components/storyblok/country/country-statistics-skeleton.tsx
@@ -5,6 +5,8 @@ const SkeletonBar = ({ className }: { className: string }) => (
 	<div className={`animate-pulse rounded-full bg-slate-200 ${className}`} />
 );
 
+const SKELETON_ROW_COUNT = 5;
+
 type Props = {
 	lang: WebsiteLanguage;
 };
@@ -27,7 +29,7 @@ export const CountryStatisticsSkeleton = async ({ lang }: Props) => {
 									<SkeletonBar className="h-7 w-7 rounded-full" />
 									<SkeletonBar className="mt-3 h-5 w-28 rounded-md" />
 									<div className="mt-8 flex flex-col gap-7">
-										{Array.from({ length: 4 }, (_, index) => (
+										{Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
 											<div key={`country-statistics-skeleton-mobile-left-${index}`} className="flex flex-col gap-0">
 												<SkeletonBar className="h-5 w-20 rounded-md" />
 												<SkeletonBar className="mt-0.5 h-5 w-16 rounded-md" />
@@ -39,7 +41,7 @@ export const CountryStatisticsSkeleton = async ({ lang }: Props) => {
 									<SkeletonBar className="h-7 w-7 rounded-full" />
 									<SkeletonBar className="mt-3 h-5 w-28 rounded-md" />
 									<div className="mt-8 flex flex-col gap-7">
-										{Array.from({ length: 4 }, (_, index) => (
+										{Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
 											<div key={`country-statistics-skeleton-mobile-right-${index}`} className="flex flex-col gap-0">
 												<SkeletonBar className="pointer-events-none invisible h-5 w-20 rounded-md" />
 												<SkeletonBar className="mt-0.5 h-5 w-16 rounded-md" />
@@ -61,7 +63,7 @@ export const CountryStatisticsSkeleton = async ({ lang }: Props) => {
 										<SkeletonBar className="mt-3 h-8 w-40 rounded-md" />
 									</div>
 									<div className="mt-8 flex flex-col gap-4">
-										{Array.from({ length: 4 }, (_, index) => (
+										{Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
 											<SkeletonBar key={`country-statistics-skeleton-label-${index}`} className="h-6 w-32 rounded-md" />
 										))}
 									</div>
@@ -70,7 +72,7 @@ export const CountryStatisticsSkeleton = async ({ lang }: Props) => {
 									<SkeletonBar className="h-7 w-7 rounded-full" />
 									<SkeletonBar className="mt-3 h-8 w-40 rounded-md" />
 									<div className="mt-8 flex flex-col gap-4">
-										{Array.from({ length: 4 }, (_, index) => (
+										{Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
 											<SkeletonBar key={`country-statistics-skeleton-country-${index}`} className="h-6 w-24 rounded-md" />
 										))}
 									</div>
@@ -79,7 +81,7 @@ export const CountryStatisticsSkeleton = async ({ lang }: Props) => {
 									<SkeletonBar className="h-7 w-7 rounded-full" />
 									<SkeletonBar className="mt-3 h-8 w-40 rounded-md" />
 									<div className="mt-8 flex flex-col gap-4">
-										{Array.from({ length: 4 }, (_, index) => (
+										{Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
 											<SkeletonBar key={`country-statistics-skeleton-visitor-${index}`} className="h-6 w-24 rounded-md" />
 										))}
 									</div>

--- a/website/src/components/storyblok/country/country-statistics-skeleton.tsx
+++ b/website/src/components/storyblok/country/country-statistics-skeleton.tsx
@@ -1,0 +1,95 @@
+import { Translator } from '@/lib/i18n/translator';
+import { type WebsiteLanguage } from '@/lib/i18n/utils';
+
+const SkeletonBar = ({ className }: { className: string }) => (
+	<div className={`animate-pulse rounded-full bg-slate-200 ${className}`} />
+);
+
+type Props = {
+	lang: WebsiteLanguage;
+};
+
+export const CountryStatisticsSkeleton = async ({ lang }: Props) => {
+	const translator = await Translator.getInstance({ language: lang, namespaces: ['website-common'] });
+
+	return (
+		<section className="w-site-width max-w-content mx-auto px-6 py-8 lg:py-12">
+			<div className="flex flex-col items-center gap-6">
+				<h2 className="text-primary text-center text-4xl leading-tight font-bold md:text-5xl">
+					{translator.t('countries-page.statistics.title')}
+				</h2>
+				<div className="border-border bg-background w-full overflow-hidden rounded-[calc(var(--radius)+4px)] border shadow-[0px_4px_28px_0px_rgba(0,30,101,0.07)]">
+					<div className="lg:hidden">
+						<div className="bg-accent relative overflow-hidden">
+							<div className="bg-border absolute inset-y-0 left-1/2 z-10 w-px -translate-x-1/2" />
+							<div className="grid grid-cols-2 items-stretch">
+								<div className="bg-background rounded-l-[calc(var(--radius)+4px)] px-6 py-6">
+									<SkeletonBar className="h-7 w-7 rounded-full" />
+									<SkeletonBar className="mt-3 h-5 w-28 rounded-md" />
+									<div className="mt-8 flex flex-col gap-7">
+										{Array.from({ length: 4 }, (_, index) => (
+											<div key={`country-statistics-skeleton-mobile-left-${index}`} className="flex flex-col gap-0">
+												<SkeletonBar className="h-5 w-20 rounded-md" />
+												<SkeletonBar className="mt-0.5 h-5 w-16 rounded-md" />
+											</div>
+										))}
+									</div>
+								</div>
+								<div className="bg-background px-6 py-6">
+									<SkeletonBar className="h-7 w-7 rounded-full" />
+									<SkeletonBar className="mt-3 h-5 w-28 rounded-md" />
+									<div className="mt-8 flex flex-col gap-7">
+										{Array.from({ length: 4 }, (_, index) => (
+											<div key={`country-statistics-skeleton-mobile-right-${index}`} className="flex flex-col gap-0">
+												<SkeletonBar className="pointer-events-none invisible h-5 w-20 rounded-md" />
+												<SkeletonBar className="mt-0.5 h-5 w-16 rounded-md" />
+											</div>
+										))}
+									</div>
+								</div>
+							</div>
+							<div className="bg-muted absolute top-16 left-1/2 z-20 size-5 -translate-x-1/2 rounded-full" />
+						</div>
+					</div>
+					<div className="hidden lg:block">
+						<div className="bg-accent relative overflow-hidden">
+							<div className="bg-border absolute inset-y-0 left-[calc(50%+160px)] z-10 w-px -translate-x-1/2" />
+							<div className="grid grid-cols-[320px_minmax(0,1fr)_minmax(0,1fr)] items-stretch">
+								<div className="bg-accent p-12">
+									<div className="pointer-events-none invisible select-none">
+										<SkeletonBar className="h-7 w-7 rounded-full" />
+										<SkeletonBar className="mt-3 h-8 w-40 rounded-md" />
+									</div>
+									<div className="mt-8 flex flex-col gap-4">
+										{Array.from({ length: 4 }, (_, index) => (
+											<SkeletonBar key={`country-statistics-skeleton-label-${index}`} className="h-6 w-32 rounded-md" />
+										))}
+									</div>
+								</div>
+								<div className="border-border bg-background rounded-l-[calc(var(--radius)+4px)] border-l p-12">
+									<SkeletonBar className="h-7 w-7 rounded-full" />
+									<SkeletonBar className="mt-3 h-8 w-40 rounded-md" />
+									<div className="mt-8 flex flex-col gap-4">
+										{Array.from({ length: 4 }, (_, index) => (
+											<SkeletonBar key={`country-statistics-skeleton-country-${index}`} className="h-6 w-24 rounded-md" />
+										))}
+									</div>
+								</div>
+								<div className="bg-background p-12">
+									<SkeletonBar className="h-7 w-7 rounded-full" />
+									<SkeletonBar className="mt-3 h-8 w-40 rounded-md" />
+									<div className="mt-8 flex flex-col gap-4">
+										{Array.from({ length: 4 }, (_, index) => (
+											<SkeletonBar key={`country-statistics-skeleton-visitor-${index}`} className="h-6 w-24 rounded-md" />
+										))}
+									</div>
+								</div>
+							</div>
+							<div className="bg-muted absolute top-20 left-[calc(50%+160px)] z-20 size-10 -translate-x-1/2 rounded-full" />
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+};

--- a/website/src/components/storyblok/country/country-statistics.tsx
+++ b/website/src/components/storyblok/country/country-statistics.tsx
@@ -1,0 +1,238 @@
+import { COUNTRY_COOKIE } from '@/app/[lang]/[region]';
+import { type CountryCode } from '@/generated/prisma/enums';
+import { Translator } from '@/lib/i18n/translator';
+import { type WebsiteLanguage } from '@/lib/i18n/utils';
+import {
+	loadCountryStatisticsComparison,
+	type CountryStatisticFormat,
+} from '@/lib/services/country/world-bank-country-statistics';
+import { getCountryNameByCode, isValidCountryCode } from '@/lib/types/country';
+import { formatNumberLocale } from '@/lib/utils/string-utils';
+import { cookies, headers } from 'next/headers';
+import NextImage from 'next/image';
+
+type Props = {
+	countryIsoCode: string;
+	countryName: string;
+	lang: WebsiteLanguage;
+};
+
+const getSafeLocale = (lang: WebsiteLanguage) => {
+	try {
+		new Intl.NumberFormat(lang);
+
+		return lang;
+	} catch {
+		return 'en';
+	}
+};
+
+const formatStatisticValue = (value: number, format: CountryStatisticFormat, locale: string, yearsLabel: string): string => {
+	switch (format) {
+		case 'percentage':
+			return `${formatNumberLocale(value, locale, { minimumFractionDigits: 0, maximumFractionDigits: 2 })}%`;
+		case 'years':
+			return `${formatNumberLocale(value, locale, { minimumFractionDigits: 0, maximumFractionDigits: 0 })} ${yearsLabel}`;
+		case 'number':
+		default:
+			return formatNumberLocale(value, locale, { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+	}
+};
+
+const normalizeCountryCode = (value: string | undefined): CountryCode | null => {
+	const normalizedValue = value?.trim().toUpperCase();
+
+	if (!normalizedValue || !isValidCountryCode(normalizedValue)) {
+		return null;
+	}
+
+	return normalizedValue;
+};
+
+const resolveVisitorCountryCode = async (): Promise<CountryCode | null> => {
+	const cookieStore = await cookies();
+	const countryFromCookie = normalizeCountryCode(cookieStore.get(COUNTRY_COOKIE)?.value);
+	if (countryFromCookie) {
+		return countryFromCookie;
+	}
+
+	const headerStore = await headers();
+	const countryFromHeader = normalizeCountryCode(headerStore.get('cf-ipcountry') ?? undefined);
+	if (countryFromHeader) {
+		return countryFromHeader;
+	}
+
+	return 'CH'; // Default fallback country code
+};
+
+type CountryHeaderProps = {
+	countryCode: CountryCode;
+	countryName: string;
+	align?: 'left' | 'right';
+	nameClassName?: string;
+};
+
+const CountryHeader = ({ countryCode, countryName, align = 'left', nameClassName }: CountryHeaderProps) => {
+	const alignmentClassName = align === 'right' ? 'items-end text-right' : 'items-start text-left';
+
+	return (
+		<div className={`flex flex-col gap-3 ${alignmentClassName}`}>
+			<NextImage
+				src={`/assets/flags/${countryCode.toLowerCase()}.svg`}
+				alt={`${countryCode} flag`}
+				width={28}
+				height={28}
+				className="h-7 w-7 rounded-full object-cover"
+			/>
+			<div className="space-y-1">
+				<p className={`text-primary leading-tight font-medium ${nameClassName ?? 'text-2xl md:text-3xl'}`}>{countryName}</p>
+			</div>
+		</div>
+	);
+};
+
+const MobileStatisticRow = ({ label, value, showLabel = true }: { label: string; value: string; showLabel?: boolean }) => {
+	return (
+		<div className="flex flex-col gap-0">
+			<p
+				className={`text-primary text-sm leading-5 font-bold ${showLabel ? '' : 'pointer-events-none invisible select-none'}`}
+			>
+				{label}
+			</p>
+			<p className="text-primary font-sans text-sm leading-5 font-normal">{value}</p>
+		</div>
+	);
+};
+
+export const CountryStatistics = async ({ countryIsoCode, countryName, lang }: Props) => {
+	const normalizedCountryIsoCode = normalizeCountryCode(countryIsoCode);
+	if (!normalizedCountryIsoCode) {
+		return null;
+	}
+
+	const visitorCountryCode = await resolveVisitorCountryCode();
+	if (!visitorCountryCode) {
+		return null;
+	}
+
+	const rows = await loadCountryStatisticsComparison(normalizedCountryIsoCode, visitorCountryCode);
+	if (rows.length === 0) {
+		return null;
+	}
+
+	const translator = await Translator.getInstance({ language: lang, namespaces: ['website-common'] });
+	const visitorCountryName = getCountryNameByCode(visitorCountryCode);
+	const locale = getSafeLocale(lang);
+	const yearsLabel = translator.t('countries-page.statistics.years');
+
+	const formattedRows = rows.map((row) => ({
+		...row,
+		label: translator.t(row.labelKey),
+		countryValue: formatStatisticValue(row.countryValue, row.format, locale, yearsLabel),
+		visitorValue: formatStatisticValue(row.visitorValue, row.format, locale, yearsLabel),
+	}));
+
+	return (
+		<section className="w-site-width max-w-content mx-auto px-6 py-8 lg:py-12">
+			<div className="flex flex-col items-center gap-6">
+				<h2 className="text-primary text-center text-4xl leading-tight font-bold md:text-5xl">
+					{translator.t('countries-page.statistics.title')}
+				</h2>
+				<div className="border-border bg-background w-full overflow-hidden rounded-[calc(var(--radius)+4px)] border shadow-[0px_4px_28px_0px_rgba(0,30,101,0.07)]">
+					<div className="lg:hidden">
+						<div className="bg-accent relative overflow-hidden">
+							<div className="bg-border absolute inset-y-0 left-1/2 z-10 w-px -translate-x-1/2" aria-hidden="true" />
+							<div className="grid grid-cols-2 items-stretch">
+								<div className="bg-background rounded-l-[calc(var(--radius)+4px)] px-6 py-6">
+									<CountryHeader
+										countryCode={normalizedCountryIsoCode}
+										countryName={countryName}
+										nameClassName="text-[16px]"
+									/>
+									<div className="mt-8 flex flex-col gap-7">
+										{formattedRows.map((row) => (
+											<MobileStatisticRow key={row.key} label={row.label} value={row.countryValue} />
+										))}
+									</div>
+								</div>
+								<div className="bg-background px-6 py-6">
+									<CountryHeader
+										countryCode={visitorCountryCode}
+										countryName={visitorCountryName}
+										nameClassName="text-[16px]"
+									/>
+									<div className="mt-8 flex flex-col gap-7">
+										{formattedRows.map((row) => (
+											<MobileStatisticRow key={row.key} label={row.label} value={row.visitorValue} showLabel={false} />
+										))}
+									</div>
+								</div>
+							</div>
+							<div className="bg-muted text-muted-foreground absolute top-16 left-1/2 z-20 flex size-5 -translate-x-1/2 items-center justify-center rounded-full text-[8px] font-bold uppercase">
+								{translator.t('countries-page.statistics.vs')}
+							</div>
+						</div>
+					</div>
+
+					<div className="hidden lg:block">
+						<div className="bg-accent relative overflow-hidden">
+							<div
+								className="bg-border absolute inset-y-0 left-[calc(50%+160px)] z-10 w-px -translate-x-1/2"
+								aria-hidden="true"
+							/>
+							<div className="grid grid-cols-[320px_minmax(0,1fr)_minmax(0,1fr)] items-stretch">
+								<div className="bg-accent p-12">
+									<div className="pointer-events-none invisible select-none">
+										<CountryHeader
+											countryCode={normalizedCountryIsoCode}
+											countryName={countryName}
+											nameClassName="font-sans text-2xl font-medium"
+										/>
+									</div>
+									<div className="mt-8 flex flex-col gap-4">
+										{formattedRows.map((row) => (
+											<p key={row.key} className="text-primary font-sans text-base leading-6 font-bold">
+												{row.label}
+											</p>
+										))}
+									</div>
+								</div>
+								<div className="border-border bg-background rounded-l-[calc(var(--radius)+4px)] border-l p-12">
+									<CountryHeader
+										countryCode={normalizedCountryIsoCode}
+										countryName={countryName}
+										nameClassName="font-sans text-2xl font-medium"
+									/>
+									<div className="mt-8 flex flex-col gap-4">
+										{formattedRows.map((row) => (
+											<p key={row.key} className="text-primary font-sans text-base leading-6 font-normal">
+												{row.countryValue}
+											</p>
+										))}
+									</div>
+								</div>
+								<div className="bg-background p-12">
+									<CountryHeader
+										countryCode={visitorCountryCode}
+										countryName={visitorCountryName}
+										nameClassName="font-sans text-2xl font-medium"
+									/>
+									<div className="mt-8 flex flex-col gap-4">
+										{formattedRows.map((row) => (
+											<p key={row.key} className="text-primary font-sans text-base leading-6 font-normal">
+												{row.visitorValue}
+											</p>
+										))}
+									</div>
+								</div>
+							</div>
+							<div className="absolute top-20 left-[calc(50%+160px)] z-20 flex size-10 -translate-x-1/2 items-center justify-center rounded-full bg-slate-100 text-xs font-normal text-slate-600 uppercase">
+								{translator.t('countries-page.statistics.vs')}
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+};

--- a/website/src/components/storyblok/country/country-statistics.tsx
+++ b/website/src/components/storyblok/country/country-statistics.tsx
@@ -49,7 +49,9 @@ const normalizeCountryCode = (value: string | undefined): CountryCode | null => 
 	return normalizedValue;
 };
 
-const resolveVisitorCountryCode = async (): Promise<CountryCode | null> => {
+const FALLBACK_VISITOR_COUNTRY_CODE: CountryCode = 'CH';
+
+const resolveVisitorCountryCode = async (): Promise<CountryCode> => {
 	const cookieStore = await cookies();
 	const countryFromCookie = normalizeCountryCode(cookieStore.get(COUNTRY_COOKIE)?.value);
 	if (countryFromCookie) {
@@ -62,7 +64,7 @@ const resolveVisitorCountryCode = async (): Promise<CountryCode | null> => {
 		return countryFromHeader;
 	}
 
-	return 'CH'; // Default fallback country code
+	return FALLBACK_VISITOR_COUNTRY_CODE;
 };
 
 type CountryHeaderProps = {
@@ -111,10 +113,6 @@ export const CountryStatistics = async ({ countryIsoCode, countryName, lang }: P
 	}
 
 	const visitorCountryCode = await resolveVisitorCountryCode();
-	if (!visitorCountryCode) {
-		return null;
-	}
-
 	const rows = await loadCountryStatisticsComparison(normalizedCountryIsoCode, visitorCountryCode);
 	if (rows.length === 0) {
 		return null;

--- a/website/src/lib/i18n/locales/de/website-common.json
+++ b/website/src/lib/i18n/locales/de/website-common.json
@@ -121,7 +121,17 @@
 		"recipient-singular": "Empfänger:in",
 		"recipient-plural": "Empfänger:innen",
 		"donate-now": "Jetzt spenden",
-		"about": "Über"
+		"about": "Über",
+		"statistics": {
+			"title": "Wichtige Kennzahlen",
+			"population": "Bevölkerung",
+			"growth-rate": "Wachstumsrate",
+			"literacy-rate": "Alphabetisierungsrate",
+			"poverty-level": "Armutsquote",
+			"life-expectancy": "Lebenserwartung",
+			"years": "Jahre",
+			"vs": "vs"
+		}
 	},
 	"local-partners-page": {
 		"empty": "Keine lokalen Partner gefunden.",

--- a/website/src/lib/i18n/locales/en/website-common.json
+++ b/website/src/lib/i18n/locales/en/website-common.json
@@ -121,7 +121,17 @@
 		"recipient-singular": "recipient",
 		"recipient-plural": "recipients",
 		"donate-now": "Donate now",
-		"about": "About"
+		"about": "About",
+		"statistics": {
+			"title": "Key statistics",
+			"population": "Population",
+			"growth-rate": "Growth Rate",
+			"literacy-rate": "Literacy Rate",
+			"poverty-level": "Poverty Level",
+			"life-expectancy": "Life Expectancy",
+			"years": "Years",
+			"vs": "vs"
+		}
 	},
 	"local-partners-page": {
 		"empty": "No local partners found.",

--- a/website/src/lib/i18n/locales/fr/website-common.json
+++ b/website/src/lib/i18n/locales/fr/website-common.json
@@ -121,7 +121,17 @@
 		"recipient-singular": "bénéficiaire",
 		"recipient-plural": "bénéficiaires",
 		"donate-now": "Faire un don",
-		"about": "À propos de"
+		"about": "À propos de",
+		"statistics": {
+			"title": "Chiffres clés",
+			"population": "Population",
+			"growth-rate": "Taux de croissance",
+			"literacy-rate": "Taux d'alphabétisation",
+			"poverty-level": "Taux de pauvreté",
+			"life-expectancy": "Espérance de vie",
+			"years": "ans",
+			"vs": "vs"
+		}
 	},
 	"local-partners-page": {
 		"empty": "Aucun partenaire local trouvé.",

--- a/website/src/lib/i18n/locales/it/website-common.json
+++ b/website/src/lib/i18n/locales/it/website-common.json
@@ -121,7 +121,17 @@
 		"recipient-singular": "beneficiario",
 		"recipient-plural": "beneficiari",
 		"donate-now": "Dona ora",
-		"about": "Informazioni su"
+		"about": "Informazioni su",
+		"statistics": {
+			"title": "Statistiche chiave",
+			"population": "Popolazione",
+			"growth-rate": "Tasso di crescita",
+			"literacy-rate": "Tasso di alfabetizzazione",
+			"poverty-level": "Livello di povertà",
+			"life-expectancy": "Aspettativa di vita",
+			"years": "anni",
+			"vs": "vs"
+		}
 	},
 	"local-partners-page": {
 		"empty": "Nessun partner locale trovato.",

--- a/website/src/lib/services/country/world-bank-country-statistics.ts
+++ b/website/src/lib/services/country/world-bank-country-statistics.ts
@@ -1,0 +1,159 @@
+import { type CountryCode } from '@/generated/prisma/enums';
+
+export const COUNTRY_STATISTIC_DEFINITIONS = [
+	{
+		key: 'population',
+		indicator: 'SP.POP.TOTL',
+		labelKey: 'countries-page.statistics.population',
+		format: 'number',
+	},
+	{
+		key: 'growthRate',
+		indicator: 'SP.POP.GROW',
+		labelKey: 'countries-page.statistics.growth-rate',
+		format: 'percentage',
+	},
+	{
+		key: 'literacyRate',
+		indicator: 'SE.ADT.LITR.ZS',
+		labelKey: 'countries-page.statistics.literacy-rate',
+		format: 'percentage',
+	},
+	{
+		key: 'povertyLevel',
+		indicator: 'SI.POV.DDAY',
+		labelKey: 'countries-page.statistics.poverty-level',
+		format: 'percentage',
+	},
+	{
+		key: 'lifeExpectancy',
+		indicator: 'SP.DYN.LE00.IN',
+		labelKey: 'countries-page.statistics.life-expectancy',
+		format: 'years',
+	},
+] as const;
+
+const WORLD_BANK_REVALIDATE_SECONDS = 60 * 60 * 24;
+
+type CountryStatisticDefinition = (typeof COUNTRY_STATISTIC_DEFINITIONS)[number];
+type WorldBankIndicatorResponse = [
+	unknown,
+	{
+		value?: number | string | null;
+	}[]?,
+];
+
+export type CountryStatisticKey = CountryStatisticDefinition['key'];
+export type CountryStatisticFormat = CountryStatisticDefinition['format'];
+export type CountryStatisticRow = {
+	key: CountryStatisticKey;
+	labelKey: CountryStatisticDefinition['labelKey'];
+	format: CountryStatisticFormat;
+	countryValue: number;
+	visitorValue: number;
+};
+
+type CountryStatisticValueMap = Record<CountryStatisticKey, number | null>;
+
+const WORLD_BANK_BASE_URL = 'https://api.worldbank.org/v2/country';
+const EMPTY_COUNTRY_STATISTIC_VALUE_MAP: CountryStatisticValueMap = {
+	population: null,
+	growthRate: null,
+	literacyRate: null,
+	povertyLevel: null,
+	lifeExpectancy: null,
+};
+
+export const extractLatestWorldBankValue = (payload: unknown): number | null => {
+	if (!Array.isArray(payload) || payload.length < 2) {
+		return null;
+	}
+
+	const [, entries] = payload as WorldBankIndicatorResponse;
+	const latestEntry = entries?.find((entry) => entry?.value !== null && entry?.value !== undefined);
+	const { value } = latestEntry ?? {};
+
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return value;
+	}
+
+	if (typeof value === 'string') {
+		const parsedValue = Number(value);
+
+		return Number.isFinite(parsedValue) ? parsedValue : null;
+	}
+
+	return null;
+};
+
+export const buildCountryStatisticRows = (
+	countryValues: CountryStatisticValueMap,
+	visitorValues: CountryStatisticValueMap,
+): CountryStatisticRow[] => {
+	return COUNTRY_STATISTIC_DEFINITIONS.flatMap((definition) => {
+		const countryValue = countryValues[definition.key];
+		const visitorValue = visitorValues[definition.key];
+
+		if (countryValue === null || visitorValue === null) {
+			return [];
+		}
+
+		return [
+			{
+				key: definition.key,
+				labelKey: definition.labelKey,
+				format: definition.format,
+				countryValue,
+				visitorValue,
+			},
+		];
+	});
+};
+
+export const fetchWorldBankIndicator = async (
+	countryCode: CountryCode,
+	indicator: CountryStatisticDefinition['indicator'],
+): Promise<number | null> => {
+	try {
+		const response = await fetch(`${WORLD_BANK_BASE_URL}/${countryCode}/indicator/${indicator}?format=json&mrv=1`, {
+			next: { revalidate: WORLD_BANK_REVALIDATE_SECONDS },
+		});
+
+		if (!response.ok) {
+			return null;
+		}
+
+		return extractLatestWorldBankValue((await response.json()) as unknown);
+	} catch {
+		return null;
+	}
+};
+
+export const loadCountryStatisticValues = async (countryCode: CountryCode): Promise<CountryStatisticValueMap> => {
+	const indicatorResults = await Promise.all(
+		COUNTRY_STATISTIC_DEFINITIONS.map(async (definition) => ({
+			key: definition.key,
+			value: await fetchWorldBankIndicator(countryCode, definition.indicator),
+		})),
+	);
+
+	return indicatorResults.reduce<CountryStatisticValueMap>(
+		(accumulator, result) => ({
+			...accumulator,
+			[result.key]: result.value,
+		}),
+		EMPTY_COUNTRY_STATISTIC_VALUE_MAP,
+	);
+};
+
+export const loadCountryStatisticsComparison = async (
+	countryCode: CountryCode,
+	visitorCountryCode: CountryCode,
+): Promise<CountryStatisticRow[]> => {
+	const [countryValues, visitorValues] = await Promise.all([
+		loadCountryStatisticValues(countryCode),
+		loadCountryStatisticValues(visitorCountryCode),
+	]);
+
+	return buildCountryStatisticRows(countryValues, visitorValues);
+};

--- a/website/src/lib/services/country/world-bank-country-statistics.ts
+++ b/website/src/lib/services/country/world-bank-country-statistics.ts
@@ -33,15 +33,13 @@ export const COUNTRY_STATISTIC_DEFINITIONS = [
 	},
 ] as const;
 
+const WORLD_BANK_RECENT_VALUE_COUNT = 10;
 const WORLD_BANK_REVALIDATE_SECONDS = 60 * 60 * 24;
 
 type CountryStatisticDefinition = (typeof COUNTRY_STATISTIC_DEFINITIONS)[number];
-type WorldBankIndicatorResponse = [
-	unknown,
-	{
-		value?: number | string | null;
-	}[]?,
-];
+type WorldBankIndicatorEntry = {
+	value?: number | string | null;
+};
 
 export type CountryStatisticKey = CountryStatisticDefinition['key'];
 export type CountryStatisticFormat = CountryStatisticDefinition['format'];
@@ -64,13 +62,29 @@ const EMPTY_COUNTRY_STATISTIC_VALUE_MAP: CountryStatisticValueMap = {
 	lifeExpectancy: null,
 };
 
+const isWorldBankIndicatorEntry = (entry: unknown): entry is WorldBankIndicatorEntry => {
+	return typeof entry === 'object' && entry !== null && 'value' in entry;
+};
+
+const hasWorldBankIndicatorValue = (entry: unknown): entry is WorldBankIndicatorEntry => {
+	return isWorldBankIndicatorEntry(entry) && entry.value !== null && entry.value !== undefined;
+};
+
+const isArray = (value: unknown): value is unknown[] => {
+	return Array.isArray(value);
+};
+
 export const extractLatestWorldBankValue = (payload: unknown): number | null => {
-	if (!Array.isArray(payload) || payload.length < 2) {
+	if (!isArray(payload)) {
 		return null;
 	}
 
-	const [, entries] = payload as WorldBankIndicatorResponse;
-	const latestEntry = entries?.find((entry) => entry?.value !== null && entry?.value !== undefined);
+	const entries = payload[1];
+	if (!isArray(entries)) {
+		return null;
+	}
+
+	const latestEntry = entries.find(hasWorldBankIndicatorValue);
 	const { value } = latestEntry ?? {};
 
 	if (typeof value === 'number' && Number.isFinite(value)) {
@@ -115,7 +129,12 @@ export const fetchWorldBankIndicator = async (
 	indicator: CountryStatisticDefinition['indicator'],
 ): Promise<number | null> => {
 	try {
-		const response = await fetch(`${WORLD_BANK_BASE_URL}/${countryCode}/indicator/${indicator}?format=json&mrv=1`, {
+		const query = new URLSearchParams({
+			format: 'json',
+			mrv: WORLD_BANK_RECENT_VALUE_COUNT.toString(),
+			per_page: WORLD_BANK_RECENT_VALUE_COUNT.toString(),
+		});
+		const response = await fetch(`${WORLD_BANK_BASE_URL}/${countryCode}/indicator/${indicator}?${query}`, {
 			next: { revalidate: WORLD_BANK_REVALIDATE_SECONDS },
 		});
 
@@ -123,7 +142,9 @@ export const fetchWorldBankIndicator = async (
 			return null;
 		}
 
-		return extractLatestWorldBankValue((await response.json()) as unknown);
+		const payload: unknown = await response.json();
+
+		return extractLatestWorldBankValue(payload);
 	} catch {
 		return null;
 	}

--- a/website/src/lib/services/country/world-bank-country-statistics.ts
+++ b/website/src/lib/services/country/world-bank-country-statistics.ts
@@ -1,6 +1,6 @@
 import { type CountryCode } from '@/generated/prisma/enums';
 
-export const COUNTRY_STATISTIC_DEFINITIONS = [
+const COUNTRY_STATISTIC_DEFINITIONS = [
 	{
 		key: 'population',
 		indicator: 'SP.POP.TOTL',
@@ -41,9 +41,9 @@ type WorldBankIndicatorEntry = {
 	value?: number | string | null;
 };
 
-export type CountryStatisticKey = CountryStatisticDefinition['key'];
+type CountryStatisticKey = CountryStatisticDefinition['key'];
 export type CountryStatisticFormat = CountryStatisticDefinition['format'];
-export type CountryStatisticRow = {
+type CountryStatisticRow = {
 	key: CountryStatisticKey;
 	labelKey: CountryStatisticDefinition['labelKey'];
 	format: CountryStatisticFormat;
@@ -74,7 +74,7 @@ const isArray = (value: unknown): value is unknown[] => {
 	return Array.isArray(value);
 };
 
-export const extractLatestWorldBankValue = (payload: unknown): number | null => {
+const extractLatestWorldBankValue = (payload: unknown): number | null => {
 	if (!isArray(payload)) {
 		return null;
 	}
@@ -100,7 +100,7 @@ export const extractLatestWorldBankValue = (payload: unknown): number | null => 
 	return null;
 };
 
-export const buildCountryStatisticRows = (
+const buildCountryStatisticRows = (
 	countryValues: CountryStatisticValueMap,
 	visitorValues: CountryStatisticValueMap,
 ): CountryStatisticRow[] => {
@@ -124,7 +124,7 @@ export const buildCountryStatisticRows = (
 	});
 };
 
-export const fetchWorldBankIndicator = async (
+const fetchWorldBankIndicator = async (
 	countryCode: CountryCode,
 	indicator: CountryStatisticDefinition['indicator'],
 ): Promise<number | null> => {
@@ -150,7 +150,7 @@ export const fetchWorldBankIndicator = async (
 	}
 };
 
-export const loadCountryStatisticValues = async (countryCode: CountryCode): Promise<CountryStatisticValueMap> => {
+const loadCountryStatisticValues = async (countryCode: CountryCode): Promise<CountryStatisticValueMap> => {
 	const indicatorResults = await Promise.all(
 		COUNTRY_STATISTIC_DEFINITIONS.map(async (definition) => ({
 			key: definition.key,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Country detail pages now display a statistics section (population, growth, literacy, poverty, life expectancy) when a valid country code is present.
  * Compares selected country metrics against the visitor’s country (auto-resolved) with async loading and a skeleton placeholder.
  * Statistics data is fetched from the World Bank.

* **Localization**
  * Added localized labels for English, French, German, and Italian.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/socialincome-san/public/pull/2056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->