### PR TITLE
feat: split modal cards and explainer video

### DIFF
--- a/website/src/components/content-blocks/explainer-video-header.tsx
+++ b/website/src/components/content-blocks/explainer-video-header.tsx
@@ -1,0 +1,65 @@
+import { BlockWrapper } from '@/components/block-wrapper';
+import { ExplainerVideoTrigger } from '@/components/explainer-video/explainer-video-trigger';
+import { SectionHeading } from '@/components/section-heading';
+import { StoryblokMarkdown } from '@/components/storyblok-markdown';
+import type { ExplainerVideoHeader } from '@/generated/storyblok/types/109655/storyblok-components';
+import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
+import { resolveStoryblokLink } from '@/lib/services/storyblok/storyblok.utils';
+import { VimeoVideoMatchAndExtract } from '@/lib/utils/UrlVideoParser';
+import { cn } from '@/lib/utils/cn';
+import { storyblokEditable, type SbBlokData } from '@storyblok/react';
+
+type Props = {
+	blok: ExplainerVideoHeader;
+	lang: WebsiteLanguage;
+	region: WebsiteRegion;
+};
+
+const vimeoMatcher = new VimeoVideoMatchAndExtract();
+
+export const ExplainerVideoHeaderBlock = ({ blok, lang, region }: Props) => {
+	const {
+		disableMarginBottom,
+		disableMarginTop,
+		explainerVideoThumbnail,
+		heading,
+		labelForExplainerVideo,
+		linkToExplainerVideo,
+	} = blok;
+	const headingText = heading?.trim();
+	const explainerVideoLabel = labelForExplainerVideo?.trim();
+	const resolvedExplainerVideoUrl = linkToExplainerVideo ? resolveStoryblokLink(linkToExplainerVideo, lang, region) : null;
+	const explainerVideoEmbedUrl = resolvedExplainerVideoUrl ? vimeoMatcher.parseUrl(resolvedExplainerVideoUrl) : null;
+	const hasExplainerVideo = Boolean(explainerVideoLabel && explainerVideoEmbedUrl);
+	const explainerVideoThumbnailSrc = explainerVideoThumbnail?.filename;
+
+	if (!headingText && !hasExplainerVideo) {
+		return null;
+	}
+
+	return (
+		<BlockWrapper
+			className={cn(disableMarginTop && 'mt-0 md:mt-0 lg:mt-0', disableMarginBottom && 'mb-0 md:mb-0 lg:mb-0')}
+			{...storyblokEditable(blok as SbBlokData)}
+		>
+			<div className="flex flex-col items-start justify-between gap-4 md:flex-row">
+				{headingText && (
+					<SectionHeading as="h1" align="left" className="mb-0 whitespace-pre-line md:mb-0">
+						<StoryblokMarkdown>{headingText}</StoryblokMarkdown>
+					</SectionHeading>
+				)}
+				{explainerVideoLabel && explainerVideoEmbedUrl && (
+					<ExplainerVideoTrigger
+						layout="stacked"
+						label={explainerVideoLabel}
+						embedUrl={explainerVideoEmbedUrl}
+						thumbnailSrc={explainerVideoThumbnailSrc ?? undefined}
+						thumbnailAlt={explainerVideoThumbnail?.alt ?? undefined}
+						dialogTitle={explainerVideoLabel}
+						className="self-center"
+					/>
+				)}
+			</div>
+		</BlockWrapper>
+	);
+};

--- a/website/src/components/content-blocks/explainer-video-header.tsx
+++ b/website/src/components/content-blocks/explainer-video-header.tsx
@@ -6,7 +6,6 @@ import type { ExplainerVideoHeader } from '@/generated/storyblok/types/109655/st
 import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
 import { resolveStoryblokLink } from '@/lib/services/storyblok/storyblok.utils';
 import { VimeoVideoMatchAndExtract } from '@/lib/utils/UrlVideoParser';
