### PR TITLE
feat: add dedicated login page

### DIFF
--- a/website/src/app/[lang]/[region]/login/login-page-content.tsx
+++ b/website/src/app/[lang]/[region]/login/login-page-content.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { MagicLinkLoginForm } from '@/components/login/magic-link-login-form';
+import { useTranslator } from '@/lib/hooks/useTranslator';
+import { WebsiteLanguage } from '@/lib/i18n/utils';
+
+type Props = {
+	lang: WebsiteLanguage;
+};
+
+export const LoginPageContent = ({ lang }: Props) => {
+	const translator = useTranslator(lang, 'website-login');
+
+	return (
+		<div className="flex min-h-[40vh] flex-1 flex-col items-center justify-center px-4">
+			<div className="border-border mx-auto w-full max-w-[400px] rounded-3xl border bg-white px-4 pt-4 pb-6 shadow-[0_2px_4px_rgba(0,0,0,0.05)] sm:px-6 sm:pt-5 sm:pb-7 md:px-9 md:py-9">
+				<h1 className="text-foreground mb-5 text-xl leading-tight font-semibold text-pretty sm:text-2xl sm:leading-none">
+					{translator?.t('title')}
+				</h1>
+				<MagicLinkLoginForm embedded lang={lang} />
+			</div>
+		</div>
+	);
+};

