### PR TITLE
feat: add ImpactMeasurementPreview on FocusDetailPage

### DIFF
--- a/website/src/app/[lang]/[region]/new-website/programs/impact-measurement/view.tsx
+++ b/website/src/app/[lang]/[region]/new-website/programs/impact-measurement/view.tsx
@@ -10,10 +10,16 @@ import { getImpactTranslator } from './translator';
 type ImpactMeasurementViewProps = {
 	lang: string;
 	searchParams: ParsedUrlQueryInput;
+	showStudyDetails?: boolean;
 	variant?: 'standalone' | 'embedded';
 };
 
-export const ImpactMeasurementView = async ({ lang, searchParams, variant = 'standalone' }: ImpactMeasurementViewProps) => {
+export const ImpactMeasurementView = async ({
+	lang,
+	searchParams,
+	showStudyDetails = true,
+	variant = 'standalone',
+}: ImpactMeasurementViewProps) => {
 	const normalizedSearchParams = Object.fromEntries(
 		Object.entries(searchParams).filter(([, value]) => typeof value === 'string'),
 	) as Record<string, string | undefined>;
@@ -28,7 +34,7 @@ export const ImpactMeasurementView = async ({ lang, searchParams, variant = 'sta
 		<div
 			className={
 				variant === 'embedded'
-					? 'w-full space-y-3'
+					? 'w-full space-y-3 px-4 py-6'
 					: 'w-site-width max-w-content mx-auto space-y-3 px-4 py-6 sm:px-0 sm:py-10'
 			}
 		>
@@ -50,6 +56,11 @@ export const ImpactMeasurementView = async ({ lang, searchParams, variant = 'sta
 						<ImpactMeasurementStudyDetails lang={lang} searchParams={normalizedSearchParams} />
 					</Suspense>
 				</div>
+			) : null}
+			{variant === 'embedded' && showStudyDetails ? (
+				<Suspense key={`summary-${suspenseKey}`} fallback={<ImpactMeasurementStudyDetailsSkeleton />}>
+					<ImpactMeasurementStudyDetails lang={lang} searchParams={normalizedSearchParams} />
+				</Suspense>
 			) : null}
 			<Suspense key={suspenseKey} fallback={<ImpactMeasurementResultsSkeleton />}>
 				<ImpactMeasurementResults lang={lang} searchParams={normalizedSearchParams} />

--- a/website/src/app/[lang]/[region]/new-website/programs/impact-measurement/view.tsx
+++ b/website/src/app/[lang]/[region]/new-website/programs/impact-measurement/view.tsx
@@ -28,31 +28,29 @@ export const ImpactMeasurementView = async ({ lang, searchParams, variant = 'sta
 		<div
 			className={
 				variant === 'embedded'
-					? 'w-full space-y-3 px-4 py-6'
+					? 'w-full space-y-3'
 					: 'w-site-width max-w-content mx-auto space-y-3 px-4 py-6 sm:px-0 sm:py-10'
 			}
 		>
-			<div className="space-y-5">
-				{variant === 'standalone' ? (
-					<>
-						<h1 className="text-4xl leading-tight font-bold text-cyan-900 sm:text-5xl">
-							{translator.t('survey.impactMeasurement.title')}
-						</h1>
-						<p className="text-base leading-6 text-cyan-950 sm:text-lg sm:leading-7">
-							{translator.t('survey.impactMeasurement.description')}
-						</p>
-						<div className="flex w-full justify-end">
-							<div className="w-full sm:w-auto">
-								<ImpactMeasurementFilterSection lang={lang} searchParams={normalizedSearchParams} />
-							</div>
+			{variant === 'standalone' ? (
+				<div className="space-y-5">
+					<h1 className="text-4xl leading-tight font-bold text-cyan-900 sm:text-5xl">
+						{translator.t('survey.impactMeasurement.title')}
+					</h1>
+					<p className="text-base leading-6 text-cyan-950 sm:text-lg sm:leading-7">
+						{translator.t('survey.impactMeasurement.description')}
+					</p>
+					<div className="flex w-full justify-end">
+						<div className="w-full sm:w-auto">
+							<ImpactMeasurementFilterSection lang={lang} searchParams={normalizedSearchParams} />
 						</div>
-					</>
-				) : null}
+					</div>
 
-				<Suspense key={`summary-${suspenseKey}`} fallback={<ImpactMeasurementStudyDetailsSkeleton />}>
-					<ImpactMeasurementStudyDetails lang={lang} searchParams={normalizedSearchParams} />
-				</Suspense>
-			</div>
+					<Suspense key={`summary-${suspenseKey}`} fallback={<ImpactMeasurementStudyDetailsSkeleton />}>
+						<ImpactMeasurementStudyDetails lang={lang} searchParams={normalizedSearchParams} />
+					</Suspense>
+				</div>
+			) : null}
 			<Suspense key={suspenseKey} fallback={<ImpactMeasurementResultsSkeleton />}>
 				<ImpactMeasurementResults lang={lang} searchParams={normalizedSearchParams} />
 			</Suspense>

--- a/website/src/components/storyblok/focus/focus-detail.tsx
+++ b/website/src/components/storyblok/focus/focus-detail.tsx
@@ -3,9 +3,11 @@ import { buildBreadcrumbLinks } from '@/components/breadcrumb/build-breadcrumb-l
 import { StoryblokMarkdown } from '@/components/storyblok-markdown';
 import type { Study } from '@/generated/storyblok/types/109655/storyblok-components';
 import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
+import { services } from '@/lib/services/services';
 import type { ISbStoryData } from '@storyblok/js';
 import type { FocusStory } from './focus.types';
-import { getFocusText, getFocusTitle } from './focus.utils';
+import { getFocusSlug, getFocusText, getFocusTitle } from './focus.utils';
+import { ImpactMeasurementPreviewWrapper } from './impact-measurement-preview-wrapper';
 import { StudyCard } from './study-card';
 
 type Props = {
@@ -24,21 +26,45 @@ const isStudyStory = (study: StudyStory | string): study is StudyStory => {
 	return study.content.component?.toLowerCase() === 'study';
 };
 
+const getImpactMeasurementFocusId = async (focus: FocusStory) => {
+	const focusSlugs = new Set(
+		[focus.content.portalSlug, getFocusSlug(focus), focus.slug]
+			.map((slug) => slug?.trim())
+			.filter((slug): slug is string => Boolean(slug)),
+	);
+
+	if (focusSlugs.size === 0) {
+		return '';
+	}
+
+	const filterOptionsResult = await services.surveyImpact.getImpactFilterOptions();
+	if (!filterOptionsResult.success) {
+		return '';
+	}
+
+	return filterOptionsResult.data.focuses.find((option) => focusSlugs.has(option.label.trim()))?.value ?? '';
+};
+
 export const FocusDetail = async ({ focus, lang, region }: Props) => {
 	const title = getFocusTitle(focus.content);
 	const text = getFocusText(focus.content);
-	const { studiesTitle, studies } = focus.content;
+	const { impactMeasurementTeaserButtonLabel, impactMeasurementTeaserText, impactMeasurementTitle, studiesTitle, studies } =
+		focus.content;
 	const studyStories = studies?.filter(isStudyStory) ?? [];
 	const hasStudiesSection = Boolean(studiesTitle) || studyStories.length > 0;
-	const breadcrumbLinks = await buildBreadcrumbLinks({
-		fullSlug: focus.full_slug,
-		currentLabel: title,
-		lang,
-		region,
-	});
+	const hasImpactMeasurementSection = Boolean(impactMeasurementTitle);
+	const [breadcrumbLinks, impactMeasurementFocusId] = await Promise.all([
+		buildBreadcrumbLinks({
+			fullSlug: focus.full_slug,
+			currentLabel: title,
+			lang,
+			region,
+		}),
+		hasImpactMeasurementSection ? getImpactMeasurementFocusId(focus) : '',
+	]);
 
 	return (
-		<div className="w-site-width max-w-content mx-auto flex flex-col gap-8 px-6 py-8">
+		<div className="w-site-width max-w-content mx-auto flex flex-col gap-8 px-6 py-8 pb-16">
 			<Breadcrumb links={breadcrumbLinks} className="py-0" />
 			<div className="space-y-5">
 				{title && <h1 className="text-4xl leading-tight font-bold text-cyan-900 sm:text-5xl">{title}</h1>}
@@ -58,6 +84,25 @@ export const FocusDetail = async ({ focus, lang, region }: Props) => {
 								<StudyCard key={study.uuid} study={study} lang={lang} region={region} />
 							))}
 						</div>
+					)}
+				</section>
+			)}
+
+			{hasImpactMeasurementSection && (
+				<section className="flex flex-col gap-10">
+					{impactMeasurementTitle && (
+						<h2 className="text-5xl leading-tight font-normal text-cyan-900">
+							<StoryblokMarkdown>{impactMeasurementTitle}</StoryblokMarkdown>
+						</h2>
+					)}
+					{impactMeasurementFocusId && (
+						<ImpactMeasurementPreviewWrapper
+							focusId={impactMeasurementFocusId}
+							lang={lang}
+							region={region}
+							teaserText={impactMeasurementTeaserText}
+							teaserButtonLabel={impactMeasurementTeaserButtonLabel}
+						/>
 					)}
 				</section>
 			)}

--- a/website/src/components/storyblok/focus/impact-measurement-preview-wrapper.tsx
+++ b/website/src/components/storyblok/focus/impact-measurement-preview-wrapper.tsx
@@ -1,0 +1,41 @@
+import { ImpactMeasurementView } from '@/app/[lang]/[region]/new-website/programs/impact-measurement/view';
+import { Button } from '@/components/button';
+import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
+import Link from 'next/link';
+
+type Props = {
+	focusId: string;
+	lang: WebsiteLanguage;
+	region: WebsiteRegion;
+	teaserButtonLabel?: string;
+	teaserText?: string;
+};
+
+export const ImpactMeasurementPreviewWrapper = ({ focusId, lang, region, teaserButtonLabel, teaserText }: Props) => {
+	const trimmedTeaserText = teaserText?.trim();
+	const trimmedTeaserButtonLabel = teaserButtonLabel?.trim();
+	const hasTeaser = [trimmedTeaserText, trimmedTeaserButtonLabel].some(Boolean);
+
+	return (
+		<div className={hasTeaser ? 'relative pb-24 sm:pb-16' : undefined}>
+			<div className="relative h-96 overflow-hidden rounded-3xl bg-white shadow-[0_4px_6px_-4px_rgba(0,0,0,0.10),0_0_20px_0_rgba(0,0,0,0.05)] after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-1/2 after:bg-white after:mask-[linear-gradient(to_bottom,transparent_0%,black_100%)] after:backdrop-blur-[100px] after:content-[''] after:[-webkit-mask-image:linear-gradient(to_bottom,transparent_0%,black_100%)]">
+				<ImpactMeasurementView lang={lang} searchParams={{ focus: focusId }} variant="embedded" />
+			</div>
+
+			{hasTeaser && (
+				<div className="absolute inset-x-4 bottom-24 mx-auto flex max-w-3xl translate-y-1/2 flex-col items-stretch gap-4 rounded-[160px] bg-white px-6 py-6 shadow-[0_4px_100px_0_#dfebf2] sm:bottom-16 sm:flex-row sm:items-center sm:justify-between sm:gap-16 sm:px-12 sm:py-10">
+					{trimmedTeaserText && (
+						<p className="text-foreground min-w-0 text-center text-xl font-bold sm:text-left">{trimmedTeaserText}</p>
+					)}
+					{trimmedTeaserButtonLabel && (
+						<Button variant="outline" size="lg" className="w-full shrink-0 sm:w-auto" asChild>
+							<Link href={{ pathname: `/${lang}/${region}/impact-measurement`, query: { focus: focusId } }}>
+								{trimmedTeaserButtonLabel}
+							</Link>
+						</Button>
+					)}
+				</div>
+			)}
+		</div>
+	);
+};

--- a/website/src/components/storyblok/focus/impact-measurement-preview-wrapper.tsx
+++ b/website/src/components/storyblok/focus/impact-measurement-preview-wrapper.tsx
@@ -19,7 +19,9 @@ export const ImpactMeasurementPreviewWrapper = ({ focusId, lang, region, teaserB
 	return (
 		<div className={hasTeaser ? 'relative pb-24 sm:pb-16' : undefined}>
 			<div className="relative h-96 overflow-hidden rounded-3xl bg-white shadow-[0_4px_6px_-4px_rgba(0,0,0,0.10),0_0_20px_0_rgba(0,0,0,0.05)] after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-1/2 after:bg-white after:mask-[linear-gradient(to_bottom,transparent_0%,black_100%)] after:backdrop-blur-[100px] after:content-[''] after:[-webkit-mask-image:linear-gradient(to_bottom,transparent_0%,black_100%)]">
-				<ImpactMeasurementView lang={lang} searchParams={{ focus: focusId }} variant="embedded" />
+				<div className="-mx-4 -my-6">
+					<ImpactMeasurementView lang={lang} searchParams={{ focus: focusId }} showStudyDetails={false} variant="embedded" />
+				</div>
 			</div>
 
 			{hasTeaser && (

--- a/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
+++ b/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
@@ -163,6 +163,9 @@ export interface Focus {
   text?: string;
   studiesTitle?: string;
   studies?: (ISbStoryData<Study> | string)[];
+  impactMeasurementTitle?: string;
+  impactMeasurementTeaserText?: string;
+  impactMeasurementTeaserButtonLabel?: string;
   component: "Focus";
   _uid: string;
   [k: string]: unknown;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an impact measurement preview section on focus pages that conditionally shows a teaser and CTA linking to full reports.
  * Introduced an embedded preview component that loads a focused impact-measurement view and only shows study details when enabled.
  * Focus pages now compute and fetch a focus identifier to drive the preview display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->