### PR TITLE
feat: add breadcrumb, title, description and studies on focusPage

### DIFF
--- a/website/src/app/[lang]/[region]/new-website/focuses/[slug]/page.tsx
+++ b/website/src/app/[lang]/[region]/new-website/focuses/[slug]/page.tsx
@@ -1,17 +1,18 @@
 import { DefaultLayoutPropsWithSlug } from '@/app/[lang]/[region]';
 import { FocusDetail } from '@/components/storyblok/focus/focus-detail';
+import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
 import { services } from '@/lib/services/services';
 import { notFound } from 'next/navigation';
 
 export const revalidate = 900;
 
 export default async function FocusPage({ params }: DefaultLayoutPropsWithSlug) {
-	const { slug, lang } = await params;
+	const { slug, lang, region } = await params;
 	const focusResult = await services.storyblok.getFocusBySlug(slug, lang);
 
 	if (!focusResult.success) {
 		return notFound();
 	}
 
-	return <FocusDetail focus={focusResult.data} />;
+	return <FocusDetail focus={focusResult.data} lang={lang as WebsiteLanguage} region={region as WebsiteRegion} />;
 }

--- a/website/src/app/[lang]/[region]/new-website/focuses/[slug]/preview/page.tsx
+++ b/website/src/app/[lang]/[region]/new-website/focuses/[slug]/preview/page.tsx
@@ -1,6 +1,6 @@
 import { DefaultLayoutProps, DefaultParams } from '@/app/[lang]/[region]';
 import { StoryblokPreviewFocusPage } from '@/components/storyblok/storyblok-preview-focus-page';
-import { WebsiteLanguage } from '@/lib/i18n/utils';
+import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
 import { getFocusStoryPath } from '@/lib/storyblok/storyblok-paths';
 import { NEW_WEBSITE_SLUG } from '@/lib/utils/const';
 