--- a/website/src/app/[lang]/[region]/login/login-page-content.tsx
+++ b/website/src/app/[lang]/[region]/login/login-page-content.tsx
@@ -14,10 +14,8 @@ export const LoginPageContent = ({ lang }: Props) => {
 	return (
 		<div className="flex min-h-[40vh] flex-1 flex-col items-center justify-center px-4">
 			<div className="border-border mx-auto w-full max-w-[400px] rounded-3xl border bg-white px-4 pt-4 pb-6 shadow-[0_2px_4px_rgba(0,0,0,0.05)] sm:px-6 sm:pt-5 sm:pb-7 md:px-9 md:py-9">
-				<h1 className="text-foreground mb-5 text-xl leading-tight font-semibold text-pretty sm:text-2xl sm:leading-none">
-					{translator?.t('title')}
-				</h1>
-				<MagicLinkLoginForm embedded lang={lang} />
+				<h1 className="text-foreground mb-5 text-xl font-semibold">{translator?.t('title')}</h1>
+				<MagicLinkLoginForm lang={lang} />
 			</div>
 		</div>
 	);

--- a/website/src/app/[lang]/[region]/login/login-page-content.tsx
+++ b/website/src/app/[lang]/[region]/login/login-page-content.tsx
@@ -1,20 +1,21 @@
-'use client';
-
 import { MagicLinkLoginForm } from '@/components/login/magic-link-login-form';
-import { useTranslator } from '@/lib/hooks/useTranslator';
+import { Translator } from '@/lib/i18n/translator';
 import { WebsiteLanguage } from '@/lib/i18n/utils';
 
 type Props = {
 	lang: WebsiteLanguage;
 };
 
-export const LoginPageContent = ({ lang }: Props) => {
-	const translator = useTranslator(lang, 'website-login');
+export const LoginPageContent = async ({ lang }: Props) => {
+	const translator = await Translator.getInstance({
+		language: lang,
+		namespaces: ['website-login'],
+	});
 
 	return (
 		<div className="flex min-h-[40vh] flex-1 flex-col items-center justify-center px-4">
 			<div className="border-border mx-auto w-full max-w-[400px] rounded-3xl border bg-white px-4 pt-4 pb-6 shadow-[0_2px_4px_rgba(0,0,0,0.05)] sm:px-6 sm:pt-5 sm:pb-7 md:px-9 md:py-9">
-				<h1 className="text-foreground mb-5 text-xl font-semibold">{translator?.t('title')}</h1>
+				<h1 className="text-foreground mb-5 text-xl font-semibold">{translator.t('title')}</h1>
 				<MagicLinkLoginForm lang={lang} />
 			</div>
 		</div>

--- a/website/src/app/[lang]/[region]/login/page.tsx
+++ b/website/src/app/[lang]/[region]/login/page.tsx
@@ -1,5 +1,16 @@
 import type { DefaultPageProps } from '@/app/[lang]/[region]';
+import { getCurrentSessions } from '@/lib/firebase/current-account';
+import { WebsiteLanguage } from '@/lib/i18n/utils';
+import { getRedirectPathAfterLoginAction } from '@/lib/server-actions/session-actions';
+import { getMetadata } from '@/lib/utils/metadata';
 import { redirect } from 'next/navigation';
+import { LoginPageContent } from './login-page-content';
+
+export const generateMetadata = async ({ params }: DefaultPageProps) => {
+	const { lang } = await params;
+
+	return getMetadata(lang as WebsiteLanguage, 'website-login');
+};
 
 const LoginPage = async ({ params, searchParams }: DefaultPageProps) => {
 	const { lang, region } = await params;
@@ -13,7 +24,15 @@ const LoginPage = async ({ params, searchParams }: DefaultPageProps) => {
 		redirect(`/${lang}/${region}/auth/confirm-login${search}`);
 	}
 
-	redirect(`/${lang}/${region}`);
+	const sessions = await getCurrentSessions();
+	if (sessions.length > 0) {
+		const redirectPathResult = await getRedirectPathAfterLoginAction();
+		if (redirectPathResult.success) {
+			redirect(redirectPathResult.data);
+		}
+	}
+
+	return <LoginPageContent lang={lang as WebsiteLanguage} />;
 };
 
 export default LoginPage;

--- a/website/src/components/app-shells/website/navbar/login-flyout.tsx
+++ b/website/src/components/app-shells/website/navbar/login-flyout.tsx
@@ -2,72 +2,20 @@
 
 import { Button } from '@/components/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/dialog';
-import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/form';
-import { Input } from '@/components/input';
-import { Label } from '@/components/label';
-import { useAuth } from '@/lib/firebase/hooks/useAuth';
+import { MagicLinkLoginForm } from '@/components/login/magic-link-login-form';
 import { useTranslator } from '@/lib/hooks/useTranslator';
 import { WebsiteLanguage } from '@/lib/i18n/utils';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { sendSignInLinkToEmail } from 'firebase/auth';
 import { UserRound } from 'lucide-react';
-import Link from 'next/link';
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { z } from 'zod';
-
-const formSchema = z.object({
-	email: z.string().trim().email('Please enter a valid email address.'),
-});
-
-type FormValues = z.infer<typeof formSchema>;
-
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 type Props = {
 	lang: WebsiteLanguage;
 };
 
 export const LoginFlyout = ({ lang }: Props) => {
-	const { auth } = useAuth();
 	const translator = useTranslator(lang, 'website-login');
 
 	const [open, setOpen] = useState(false);
-	const [status, setStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
-	const [submittedEmail, setSubmittedEmail] = useState('');
-
-	const form = useForm<FormValues>({
-		resolver: zodResolver(formSchema),
-		defaultValues: { email: '' },
-	});
-
-	const handleSend = async ({ email }: FormValues) => {
-		setStatus('sending');
-		setSubmittedEmail(email);
-
-		try {
-			localStorage.setItem('loginEmail', email);
-
-			const actionCodeSettings = {
-				url: `${window.location.origin}/auth/confirm-login`,
-				handleCodeInApp: true,
-			};
-
-			await sendSignInLinkToEmail(auth, email, actionCodeSettings);
-		} catch {
-			// intentionally ignore errors to avoid attacking information disclosure
-		}
-
-		// prevent timing attacks
-		await delay(1200);
-
-		setStatus('sent');
-	};
-
-	const retry = () => {
-		form.reset();
-		setStatus('idle');
-	};
 
 	return (
 		<>
@@ -82,59 +30,7 @@ export const LoginFlyout = ({ lang }: Props) => {
 						<DialogTitle>{translator?.t('flyout.title')}</DialogTitle>
 					</DialogHeader>
 
-					{status === 'idle' && (
-						<Form {...form}>
-							<form onSubmit={form.handleSubmit(handleSend)} className="mt-4 space-y-4">
-								<FormField
-									control={form.control}
-									name="email"
-									render={({ field }) => (
-										<FormItem>
-											<Label>{translator?.t('email')}</Label>
-											<FormControl>
-												<Input type="email" placeholder="you@example.org" {...field} />
-											</FormControl>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-
-								<Button type="submit" className="w-full">
-									{translator?.t('submit-button')}
-								</Button>
-
-								<p className="text-muted-foreground text-center text-xs">{translator?.t('flyout.magic-link-description')}</p>
-							</form>
-						</Form>
-					)}
-
-					{status === 'sending' && <div className="mt-4 text-center text-sm">{translator?.t('flyout.sending')}</div>}
-
-					{status === 'sent' && (
-						<div className="mt-4 space-y-4 text-center">
-							<p className="text-sm">{translator?.t('flyout.sent-message', { context: { email: submittedEmail } })}</p>
-
-							<Button variant="outline" onClick={retry} className="w-full">
-								{translator?.t('flyout.retry')}
-							</Button>
-
-							<p className="text-muted-foreground text-xs">
-								{translator?.t('flyout.support-prefix')}{' '}
-								<a className="underline" href="mailto:support@socialincome.org">
-									support@socialincome.org
-								</a>
-							</p>
-						</div>
-					)}
-
-					<div className="mt-6 border-t pt-4 text-center">
-						<p className="text-sm">
-							{translator?.t('flyout.no-account')}{' '}
-							<Link href="/get-started" className="underline">
-								{translator?.t('flyout.get-started')}
-							</Link>
-						</p>
-					</div>
+					<MagicLinkLoginForm key={open ? 'open' : 'closed'} lang={lang} />
 				</DialogContent>
 			</Dialog>
 		</>

--- a/website/src/components/app-shells/website/navbar/login-flyout.tsx
+++ b/website/src/components/app-shells/website/navbar/login-flyout.tsx
@@ -30,7 +30,9 @@ export const LoginFlyout = ({ lang }: Props) => {
 						<DialogTitle>{translator?.t('flyout.title')}</DialogTitle>
 					</DialogHeader>
 
-					<MagicLinkLoginForm key={open ? 'open' : 'closed'} lang={lang} />
+					<div className="mt-4">
+						<MagicLinkLoginForm key={open ? 'open' : 'closed'} lang={lang} />
+					</div>
 				</DialogContent>
 			</Dialog>
 		</>

--- a/website/src/components/login/magic-link-login-form.tsx
+++ b/website/src/components/login/magic-link-login-form.tsx
@@ -13,11 +13,9 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-const formSchema = z.object({
-	email: z.string().trim().email('Please enter a valid email address.'),
-});
-
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = {
+	email: string;
+};
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -28,6 +26,13 @@ type Props = {
 export const MagicLinkLoginForm = ({ lang }: Props) => {
 	const { auth } = useAuth();
 	const translator = useTranslator(lang, 'website-login');
+
+	const formSchema = z.object({
+		email: z
+			.string()
+			.trim()
+			.email(translator?.t('error.invalid-email') ?? 'Invalid email address'),
+	});
 
 	const [status, setStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
 	const [submittedEmail, setSubmittedEmail] = useState('');

--- a/website/src/components/login/magic-link-login-form.tsx
+++ b/website/src/components/login/magic-link-login-form.tsx
@@ -10,7 +10,6 @@ import { WebsiteLanguage } from '@/lib/i18n/utils';
 import { cn } from '@/lib/utils/cn';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { sendSignInLinkToEmail } from 'firebase/auth';
-import Link from 'next/link';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -116,15 +115,6 @@ export const MagicLinkLoginForm = ({ lang, embedded = false }: Props) => {
 					</p>
 				</div>
 			)}
-
-			<div className="mt-6 border-t pt-4 text-center">
-				<p className="text-sm">
-					{translator?.t('flyout.no-account')}{' '}
-					<Link href="/get-started" className="underline">
-						{translator?.t('flyout.get-started')}
-					</Link>
-				</p>
-			</div>
 		</>
 	);
 };

--- a/website/src/components/login/magic-link-login-form.tsx
+++ b/website/src/components/login/magic-link-login-form.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { Button } from '@/components/button';
+import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/form';
+import { Input } from '@/components/input';
+import { Label } from '@/components/label';
+import { useAuth } from '@/lib/firebase/hooks/useAuth';
+import { useTranslator } from '@/lib/hooks/useTranslator';
+import { WebsiteLanguage } from '@/lib/i18n/utils';
+import { cn } from '@/lib/utils/cn';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { sendSignInLinkToEmail } from 'firebase/auth';
+import Link from 'next/link';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const formSchema = z.object({
+	email: z.string().trim().email('Please enter a valid email address.'),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+type Props = {
+	lang: WebsiteLanguage;
+	/** When true, omits top margin (title is rendered in the parent card, e.g. login page). */
+	embedded?: boolean;
+};
+
+export const MagicLinkLoginForm = ({ lang, embedded = false }: Props) => {
+	const { auth } = useAuth();
+	const translator = useTranslator(lang, 'website-login');
+
+	const [status, setStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
+	const [submittedEmail, setSubmittedEmail] = useState('');
+
+	const form = useForm<FormValues>({
+		resolver: zodResolver(formSchema),
+		defaultValues: { email: '' },
+	});
+
+	const handleSend = async ({ email }: FormValues) => {
+		setStatus('sending');
+		setSubmittedEmail(email);
+
+		try {
+			localStorage.setItem('loginEmail', email);
+
+			const actionCodeSettings = {
+				url: `${window.location.origin}/auth/confirm-login`,
+				handleCodeInApp: true,
+			};
+
+			await sendSignInLinkToEmail(auth, email, actionCodeSettings);
+		} catch {
+			// Intentionally ignore errors to avoid account enumeration.
+		}
+
+		await delay(1200);
+
+		setStatus('sent');
+	};
+
+	const retry = () => {
+		form.reset();
+		setStatus('idle');
+	};
+
+	return (
+		<>
+			{status === 'idle' && (
+				<Form {...form}>
+					<form onSubmit={form.handleSubmit(handleSend)} className={cn(!embedded && 'mt-4', 'space-y-4')}>
+						<FormField
+							control={form.control}
+							name="email"
+							render={({ field }) => (
+								<FormItem>
+									<Label>{translator?.t('email')}</Label>
+									<FormControl>
+										<Input type="email" placeholder="you@example.org" {...field} />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+
+						<Button type="submit" className="w-full">
+							{translator?.t('submit-button')}
+						</Button>
+
+						<p className="text-muted-foreground text-center text-xs">{translator?.t('flyout.magic-link-description')}</p>
+					</form>
+				</Form>
+			)}
+
+			{status === 'sending' && (
+				<div className={cn(!embedded && 'mt-4', 'text-center text-sm')}>{translator?.t('flyout.sending')}</div>
+			)}
+
+			{status === 'sent' && (
+				<div className={cn(!embedded && 'mt-4', 'space-y-4 text-center')}>
+					<p className="text-sm">{translator?.t('flyout.sent-message', { context: { email: submittedEmail } })}</p>
+
+					<Button variant="outline" onClick={retry} className="w-full">
+						{translator?.t('flyout.retry')}
+					</Button>
+
+					<p className="text-muted-foreground text-xs">
+						{translator?.t('flyout.support-prefix')}{' '}
+						<a className="underline" href="mailto:support@socialincome.org">
+							support@socialincome.org
+						</a>
+					</p>
+				</div>
+			)}
+
+			<div className="mt-6 border-t pt-4 text-center">
+				<p className="text-sm">
+					{translator?.t('flyout.no-account')}{' '}
+					<Link href="/get-started" className="underline">
+						{translator?.t('flyout.get-started')}
+					</Link>
+				</p>
+			</div>
+		</>
+	);
+};

--- a/website/src/components/login/magic-link-login-form.tsx
+++ b/website/src/components/login/magic-link-login-form.tsx
@@ -7,7 +7,6 @@ import { Label } from '@/components/label';
 import { useAuth } from '@/lib/firebase/hooks/useAuth';
 import { useTranslator } from '@/lib/hooks/useTranslator';
 import { WebsiteLanguage } from '@/lib/i18n/utils';
-import { cn } from '@/lib/utils/cn';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { sendSignInLinkToEmail } from 'firebase/auth';
 import { useState } from 'react';
@@ -24,11 +23,9 @@ const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 type Props = {
 	lang: WebsiteLanguage;
-	/** When true, omits top margin (title is rendered in the parent card, e.g. login page). */
-	embedded?: boolean;
 };
 
-export const MagicLinkLoginForm = ({ lang, embedded = false }: Props) => {
+export const MagicLinkLoginForm = ({ lang }: Props) => {
 	const { auth } = useAuth();
 	const translator = useTranslator(lang, 'website-login');
 
@@ -71,7 +68,7 @@ export const MagicLinkLoginForm = ({ lang, embedded = false }: Props) => {
 		<>
 			{status === 'idle' && (
 				<Form {...form}>
-					<form onSubmit={form.handleSubmit(handleSend)} className={cn(!embedded && 'mt-4', 'space-y-4')}>
+					<form onSubmit={form.handleSubmit(handleSend)} className="space-y-4">
 						<FormField
 							control={form.control}
 							name="email"
@@ -95,12 +92,10 @@ export const MagicLinkLoginForm = ({ lang, embedded = false }: Props) => {
 				</Form>
 			)}
 
-			{status === 'sending' && (
-				<div className={cn(!embedded && 'mt-4', 'text-center text-sm')}>{translator?.t('flyout.sending')}</div>
-			)}
+			{status === 'sending' && <div className="text-center text-sm">{translator?.t('flyout.sending')}</div>}
 
 			{status === 'sent' && (
-				<div className={cn(!embedded && 'mt-4', 'space-y-4 text-center')}>
+				<div className="space-y-4 text-center">
 					<p className="text-sm">{translator?.t('flyout.sent-message', { context: { email: submittedEmail } })}</p>
 
 					<Button variant="outline" onClick={retry} className="w-full">

--- a/website/src/lib/i18n/locales/de/website-login.json
+++ b/website/src/lib/i18n/locales/de/website-login.json
@@ -21,7 +21,6 @@
 		"sent-message": "Wenn ein Konto für {{ email }} existiert, erhältst du in Kürze einen Anmeldelink.",
 		"retry": "Erneut versuchen",
 		"support-prefix": "Wenn sie nicht ankommt, kontaktiere",
-		"no-account": "Du hast noch kein Konto?",
-		"get-started": "Erfahre, wie du loslegen kannst"
+		"no-account": "Du hast noch kein Konto?"
 	}
 }

--- a/website/src/lib/i18n/locales/en/website-login.json
+++ b/website/src/lib/i18n/locales/en/website-login.json
@@ -21,7 +21,6 @@
 		"sent-message": "If an account exists for {{ email }}, you'll receive a login link shortly.",
 		"retry": "Retry",
 		"support-prefix": "If it doesn't arrive, contact",
-		"no-account": "Don't have an account?",
-		"get-started": "Learn how to get started"
+		"no-account": "Don't have an account?"
 	}
 }

--- a/website/src/lib/i18n/locales/fr/website-login.json
+++ b/website/src/lib/i18n/locales/fr/website-login.json
@@ -21,7 +21,6 @@
 		"sent-message": "Si un compte existe pour {{ email }}, tu recevras bientôt un lien de connexion.",
 		"retry": "Réessayer",
 		"support-prefix": "Si tu ne le reçois pas, contacte",
-		"no-account": "Tu n’as pas de compte ?",
-		"get-started": "Découvre comment commencer"
+		"no-account": "Tu n’as pas de compte ?"
 	}
 }

--- a/website/src/lib/i18n/locales/it/website-login.json
+++ b/website/src/lib/i18n/locales/it/website-login.json
@@ -21,7 +21,6 @@
 		"sent-message": "Se esiste un account per {{ email }}, riceverai a breve un link di accesso.",
 		"retry": "Riprova",
 		"support-prefix": "Se non arriva, contatta",
-		"no-account": "Non hai un account?",
-		"get-started": "Scopri come iniziare"
+		"no-account": "Non hai un account?"
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated magic-link login form with localized email input, “sent” confirmation, retry, and support contact.
* **Refactor**
  * Replaced the login flyout’s inline magic-link flow with the shared magic-link login form.
* **Navigation / Login Behavior**
  * Improved non-email-link login routing: when sessions exist, users are redirected to the computed post-login destination; otherwise the localized login screen is shown.
* **Localization**
  * Removed the “get-started” login message from English, German, French, and Italian locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->