### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,11 +266,27 @@ pg_restore   --clean --if-exists   --no-owner   -d "postgresql://staging-website
 # 🧩 Storyblok Development
 
 1. Read the Storyblok docs → https://www.storyblok.com/docs
-2. Set env vars in `website/.env.local`:
-   - `STORYBLOK_PREVIEW_TOKEN`
-   - `STORYBLOK_PREVIEW_SECRET`
-   - `STORYBLOK_WEBHOOK_SECRET` (must match the **Secret key** on the
-     Storyblok webhook; used to verify the `webhook-signature` header)
+2. Set the public Content Delivery API token in `website/.env.local`:
+
+```
+STORYBLOK_PREVIEW_TOKEN="<public-content-delivery-api-token>"
+```
+
+Despite the name, `STORYBLOK_PREVIEW_TOKEN` is used by the website to load
+Storyblok content through the Content Delivery API. A public token is enough
+for external contributors working on frontend/UI changes against published
+content.
+
+Maintainers who need Storyblok preview, webhooks, or schema/type generation
+may also need:
+
+- `STORYBLOK_PREVIEW_SECRET`
+- `STORYBLOK_WEBHOOK_SECRET` (must match the **Secret key** on the Storyblok
+  webhook; used to verify the `webhook-signature` header)
+- `STORYBLOK_PERSONAL_ACCESS_TOKEN`
+- `STORYBLOK_SPACE_ID`
+
+
 3. Optional: start local dev with HTTPS for live preview
 
 ```

--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ Storyblok content through the Content Delivery API. A public token is enough
 for external contributors working on frontend/UI changes against published
 content.
 
+If you are an external contributor and need a token, contact
+`support@socialincome.org`.
+
 Maintainers who need Storyblok preview, webhooks, or schema/type generation
 may also need:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the Storyblok development setup guide to clarify requirements for external contributors
  * Explained that only the public `STORYBLOK_PREVIEW_TOKEN` is required to fetch and work with published Storyblok content via the API
  * Reorganized environment variables to separate essential contributor setup from additional maintainer-specific configuration needs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->