-import { cn } from '@/lib/utils/cn';
 import { storyblokEditable, type SbBlokData } from '@storyblok/react';
 
 type Props = {
@@ -39,7 +38,8 @@ export const ExplainerVideoHeaderBlock = ({ blok, lang, region }: Props) => {
 
 	return (
 		<BlockWrapper
-			className={cn(disableMarginTop && 'mt-0 md:mt-0 lg:mt-0', disableMarginBottom && 'mb-0 md:mb-0 lg:mb-0')}
+			disableMarginBottom={disableMarginBottom}
+			disableMarginTop={disableMarginTop}
 			{...storyblokEditable(blok as SbBlokData)}
 		>
 			<div className="flex flex-col items-start justify-between gap-4 md:flex-row">

--- a/website/src/components/content-blocks/modal-cards.tsx
+++ b/website/src/components/content-blocks/modal-cards.tsx
@@ -5,7 +5,6 @@ import { Dialog, DialogContent, DialogTitle } from '@/components/dialog';
 import { StoryblokMarkdown } from '@/components/storyblok-markdown';
 import { RichTextRenderer } from '@/components/storyblok/rich-text-renderer';
 import { ModalCards } from '@/generated/storyblok/types/109655/storyblok-components';
-import { cn } from '@/lib/utils/cn';
 import { storyblokEditable, type SbBlokData } from '@storyblok/react';
 import { PlusIcon } from 'lucide-react';
 import NextImage from 'next/image';
@@ -21,7 +20,8 @@ export const ModalCardsBlock = ({ blok }: Props) => {
 
 	return (
 		<BlockWrapper
-			className={cn(disableMarginTop && 'mt-0 md:mt-0 lg:mt-0', disableMarginBottom && 'mb-0 md:mb-0 lg:mb-0')}
+			disableMarginBottom={disableMarginBottom}
+			disableMarginTop={disableMarginTop}
 			{...storyblokEditable(blok as SbBlokData)}
 		>
 			<div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/website/src/components/content-blocks/modal-cards.tsx
+++ b/website/src/components/content-blocks/modal-cards.tsx
@@ -2,14 +2,10 @@
 
 import { BlockWrapper } from '@/components/block-wrapper';
 import { Dialog, DialogContent, DialogTitle } from '@/components/dialog';
-import { ExplainerVideoTrigger } from '@/components/explainer-video/explainer-video-trigger';
-import { SectionHeading } from '@/components/section-heading';
 import { StoryblokMarkdown } from '@/components/storyblok-markdown';
 import { RichTextRenderer } from '@/components/storyblok/rich-text-renderer';
 import { ModalCards } from '@/generated/storyblok/types/109655/storyblok-components';
-import { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
-import { resolveStoryblokLink } from '@/lib/services/storyblok/storyblok.utils';
-import { VimeoVideoMatchAndExtract } from '@/lib/utils/UrlVideoParser';
+import { cn } from '@/lib/utils/cn';
 import { storyblokEditable, type SbBlokData } from '@storyblok/react';
 import { PlusIcon } from 'lucide-react';
 import NextImage from 'next/image';
@@ -17,42 +13,17 @@ import { useState } from 'react';
 
 type Props = {
 	blok: ModalCards;
-	lang: WebsiteLanguage;
-	region: WebsiteRegion;
 };
 
-const vimeoMatcher = new VimeoVideoMatchAndExtract();
-
-export const ModalCardsBlock = ({ blok, lang, region }: Props) => {
-	const { heading, cards, explainerVideoThumbnail, labelForExplainerVideo, linkToExplainerVideo } = blok;
+export const ModalCardsBlock = ({ blok }: Props) => {
+	const { cards, disableMarginBottom, disableMarginTop } = blok;
 	const [openCardId, setOpenCardId] = useState<string | null>(null);
-	const explainerVideoLabel = labelForExplainerVideo?.trim();
-	const resolvedExplainerVideoUrl = linkToExplainerVideo ? resolveStoryblokLink(linkToExplainerVideo, lang, region) : null;
-	const explainerVideoEmbedUrl = resolvedExplainerVideoUrl ? vimeoMatcher.parseUrl(resolvedExplainerVideoUrl) : null;
-	const hasExplainerVideo = Boolean(explainerVideoLabel && explainerVideoEmbedUrl);
-	const explainerVideoThumbnailSrc = explainerVideoThumbnail?.filename;
 
 	return (
-		<BlockWrapper {...storyblokEditable(blok as SbBlokData)}>
-			<div className="mb-8 flex flex-col items-start justify-between gap-4 md:flex-row lg:mb-14">
-				{heading && (
-					<SectionHeading as="h1" align="left" size="large" className="mb-0 md:mb-0">
-						<StoryblokMarkdown>{heading}</StoryblokMarkdown>
-					</SectionHeading>
-				)}
-				{hasExplainerVideo && (
-					<ExplainerVideoTrigger
-						layout="stacked"
-						label={explainerVideoLabel!}
-						embedUrl={explainerVideoEmbedUrl!}
-						thumbnailSrc={explainerVideoThumbnailSrc ?? undefined}
-						thumbnailAlt={explainerVideoThumbnail?.alt ?? undefined}
-						dialogTitle={explainerVideoLabel}
-						className="self-center"
-					/>
-				)}
-			</div>
-
+		<BlockWrapper
+			className={cn(disableMarginTop && 'mt-0 md:mt-0 lg:mt-0', disableMarginBottom && 'mb-0 md:mb-0 lg:mb-0')}
+			{...storyblokEditable(blok as SbBlokData)}
+		>
 			<div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
 				{cards?.map(({ image, heading, modalContent, _uid }) => {
 					if (!image.filename) {
@@ -78,11 +49,13 @@ export const ModalCardsBlock = ({ blok, lang, region }: Props) => {
 									<PlusIcon className="size-6" />
 								</div>
 								<span className="text-primary-foreground absolute right-5 bottom-5 left-5 text-3xl leading-tight md:right-10 md:bottom-10 md:left-10 md:text-4xl">
-									{heading}
+									<StoryblokMarkdown>{heading}</StoryblokMarkdown>
 								</span>
 							</button>
 							<DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
-								<DialogTitle>{heading}</DialogTitle>
+								<DialogTitle>
+									<StoryblokMarkdown>{heading}</StoryblokMarkdown>
+								</DialogTitle>
 								{modalContent && (
 									<div className="text-foreground text-base">
 										<RichTextRenderer richTextDocument={modalContent} />

--- a/website/src/components/content-types/page.tsx
+++ b/website/src/components/content-types/page.tsx
@@ -1,5 +1,6 @@
 import { DonationsTotalBlockServer } from '@/components/content-blocks/donations-total-server';
 import { DownloadsBlock } from '@/components/content-blocks/downloads';
+import { ExplainerVideoHeaderBlock } from '@/components/content-blocks/explainer-video-header';
 import { FaqSelectionBlock } from '@/components/content-blocks/faq-selection';
 import { HeroVideoBlockServer } from '@/components/content-blocks/hero-video-server';
 import { ImageTextBlock } from '@/components/content-blocks/image-text';
@@ -41,6 +42,8 @@ const renderPageBlock = (
 			return <DonationsTotalBlockServer blok={block} lang={lang} region={region} />;
 		case 'downloads':
 			return <DownloadsBlock blok={block} />;
+		case 'explainerVideoHeader':
+			return <ExplainerVideoHeaderBlock blok={block} lang={lang} region={region} />;
 		case 'faqSelection':
 			return <FaqSelectionBlock blok={block} lang={lang} region={region} />;
 		case 'heroVideo':
@@ -52,7 +55,7 @@ const renderPageBlock = (
 		case 'journalTeasers':
 			return <JournalTeasersBlock blok={block} lang={lang} region={region} />;
 		case 'modalCards':
-			return <ModalCardsBlock blok={block} lang={lang} region={region} />;
+			return <ModalCardsBlock blok={block} />;
 		case 'openSource':
 			return <OpenSourceBlock blok={block} lang={lang} />;
 		case 'partnershipsCarousel':

--- a/website/src/components/storyblok/rich-text/shared-resolvers.tsx
+++ b/website/src/components/storyblok/rich-text/shared-resolvers.tsx
@@ -59,12 +59,12 @@ export const storyblokRichTextMarkResolvers = {
 };
 
 const headingStyles: Record<number, string> = {
-	1: 'text-4xl',
-	2: 'text-3xl',
-	3: 'text-2xl',
-	4: 'text-xl',
-	5: 'text-lg',
-	6: 'text-base',
+	1: 'text-5xl',
+	2: 'text-4xl',
+	3: 'text-3xl',
+	4: 'text-2xl',
+	5: 'text-xl',
+	6: 'text-lg',
 };
 
 export const storyblokRichTextBasicNodeResolvers = {

--- a/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
+++ b/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
@@ -140,6 +140,19 @@ export interface EmbeddedVideo {
   [k: string]: unknown;
 }
 
+export interface ExplainerVideoHeader {
+  heading?: string;
+  explainerVideo?: unknown;
+  labelForExplainerVideo?: string;
+  linkToExplainerVideo?: Exclude<StoryblokMultilink, {linktype?: "email"} | {linktype?: "asset"}>;
+  explainerVideoThumbnail?: StoryblokAsset;
+  disableMarginTop?: boolean;
+  disableMarginBottom?: boolean;
+  component: "explainerVideoHeader";
+  _uid: string;
+  [k: string]: unknown;
+}
+
 export interface Faq {
   question: StoryblokRichtext;
   answer?: StoryblokRichtext;
@@ -296,16 +309,14 @@ export interface ModalCard {
 }
 
 export interface ModalCards {
-  heading?: string;
-  explainerVideo?: unknown;
-  labelForExplainerVideo?: string;
-  linkToExplainerVideo?: Exclude<StoryblokMultilink, {linktype?: "email"} | {linktype?: "asset"}>;
   cards?: ModalCard[];
-  explainerVideoThumbnail?: StoryblokAsset;
+  disableMarginTop?: boolean;
+  disableMarginBottom?: boolean;
   component: "modalCards";
   _uid: string;
   [k: string]: unknown;
 }
+
 
 export interface NewsletterSignup {
   component: "newsletterSignup";
@@ -339,6 +350,7 @@ export interface Page {
     | VideoText
     | Transparency
     | OpenSource
+    | ExplainerVideoHeader
   )[];
   component: "page";
   _uid: string;

--- a/website/src/generated/storyblok/types/storyblok.d.ts
+++ b/website/src/generated/storyblok/types/storyblok.d.ts
@@ -71,7 +71,7 @@ interface StoryblokMultilinkUrl {
     url: string;
     full_slug: string;
 }
-interface StoryblokMultilink {
+interface StoryblokMultilinkBase {
     fieldtype: 'multilink';
     id: string;
     url: string;
@@ -81,10 +81,18 @@ interface StoryblokMultilink {
     rel?: string;
     title?: string;
     prep?: string;
-    linktype: 'story' | 'url' | 'email' | 'asset';
-    story?: StoryblokMultilinkStory | StoryblokMultilinkLink | StoryblokMultilinkUrl;
-    email?: string;
 }
+type StoryblokMultilink = (StoryblokMultilinkBase & {
+    linktype: 'story';
+    story?: StoryblokMultilinkStory | StoryblokMultilinkLink | StoryblokMultilinkUrl;
+}) | (StoryblokMultilinkBase & {
+    linktype: 'url';
+}) | (StoryblokMultilinkBase & {
+    linktype: 'email';
+    email: string;
+}) | (StoryblokMultilinkBase & {
+    linktype: 'asset';
+});
 interface StoryblokTable {
     fieldtype: 'table';
     thead: Array<{

--- a/website/src/generated/storyblok/types/storyblok.d.ts
+++ b/website/src/generated/storyblok/types/storyblok.d.ts
@@ -71,7 +71,7 @@ interface StoryblokMultilinkUrl {
     url: string;
     full_slug: string;
 }
-interface StoryblokMultilinkBase {
+interface StoryblokMultilink {
     fieldtype: 'multilink';
     id: string;
     url: string;
@@ -81,18 +81,10 @@ interface StoryblokMultilinkBase {
     rel?: string;
     title?: string;
     prep?: string;
-}
-type StoryblokMultilink = (StoryblokMultilinkBase & {
-    linktype: 'story';
+    linktype: 'story' | 'url' | 'email' | 'asset';
     story?: StoryblokMultilinkStory | StoryblokMultilinkLink | StoryblokMultilinkUrl;
-}) | (StoryblokMultilinkBase & {
-    linktype: 'url';
-}) | (StoryblokMultilinkBase & {
-    linktype: 'email';
-    email: string;
-}) | (StoryblokMultilinkBase & {
-    linktype: 'asset';
-});
+    email?: string;
+}
 interface StoryblokTable {
     fieldtype: 'table';
     thead: Array<{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explainer video header section to pages, with heading support and an embedded video trigger when available.
* **Bug Fixes**
  * Improved modal card heading rendering so formatted headings display consistently in both the overlay and the dialog title.
* **Style**
  * Refined Storyblok rich-text heading sizes to better match the intended visual hierarchy.
* **Refactor**
  * Simplified the modal cards section interface and forwarding of spacing options into the wrapper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->