### PR TITLE
[new-website]: Remove Teaser text from Journal page (#2062)

### DIFF
--- a/website/src/components/storyblok/journal/article-detail-body.tsx
+++ b/website/src/components/storyblok/journal/article-detail-body.tsx
@@ -32,10 +32,6 @@ export const ArticleDetailBody = ({ story, slug, lang, region, translator }: Pro
 				languageName={translator.t('language-name.' + article.originalLanguage)}
 			/>
 
-			{article.leadText && (
-				<p className="text-foreground text-xl leading-relaxed font-medium md:text-2xl">{article.leadText}</p>
-			)}
-
 			<div className="prose prose-neutral text-foreground prose-headings:font-semibold prose-a:text-primary max-w-none">
 				<ArticleRichText document={article.content as StoryblokRichtext} lang={lang} />
 			</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed lead text display from article detail pages, streamlining the layout to flow directly from the language selector to the main article body, footnotes, tags, and author information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->