@@ -17,6 +17,7 @@ export default async function FocusPreviewRoute({ params, searchParams }: Previe
 			storyPath={getFocusStoryPath(slug)}
 			slug={slug}
 			lang={lang as WebsiteLanguage}
+			region={region as WebsiteRegion}
 			previewRoutePath={`/${lang}/${region}/${NEW_WEBSITE_SLUG}/focuses/${slug}/preview`}
 			searchParams={resolvedSearchParams}
 		/>

--- a/website/src/components/storyblok/focus/focus-detail.tsx
+++ b/website/src/components/storyblok/focus/focus-detail.tsx
@@ -1,18 +1,62 @@
+import { Breadcrumb } from '@/components/breadcrumb/breadcrumb';
+import { buildBreadcrumbLinks } from '@/components/breadcrumb/build-breadcrumb-links';
+import { StoryblokMarkdown } from '@/components/storyblok-markdown';
+import type { Study } from '@/generated/storyblok/types/109655/storyblok-components';
+import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
+import type { ISbStoryData } from '@storyblok/js';
 import type { FocusStory } from './focus.types';
-import { getFocusSlug, getFocusTitle } from './focus.utils';
+import { getFocusText, getFocusTitle } from './focus.utils';
+import { StudyCard } from './study-card';
 
 type Props = {
 	focus: FocusStory;
+	lang: WebsiteLanguage;
+	region: WebsiteRegion;
 };
 
-export const FocusDetail = ({ focus }: Props) => {
-	const slug = getFocusSlug(focus);
+type StudyStory = ISbStoryData<Study>;
+
+const isStudyStory = (study: StudyStory | string): study is StudyStory => {
+	return typeof study === 'object' && study !== null && study.content.component === 'study';
+};
+
+export const FocusDetail = async ({ focus, lang, region }: Props) => {
 	const title = getFocusTitle(focus.content);
+	const text = getFocusText(focus.content);
+	const { studiesTitle, studies } = focus.content;
+	const studyStories = studies?.filter(isStudyStory) ?? [];
+	const hasStudiesSection = Boolean(studiesTitle) || studyStories.length > 0;
+	const breadcrumbLinks = await buildBreadcrumbLinks({
+		fullSlug: focus.full_slug,
+		currentLabel: title,
+		lang,
+		region,
+	});
 
 	return (
-		<div>
-			<p>slug: {slug}</p>
-			<p>title: {title}</p>
+		<div className="w-site-width max-w-content mx-auto flex flex-col gap-8 px-6 py-8">
+			<Breadcrumb links={breadcrumbLinks} className="py-0" />
+			<div className="space-y-5">
+				{title && <h1 className="text-4xl leading-tight font-bold text-cyan-900 sm:text-5xl">{title}</h1>}
+				{text && <p className="text-base leading-6 text-cyan-950 sm:text-lg sm:leading-7">{text}</p>}
+			</div>
+
+			{hasStudiesSection && (
+				<section className="flex flex-col gap-10">
+					{studiesTitle && (
+						<h2 className="text-5xl leading-tight font-normal text-cyan-900">
+							<StoryblokMarkdown>{studiesTitle}</StoryblokMarkdown>
+						</h2>
+					)}
+					{studyStories.length > 0 && (
+						<div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+							{studyStories.map((study) => (
+								<StudyCard key={study.uuid} study={study} lang={lang} region={region} />
+							))}
+						</div>
+					)}
+				</section>
+			)}
 		</div>
 	);
 };

--- a/website/src/components/storyblok/focus/focus-detail.tsx
+++ b/website/src/components/storyblok/focus/focus-detail.tsx
@@ -17,7 +17,11 @@ type Props = {
 type StudyStory = ISbStoryData<Study>;
 
 const isStudyStory = (study: StudyStory | string): study is StudyStory => {
-	return typeof study === 'object' && study !== null && study.content.component === 'study';
+	if (typeof study !== 'object' || study === null || !('content' in study)) {
+		return false;
+	}
+
+	return study.content.component?.toLowerCase() === 'study';
 };
 
 export const FocusDetail = async ({ focus, lang, region }: Props) => {

--- a/website/src/components/storyblok/focus/focus.utils.ts
+++ b/website/src/components/storyblok/focus/focus.utils.ts
@@ -32,3 +32,7 @@ export const getFocusTitle = (focus: Focus) => {
 
 	return title || slug;
 };
+
+export const getFocusText = (focus: Focus) => {
+	return focus.text?.trim() ?? '';
+};

--- a/website/src/components/storyblok/focus/study-card.tsx
+++ b/website/src/components/storyblok/focus/study-card.tsx
@@ -1,0 +1,38 @@
+import type { Study } from '@/generated/storyblok/types/109655/storyblok-components';
+import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
+import { resolveStoryblokLink } from '@/lib/services/storyblok/storyblok.utils';
+import type { ISbStoryData } from '@storyblok/js';
+import { ExternalLink } from 'lucide-react';
+import Link from 'next/link';
+
+type Props = {
+	study: ISbStoryData<Study>;
+	lang: WebsiteLanguage;
+	region: WebsiteRegion;
+};
+
+export const StudyCard = ({ study, lang, region }: Props) => {
+	const { title, description, subtitle, year, link, linkText } = study.content;
+	const metadata = [subtitle?.trim(), year?.trim()].filter(Boolean).join(', ');
+	const linkLabel = linkText?.trim();
+	const href = link ? resolveStoryblokLink(link, lang, region) : null;
+
+	return (
+		<article className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white px-10 py-8 shadow-[0_4px_6px_-4px_rgba(0,0,0,0.10),0_0_20px_0_rgba(0,0,0,0.05)]">
+			<h3 className="text-foreground line-clamp-3 text-2xl font-bold">{title}</h3>
+			<p className="text-foreground line-clamp-3 font-sans text-base font-normal">{description}</p>
+			{metadata && <p className="text-foreground text-base font-light">{metadata}</p>}
+			{href && linkLabel && (
+				<Link
+					href={href}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="inline-flex w-fit items-center gap-1.5 rounded-full bg-slate-100 py-1.5 pr-2 pl-3"
+				>
+					<span className="text-foreground text-xs font-bold">{linkLabel}</span>
+					<ExternalLink className="text-foreground size-3.5" aria-hidden="true" />
+				</Link>
+			)}
+		</article>
+	);
+};

--- a/website/src/components/storyblok/focus/study-card.tsx
+++ b/website/src/components/storyblok/focus/study-card.tsx
@@ -1,6 +1,7 @@
 import type { Study } from '@/generated/storyblok/types/109655/storyblok-components';
 import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
 import { resolveStoryblokLink } from '@/lib/services/storyblok/storyblok.utils';
+import { isSafeHref } from '@/lib/utils/string-utils';
 import type { ISbStoryData } from '@storyblok/js';
 import { ExternalLink } from 'lucide-react';
 import Link from 'next/link';
@@ -16,7 +17,7 @@ export const StudyCard = ({ study, lang, region }: Props) => {
 	const metadata = [subtitle?.trim(), year?.trim()].filter(Boolean).join(', ');
 	const linkLabel = linkText?.trim();
 	const resolvedHref = link ? resolveStoryblokLink(link, lang, region) : null;
-	const href = resolvedHref === '#' ? null : resolvedHref;
+	const href = resolvedHref && resolvedHref !== '#' && isSafeHref(resolvedHref) ? resolvedHref : null;
 
 	return (
 		<article className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white px-10 py-8 shadow-[0_4px_6px_-4px_rgba(0,0,0,0.10),0_0_20px_0_rgba(0,0,0,0.05)]">

--- a/website/src/components/storyblok/focus/study-card.tsx
+++ b/website/src/components/storyblok/focus/study-card.tsx
@@ -15,7 +15,8 @@ export const StudyCard = ({ study, lang, region }: Props) => {
 	const { title, description, subtitle, year, link, linkText } = study.content;
 	const metadata = [subtitle?.trim(), year?.trim()].filter(Boolean).join(', ');
 	const linkLabel = linkText?.trim();
-	const href = link ? resolveStoryblokLink(link, lang, region) : null;
+	const resolvedHref = link ? resolveStoryblokLink(link, lang, region) : null;
+	const href = resolvedHref === '#' ? null : resolvedHref;
 
 	return (
 		<article className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white px-10 py-8 shadow-[0_4px_6px_-4px_rgba(0,0,0,0.10),0_0_20px_0_rgba(0,0,0,0.05)]">

--- a/website/src/components/storyblok/storyblok-preview-focus-page.tsx
+++ b/website/src/components/storyblok/storyblok-preview-focus-page.tsx
@@ -1,18 +1,26 @@
 import { FocusDetail } from '@/components/storyblok/focus/focus-detail';
 import type { FocusStory } from '@/components/storyblok/focus/focus.types';
 import { StoryblokPreviewStory } from '@/components/storyblok/storyblok-preview-story';
-import type { WebsiteLanguage } from '@/lib/i18n/utils';
+import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
 import { services } from '@/lib/services/services';
 
 type Props = {
 	storyPath: string;
 	slug: string;
 	lang: WebsiteLanguage;
+	region: WebsiteRegion;
 	previewRoutePath: string;
 	searchParams: Record<string, string | undefined>;
 };
 
-export const StoryblokPreviewFocusPage = async ({ storyPath, slug, lang, previewRoutePath, searchParams }: Props) => {
+export const StoryblokPreviewFocusPage = async ({
+	storyPath,
+	slug,
+	lang,
+	region,
+	previewRoutePath,
+	searchParams,
+}: Props) => {
 	return await StoryblokPreviewStory<FocusStory>({
 		storyPath,
 		lang,
@@ -23,6 +31,6 @@ export const StoryblokPreviewFocusPage = async ({ storyPath, slug, lang, preview
 
 			return storyResult.success ? storyResult.data : null;
 		},
-		renderStory: (focus) => <FocusDetail focus={focus} />,
+		renderStory: (focus) => <FocusDetail focus={focus} lang={lang} region={region} />,
 	});
 };

--- a/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
+++ b/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
@@ -160,6 +160,9 @@ export interface FaqSelection {
 export interface Focus {
   portalSlug: string;
   title: string;
+  text?: string;
+  studiesTitle?: string;
+  studies?: (ISbStoryData<Study> | string)[];
   component: "Focus";
   _uid: string;
   [k: string]: unknown;
@@ -433,6 +436,18 @@ export interface ReferencesGroup {
   [k: string]: unknown;
 }
 
+export interface Study {
+  title: string;
+  description: string;
+  subtitle?: string;
+  year?: string;
+  link?: Exclude<StoryblokMultilink, {linktype?: "email"} | {linktype?: "asset"}>;
+  linkText?: string;
+  component: "study";
+  _uid: string;
+  [k: string]: unknown;
+}
+
 export interface Tag {
   value: string;
   description?: string;
@@ -520,4 +535,5 @@ export type ContentType =
   | Program
   | ProgramOverview
   | ReferenceArticle
+  | Study
   | Tag;

--- a/website/src/lib/services/storyblok/storyblok.service.ts
+++ b/website/src/lib/services/storyblok/storyblok.service.ts
@@ -54,7 +54,6 @@ export class StoryblokService extends BaseService {
 		'downloads.documents',
 		'partnershipsCarousel.partnerships',
 		'Country.partners',
-		'Focus.studies',
 		'Local Partner.focuses',
 		'Local Partner.partners',
 	];

--- a/website/src/lib/services/storyblok/storyblok.service.ts
+++ b/website/src/lib/services/storyblok/storyblok.service.ts
@@ -54,10 +54,12 @@ export class StoryblokService extends BaseService {
 		'downloads.documents',
 		'partnershipsCarousel.partnerships',
 		'Country.partners',
+		'Focus.studies',
 		'Local Partner.focuses',
 		'Local Partner.partners',
 	];
 	private static readonly countryRelationsToResolve = ['Country.partners'];
+	private static readonly focusRelationsToResolve = ['Focus.studies'];
 	private static readonly localPartnerRelationsToResolve = ['Local Partner.focuses', 'Local Partner.partners'];
 	private static readonly defaultPageSize = 50;
 	private static readonly contentField = 'content';
@@ -703,6 +705,7 @@ export class StoryblokService extends BaseService {
 			const params: ISbStoriesParams = {
 				...baseParams,
 				starts_with: `${StoryblokService.focusesPath}/`,
+				resolve_relations: StoryblokService.focusRelationsToResolve,
 			};
 			const data = await getStoryblokApi().getAll(StoryblokService.storiesPath, params);
 			let focuses = data.filter((story) => StoryblokService.isFocusStory(story));
@@ -712,6 +715,7 @@ export class StoryblokService extends BaseService {
 					...baseParams,
 					version: 'draft',
 					starts_with: `${StoryblokService.focusesPath}/`,
+					resolve_relations: StoryblokService.focusRelationsToResolve,
 				};
 				const draftData = await getStoryblokApi().getAll(StoryblokService.storiesPath, draftParams);
 				focuses = draftData.filter((story) => StoryblokService.isFocusStory(story));

--- a/website/src/lib/utils/string-utils.ts
+++ b/website/src/lib/utils/string-utils.ts
@@ -146,3 +146,16 @@ export const formatDate = (date: Date | string | null | undefined, pattern = 'dd
 		return '—';
 	}
 };
+
+export const isSafeHref = (value: string) => {
+	if (value.startsWith('/')) {
+		return true;
+	}
+	try {
+		const protocol = new URL(value).protocol.toLowerCase();
+
+		return protocol === 'http:' || protocol === 'https:' || protocol === 'mailto:' || protocol === 'tel:';
+	} catch {
+		return false;
+	}
+};

--- a/website/src/lib/utils/string-utils.ts
+++ b/website/src/lib/utils/string-utils.ts
@@ -148,7 +148,7 @@ export const formatDate = (date: Date | string | null | undefined, pattern = 'dd
 };
 
 export const isSafeHref = (value: string) => {
-	if (value.startsWith('/')) {
+	if (value.startsWith('/') && !value.startsWith('//')) {
 		return true;
 	}
 	try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Focus pages now include a studies section with individual study cards showing title, description, year, and external resource links.
  * Breadcrumb navigation added to focus pages for clearer context.

* **Enhancements**
  * Improved regional and language support so focus content respects region selection.
  * External links in study cards are validated for safety and open appropriately in a new tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->