### PR TITLE
make text width configurable

### DIFF
--- a/website/src/components/content-blocks/text.tsx
+++ b/website/src/components/content-blocks/text.tsx
@@ -7,14 +7,31 @@ type Props = {
 	blok: Text;
 };
 
+const defaultWidthRatio = 'twoThirds';
+
+const widthClassesByRatio = {
+	'': 'sm:w-2/3',
+	full: '',
+	fourFifths: 'sm:w-4/5',
+	twoThirds: 'sm:w-2/3',
+	half: 'sm:w-1/2',
+	third: 'sm:w-1/3',
+};
+
 export const TextBlock = ({ blok }: Props) => {
-	if (!blok.content) {
+	const { content, widthRatio } = blok;
+
+	if (!content) {
 		return null;
 	}
 
+	const widthClass = widthClassesByRatio[widthRatio ?? defaultWidthRatio];
+
 	return (
 		<BlockWrapper className="text-foreground text-lg" {...storyblokEditable(blok as SbBlokData)}>
-			<RichTextRenderer richTextDocument={blok.content} />
+			<div className={widthClass}>
+				<RichTextRenderer richTextDocument={content} />
+			</div>
 		</BlockWrapper>
 	);
 };

--- a/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
+++ b/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
@@ -500,6 +500,7 @@ export interface TestimonialCarousel {
 
 export interface Text {
   content?: StoryblokRichtext;
+  widthRatio?: "" | "full" | "fourFifths" | "twoThirds" | "half" | "third";
   component: "text";
   _uid: string;
   [k: string]: unknown;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text content blocks can now be displayed at different widths, with support for several preset layout options.
  * A default width is applied when no custom width is set, improving consistency across pages.

* **Bug Fixes**
  * Text blocks now render only when content is available, avoiding empty output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->