### PR TITLE
feat: focus overview page without dsg

### DIFF
--- a/website/src/app/[lang]/[region]/focuses/page.tsx
+++ b/website/src/app/[lang]/[region]/focuses/page.tsx
@@ -9,8 +9,9 @@ import { notFound } from 'next/navigation';
 
 export const revalidate = 900;
 
-export default async function FocusesOverviewRoute({ params }: DefaultPageProps) {
+export default async function FocusesOverviewRoute({ params, searchParams }: DefaultPageProps) {
 	const { lang, region } = await params;
+	const resolvedSearchParams = await searchParams;
 	const overviewResult = await services.storyblok.getStoryWithFallback<ISbStoryData<FocusOverview>>(
 		getFocusesOverviewStoryPath(),
 		lang,
@@ -21,6 +22,11 @@ export default async function FocusesOverviewRoute({ params }: DefaultPageProps)
 	}
 
 	return (
-		<FocusesOverviewPage overview={overviewResult.data} lang={lang as WebsiteLanguage} region={region as WebsiteRegion} />
+		<FocusesOverviewPage
+			overview={overviewResult.data}
+			lang={lang as WebsiteLanguage}
+			region={region as WebsiteRegion}
+			searchParams={resolvedSearchParams}
+		/>
 	);
 }

--- a/website/src/components/storyblok/focus/focus-detail-card.tsx
+++ b/website/src/components/storyblok/focus/focus-detail-card.tsx
@@ -6,7 +6,7 @@ type FocusDetailCardLabels = {
 	recipients: string;
 	programs: string;
 	sdgs: string;
-	candidatesReady: string;
+	candidatesReady?: string;
 };
 
 type FocusDetailCardProps = {
@@ -50,7 +50,7 @@ export const FocusDetailCard = ({
 			href={href}
 			className="border-border flex min-w-0 flex-1 flex-col gap-3 rounded-2xl border bg-white p-6 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-950"
 		>
-			<h2 className="line-clamp-2 min-h-18 min-w-0 font-sans text-3xl leading-9 font-medium break-words text-cyan-950">
+			<h2 className="line-clamp-2 min-h-18 min-w-0 font-sans text-3xl leading-9 font-medium wrap-break-word text-cyan-950">
 				{focusTitle}
 			</h2>
 			<div className="grid grid-cols-3 gap-3">
@@ -59,6 +59,6 @@ export const FocusDetailCard = ({
 				<FocusDetailCardStat value={sdgsValue} label={labels.sdgs} />
 			</div>
 		</NextLink>
-		<AlertSection text={labels.candidatesReady} />
+		{labels.candidatesReady ? <AlertSection text={labels.candidatesReady} /> : null}
 	</div>
 );

--- a/website/src/components/storyblok/focus/focus-detail-card.tsx
+++ b/website/src/components/storyblok/focus/focus-detail-card.tsx
@@ -1,0 +1,64 @@
+import { CircleDot } from 'lucide-react';
+import NextLink from 'next/link';
+import type { ReactNode } from 'react';
+
+type FocusDetailCardLabels = {
+	recipients: string;
+	programs: string;
+	sdgs: string;
+	candidatesReady: string;
+};
+
+type FocusDetailCardProps = {
+	href: string;
+	focusTitle: string;
+	recipientsCount: number;
+	programsCount: number;
+	sdgsValue: ReactNode;
+	labels: FocusDetailCardLabels;
+};
+
+type FocusDetailCardStatProps = {
+	value: ReactNode;
+	label: string;
+};
+
+const FocusDetailCardStat = ({ value, label }: FocusDetailCardStatProps) => (
+	<div className="flex flex-col gap-0">
+		<div className="text-2xl font-semibold text-slate-600">{value}</div>
+		<div className="text-sm font-bold text-slate-600">{label}</div>
+	</div>
+);
+
+const AlertSection = ({ text }: { text: string }) => (
+	<div className="flex items-center gap-2 rounded-b-2xl px-4 py-2">
+		<CircleDot className="size-4 shrink-0 text-emerald-500" aria-hidden />
+		<p className="text-xs font-semibold text-slate-950">{text}</p>
+	</div>
+);
+
+export const FocusDetailCard = ({
+	href,
+	focusTitle,
+	recipientsCount,
+	programsCount,
+	sdgsValue,
+	labels,
+}: FocusDetailCardProps) => (
+	<div className="bg-confirm-foreground flex h-full flex-col rounded-2xl drop-shadow-md">
+		<NextLink
+			href={href}
+			className="border-border flex min-w-0 flex-1 flex-col gap-3 rounded-2xl border bg-white p-6 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-950"
+		>
+			<h2 className="line-clamp-2 min-h-18 min-w-0 font-sans text-3xl leading-9 font-medium break-words text-cyan-950">
+				{focusTitle}
+			</h2>
+			<div className="grid grid-cols-3 gap-3">
+				<FocusDetailCardStat value={recipientsCount} label={labels.recipients} />
+				<FocusDetailCardStat value={programsCount} label={labels.programs} />
+				<FocusDetailCardStat value={sdgsValue} label={labels.sdgs} />
+			</div>
+		</NextLink>
+		<AlertSection text={labels.candidatesReady} />
+	</div>
+);

--- a/website/src/components/storyblok/focus/focus-detail-card.tsx
+++ b/website/src/components/storyblok/focus/focus-detail-card.tsx
@@ -26,7 +26,7 @@ type FocusDetailCardStatProps = {
 const FocusDetailCardStat = ({ value, label }: FocusDetailCardStatProps) => (
 	<div className="flex flex-col gap-0">
 		<div className="text-2xl font-semibold text-slate-600">{value}</div>
-		<div className="text-sm font-bold text-slate-600">{label}</div>
+		<div className="text-sm font-medium text-slate-600">{label}</div>
 	</div>
 );
 

--- a/website/src/components/storyblok/focus/focuses-overview-country-filter.tsx
+++ b/website/src/components/storyblok/focus/focuses-overview-country-filter.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Button } from '@/components/button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/dropdown-menu';
+import { cn } from '@/lib/utils/cn';
+import { ChevronDown } from 'lucide-react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { COUNTRY_QUERY_KEY } from './focuses-overview-query';
+import type { FilterOption } from './focuses-overview.server';
+
+type Props = {
+	allCountriesLabel: string;
+	countryOptions: FilterOption[];
+	selectedCountryIsoCode?: string;
+};
+
+export const FocusesOverviewCountryFilter = ({ allCountriesLabel, countryOptions, selectedCountryIsoCode }: Props) => {
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const selectedOption = countryOptions.find((option) => option.value === selectedCountryIsoCode);
+	const isActive = Boolean(selectedOption);
+	const buttonLabel = selectedOption?.label ?? allCountriesLabel;
+
+	const updateFilter = (value: string | undefined) => {
+		const nextParams = new URLSearchParams(searchParams.toString());
+
+		if (value) {
+			nextParams.set(COUNTRY_QUERY_KEY, value);
+		} else {
+			nextParams.delete(COUNTRY_QUERY_KEY);
+		}
+
+		const nextQuery = nextParams.toString();
+		router.replace(nextQuery.length > 0 ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
+	};
+
+	return (
+		<div className="flex min-h-10 flex-1 flex-wrap items-center gap-2">
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<Button
+						type="button"
+						variant="outline"
+						className={cn(
+							'text-foreground border-border bg-card hover:bg-card h-10 px-4 text-sm font-medium',
+							isActive && 'bg-input hover:bg-input',
+						)}
+					>
+						{buttonLabel}
+						<ChevronDown className="text-foreground size-4 opacity-70" />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="start" className="bg-popover w-56">
+					<DropdownMenuItem onSelect={() => updateFilter(undefined)}>{allCountriesLabel}</DropdownMenuItem>
+					{countryOptions.map((option) => (
+						<DropdownMenuItem key={option.value} onSelect={() => updateFilter(option.value)}>
+							{option.label}
+						</DropdownMenuItem>
+					))}
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+};

--- a/website/src/components/storyblok/focus/focuses-overview-page.tsx
+++ b/website/src/components/storyblok/focus/focuses-overview-page.tsx
@@ -5,15 +5,17 @@ import { FocusesOverview } from '@/components/storyblok/focus/focuses-overview';
 import type { FocusOverview } from '@/generated/storyblok/types/109655/storyblok-components';
 import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
 import { services } from '@/lib/services/services';
+import type { AnySearchParams } from '@/lib/types/page-props';
 import type { ISbStoryData } from '@storyblok/js';
 
 type Props = {
 	overview: ISbStoryData<FocusOverview>;
 	lang: WebsiteLanguage;
 	region: WebsiteRegion;
+	searchParams?: AnySearchParams;
 };
 
-export const FocusesOverviewPage = async ({ overview, lang, region }: Props) => {
+export const FocusesOverviewPage = async ({ overview, lang, region, searchParams }: Props) => {
 	const focusesResult = await services.storyblok.getFocuses(lang);
 	const focuses = (focusesResult.success ? focusesResult.data : []) as FocusStory[];
 	const title = overview.content.title?.trim() ?? overview.name;
@@ -28,7 +30,7 @@ export const FocusesOverviewPage = async ({ overview, lang, region }: Props) => 
 	return (
 		<div className="w-site-width max-w-content mx-auto flex flex-col gap-8 px-6 py-8">
 			<Breadcrumb links={breadcrumbLinks} className="py-0" />
-			<FocusesOverview focuses={focuses} lang={lang} region={region} title={title} text={text} />
+			<FocusesOverview focuses={focuses} lang={lang} region={region} title={title} text={text} searchParams={searchParams} />
 		</div>
 	);
 };

--- a/website/src/components/storyblok/focus/focuses-overview-query.ts
+++ b/website/src/components/storyblok/focus/focuses-overview-query.ts
@@ -1,0 +1,2 @@
+export const COUNTRY_QUERY_KEY = 'country';
+export const SEARCH_QUERY_KEY = 'search';

--- a/website/src/components/storyblok/focus/focuses-overview-search.tsx
+++ b/website/src/components/storyblok/focus/focuses-overview-search.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Input } from '@/components/input';
+import { SearchIcon } from 'lucide-react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { SEARCH_QUERY_KEY } from './focuses-overview-query';
+
+type Props = {
+	defaultValue: string;
+	label: string;
+	placeholder: string;
+};
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export const FocusesOverviewSearch = ({ defaultValue, label, placeholder }: Props) => {
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const currentValue = searchParams.get(SEARCH_QUERY_KEY) ?? defaultValue;
+	const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (searchDebounceRef.current) {
+				clearTimeout(searchDebounceRef.current);
+			}
+		};
+	}, []);
+
+	const updateSearch = (nextValue: string) => {
+		if (searchDebounceRef.current) {
+			clearTimeout(searchDebounceRef.current);
+		}
+
+		searchDebounceRef.current = setTimeout(() => {
+			const nextParams = new URLSearchParams(searchParams.toString());
+			const searchQuery = nextValue.trim();
+
+			if (searchQuery.length > 0) {
+				nextParams.set(SEARCH_QUERY_KEY, searchQuery);
+			} else {
+				nextParams.delete(SEARCH_QUERY_KEY);
+			}
+
+			const nextQuery = nextParams.toString();
+			router.replace(nextQuery.length > 0 ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
+		}, SEARCH_DEBOUNCE_MS);
+	};
+
+	return (
+		<div className="relative w-full sm:w-80">
+			<SearchIcon className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+			<Input
+				type="search"
+				aria-label={label}
+				placeholder={placeholder}
+				defaultValue={currentValue}
+				onChange={(event) => updateSearch(event.target.value)}
+				className="bg-card pl-9"
+			/>
+		</div>
+	);
+};

--- a/website/src/components/storyblok/focus/focuses-overview.server.test.ts
+++ b/website/src/components/storyblok/focus/focuses-overview.server.test.ts
@@ -1,0 +1,78 @@
+import type { PublicFocusStatsBySlugMap } from '@/lib/services/focus/focus.types';
+import type { FocusStory } from './focus.types';
+import {
+	focusMatchesCountryQuery,
+	focusMatchesSearchQuery,
+	getCountryFilterOptions,
+	getCountryQuery,
+	getSearchQuery,
+} from './focuses-overview.server';
+
+const createFocus = ({ slug, portalSlug, title, text }: { slug: string; portalSlug: string; title: string; text: string }) =>
+	({
+		uuid: slug,
+		slug,
+		full_slug: `pages/focuses/${slug}`,
+		content: {
+			component: 'focus',
+			_uid: slug,
+			portalSlug,
+			title,
+			text,
+		},
+	}) as unknown as FocusStory;
+
+const focuses = [
+	createFocus({
+		slug: 'health',
+		portalSlug: 'health',
+		title: 'Healthcare access',
+		text: 'Cash transfers for medical support',
+	}),
+	createFocus({
+		slug: 'education',
+		portalSlug: 'education',
+		title: 'Education',
+		text: 'School access support',
+	}),
+];
+
+const statsBySlug = {
+	health: {
+		programsCount: 2,
+		recipientsInProgramsCount: 7,
+		candidatesCount: 3,
+		countryIsoCodes: ['KE', 'SL'],
+	},
+	education: {
+		programsCount: 1,
+		recipientsInProgramsCount: 5,
+		candidatesCount: 1,
+		countryIsoCodes: ['CH'],
+	},
+} as PublicFocusStatsBySlugMap;
+
+describe('focuses overview server helpers', () => {
+	it('reads search and country query params', () => {
+		expect(getSearchQuery({ search: ' health ' })).toBe('health');
+		expect(getCountryQuery({ country: ['KE', 'CH'] })).toBe('KE');
+	});
+
+	it('derives country options from focus stats', () => {
+		const countryOptions = getCountryFilterOptions(focuses, statsBySlug);
+
+		expect(countryOptions.map((option) => option.value).sort()).toEqual(['CH', 'KE', 'SL']);
+	});
+
+	it('filters focuses by assigned program country', () => {
+		const kenyaFocuses = focuses.filter((focus) => focusMatchesCountryQuery(focus, statsBySlug, 'KE'));
+
+		expect(kenyaFocuses.map((focus) => focus.content.portalSlug)).toEqual(['health']);
+	});
+
+	it('searches focus title, slug, portal slug, and text', () => {
+		const searchFilteredFocuses = focuses.filter((focus) => focusMatchesSearchQuery(focus, 'medical health'));
+
+		expect(searchFilteredFocuses.map((focus) => focus.content.portalSlug)).toEqual(['health']);
+	});
+});

--- a/website/src/components/storyblok/focus/focuses-overview.server.ts
+++ b/website/src/components/storyblok/focus/focuses-overview.server.ts
@@ -1,0 +1,71 @@
+import type { PublicFocusStatsBySlugMap } from '@/lib/services/focus/focus.types';
+import { getCountryNameByCode } from '@/lib/types/country';
+import type { AnySearchParams } from '@/lib/types/page-props';
+import type { FocusStory } from './focus.types';
+import { getFocusSlug, getFocusText, getFocusTitle } from './focus.utils';
+import { COUNTRY_QUERY_KEY, SEARCH_QUERY_KEY } from './focuses-overview-query';
+
+export type FilterOption = {
+	value: string;
+	label: string;
+};
+
+const getQueryValue = (searchParams: AnySearchParams | undefined, key: string) => {
+	const value = searchParams?.[key];
+	const firstValue = Array.isArray(value) ? value.at(0) : value;
+
+	return typeof firstValue === 'string' ? firstValue.trim() : '';
+};
+
+export const getSearchQuery = (searchParams?: AnySearchParams) => {
+	return getQueryValue(searchParams, SEARCH_QUERY_KEY);
+};
+
+export const getCountryQuery = (searchParams?: AnySearchParams) => {
+	return getQueryValue(searchParams, COUNTRY_QUERY_KEY);
+};
+
+const normalizeSearchValue = (value: string) => value.toLowerCase();
+
+export const focusMatchesSearchQuery = (focus: FocusStory, searchQuery: string) => {
+	const keywords = [getFocusTitle(focus.content), getFocusSlug(focus), focus.content.portalSlug, getFocusText(focus.content)]
+		.map((value) => normalizeSearchValue(value))
+		.join(' ');
+	const searchTerms = normalizeSearchValue(searchQuery).split(/\s+/);
+
+	return searchTerms.every((term) => keywords.includes(term));
+};
+
+export const focusMatchesCountryQuery = (
+	focus: FocusStory,
+	statsBySlug: PublicFocusStatsBySlugMap,
+	selectedCountryIsoCode: string | undefined,
+) => {
+	if (!selectedCountryIsoCode) {
+		return true;
+	}
+
+	const focusSlug = getFocusSlug(focus);
+
+	return (
+		statsBySlug[focusSlug]?.countryIsoCodes.some((countryIsoCode) => countryIsoCode === selectedCountryIsoCode) ?? false
+	);
+};
+
+export const getCountryFilterOptions = (focuses: FocusStory[], statsBySlug: PublicFocusStatsBySlugMap): FilterOption[] => {
+	const optionsByCountryIsoCode = new Map<string, FilterOption>();
+
+	focuses.forEach((focus) => {
+		const focusSlug = getFocusSlug(focus);
+		const stats = statsBySlug[focusSlug];
+
+		stats?.countryIsoCodes.forEach((countryIsoCode) => {
+			optionsByCountryIsoCode.set(countryIsoCode, {
+				value: countryIsoCode,
+				label: getCountryNameByCode(countryIsoCode),
+			});
+		});
+	});
+
+	return [...optionsByCountryIsoCode.values()].sort((optionA, optionB) => optionA.label.localeCompare(optionB.label));
+};

--- a/website/src/components/storyblok/focus/focuses-overview.tsx
+++ b/website/src/components/storyblok/focus/focuses-overview.tsx
@@ -91,9 +91,12 @@ export const FocusesOverview = async ({ focuses, lang, region, title, text, sear
 										sdgs: translator.t('focuses-page.sdgs'),
 										candidatesReady:
 											stats.candidatesCount > 0
-												? translator.t('focuses-page.candidates-ready-to-enroll', {
-														context: { count: stats.candidatesCount },
-													})
+												? translator.t(
+														stats.candidatesCount === 1
+															? 'focuses-page.candidates-ready-to-enroll_one'
+															: 'focuses-page.candidates-ready-to-enroll_other',
+														{ context: { count: stats.candidatesCount } },
+													)
 												: undefined,
 									}}
 								/>

--- a/website/src/components/storyblok/focus/focuses-overview.tsx
+++ b/website/src/components/storyblok/focus/focuses-overview.tsx
@@ -1,7 +1,8 @@
 import { CmsHeader } from '@/components/storyblok/shared/cms-header';
 import { Translator } from '@/lib/i18n/translator';
 import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
-import Link from 'next/link';
+import { services } from '@/lib/services/services';
+import { FocusDetailCard } from './focus-detail-card';
 import type { FocusStory } from './focus.types';
 import { getFocusSlug, getFocusTitle } from './focus.utils';
 
@@ -15,6 +16,9 @@ type Props = {
 
 export const FocusesOverview = async ({ focuses, lang, region, title, text }: Props) => {
 	const translator = await Translator.getInstance({ language: lang, namespaces: ['website-common'] });
+	const focusSlugs = focuses.map((focus) => getFocusSlug(focus));
+	const statsResult = await services.read.focus.getPublicFocusStatsBySlugs(focusSlugs);
+	const statsBySlug = statsResult.success ? statsResult.data : {};
 
 	return (
 		<div className="flex w-full flex-col gap-8">
@@ -22,14 +26,33 @@ export const FocusesOverview = async ({ focuses, lang, region, title, text }: Pr
 			{focuses.length === 0 ? (
 				<p className="text-muted-foreground">{translator.t('focuses-page.empty')}</p>
 			) : (
-				<ul>
+				<ul className="grid grid-cols-1 gap-6 md:grid-cols-3">
 					{focuses.map((focus) => {
 						const focusSlug = getFocusSlug(focus);
 						const focusTitle = getFocusTitle(focus.content);
+						const stats = statsBySlug[focusSlug] ?? {
+							programsCount: 0,
+							recipientsInProgramsCount: 0,
+							candidatesCount: 0,
+						};
 
 						return (
-							<li key={focus.uuid}>
-								<Link href={`/${lang}/${region}/focuses/${focusSlug}`}>{focusTitle}</Link>
+							<li key={focus.uuid} className="h-full">
+								<FocusDetailCard
+									href={`/${lang}/${region}/focuses/${focusSlug}`}
+									focusTitle={focusTitle}
+									recipientsCount={stats.recipientsInProgramsCount}
+									programsCount={stats.programsCount}
+									sdgsValue="-"
+									labels={{
+										recipients: translator.t('focuses-page.recipients'),
+										programs: translator.t('focuses-page.programs'),
+										sdgs: translator.t('focuses-page.sdgs'),
+										candidatesReady: translator.t('focuses-page.candidates-ready-to-enroll', {
+											context: { count: stats.candidatesCount },
+										}),
+									}}
+								/>
 							</li>
 						);
 					})}

--- a/website/src/components/storyblok/focus/focuses-overview.tsx
+++ b/website/src/components/storyblok/focus/focuses-overview.tsx
@@ -30,10 +30,12 @@ export const FocusesOverview = async ({ focuses, lang, region, title, text, sear
 	const focusSlugs = focuses.map((focus) => getFocusSlug(focus));
 	const statsResult = await services.read.focus.getPublicFocusStatsBySlugs(focusSlugs);
 	const statsBySlug = statsResult.success ? statsResult.data : {};
+	const hasStatsError = !statsResult.success;
 	const searchQuery = getSearchQuery(searchParams);
 	const countryQuery = getCountryQuery(searchParams);
 	const countryOptions = getCountryFilterOptions(focuses, statsBySlug);
 	const selectedCountryIsoCode = countryOptions.some((option) => option.value === countryQuery) ? countryQuery : undefined;
+	const hasActiveFilters = Boolean(searchQuery || selectedCountryIsoCode);
 	const countryFilteredFocuses = focuses.filter((focus) =>
 		focusMatchesCountryQuery(focus, statsBySlug, selectedCountryIsoCode),
 	);
@@ -58,8 +60,11 @@ export const FocusesOverview = async ({ focuses, lang, region, title, text, sear
 					placeholder={translator.t('focuses-page.search-placeholder')}
 				/>
 			</div>
+			{hasStatsError ? <p className="text-destructive">{translator.t('focuses-page.load-stats-error')}</p> : null}
 			{filteredFocuses.length === 0 ? (
-				<p className="text-muted-foreground">{translator.t('focuses-page.empty')}</p>
+				<p className="text-muted-foreground">
+					{translator.t(hasActiveFilters ? 'focuses-page.no-results' : 'focuses-page.empty')}
+				</p>
 			) : (
 				<ul className="grid grid-cols-1 gap-6 md:grid-cols-3">
 					{filteredFocuses.map((focus) => {
@@ -84,9 +89,12 @@ export const FocusesOverview = async ({ focuses, lang, region, title, text, sear
 										recipients: translator.t('focuses-page.recipients'),
 										programs: translator.t('focuses-page.programs'),
 										sdgs: translator.t('focuses-page.sdgs'),
-										candidatesReady: translator.t('focuses-page.candidates-ready-to-enroll', {
-											context: { count: stats.candidatesCount },
-										}),
+										candidatesReady:
+											stats.candidatesCount > 0
+												? translator.t('focuses-page.candidates-ready-to-enroll', {
+														context: { count: stats.candidatesCount },
+													})
+												: undefined,
 									}}
 								/>
 							</li>

--- a/website/src/components/storyblok/focus/focuses-overview.tsx
+++ b/website/src/components/storyblok/focus/focuses-overview.tsx
@@ -2,9 +2,19 @@ import { CmsHeader } from '@/components/storyblok/shared/cms-header';
 import { Translator } from '@/lib/i18n/translator';
 import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
 import { services } from '@/lib/services/services';
+import type { AnySearchParams } from '@/lib/types/page-props';
 import { FocusDetailCard } from './focus-detail-card';
 import type { FocusStory } from './focus.types';
 import { getFocusSlug, getFocusTitle } from './focus.utils';
+import { FocusesOverviewCountryFilter } from './focuses-overview-country-filter';
+import { FocusesOverviewSearch } from './focuses-overview-search';
+import {
+	focusMatchesCountryQuery,
+	focusMatchesSearchQuery,
+	getCountryFilterOptions,
+	getCountryQuery,
+	getSearchQuery,
+} from './focuses-overview.server';
 
 type Props = {
 	focuses: FocusStory[];
@@ -12,28 +22,54 @@ type Props = {
 	region: WebsiteRegion;
 	title?: string;
 	text?: string;
+	searchParams?: AnySearchParams;
 };
 
-export const FocusesOverview = async ({ focuses, lang, region, title, text }: Props) => {
+export const FocusesOverview = async ({ focuses, lang, region, title, text, searchParams }: Props) => {
 	const translator = await Translator.getInstance({ language: lang, namespaces: ['website-common'] });
 	const focusSlugs = focuses.map((focus) => getFocusSlug(focus));
 	const statsResult = await services.read.focus.getPublicFocusStatsBySlugs(focusSlugs);
 	const statsBySlug = statsResult.success ? statsResult.data : {};
+	const searchQuery = getSearchQuery(searchParams);
+	const countryQuery = getCountryQuery(searchParams);
+	const countryOptions = getCountryFilterOptions(focuses, statsBySlug);
+	const selectedCountryIsoCode = countryOptions.some((option) => option.value === countryQuery) ? countryQuery : undefined;
+	const countryFilteredFocuses = focuses.filter((focus) =>
+		focusMatchesCountryQuery(focus, statsBySlug, selectedCountryIsoCode),
+	);
+	const filteredFocuses = searchQuery
+		? countryFilteredFocuses.filter((focus) => focusMatchesSearchQuery(focus, searchQuery))
+		: countryFilteredFocuses;
 
 	return (
 		<div className="flex w-full flex-col gap-8">
 			<CmsHeader title={title} text={text} />
-			{focuses.length === 0 ? (
+			<div className="flex flex-wrap items-center justify-between gap-4">
+				<FocusesOverviewCountryFilter
+					allCountriesLabel={translator.t('focuses-page.all-countries', {
+						context: { count: countryOptions.length },
+					})}
+					countryOptions={countryOptions}
+					selectedCountryIsoCode={selectedCountryIsoCode}
+				/>
+				<FocusesOverviewSearch
+					defaultValue={searchQuery}
+					label={translator.t('focuses-page.search-label')}
+					placeholder={translator.t('focuses-page.search-placeholder')}
+				/>
+			</div>
+			{filteredFocuses.length === 0 ? (
 				<p className="text-muted-foreground">{translator.t('focuses-page.empty')}</p>
 			) : (
 				<ul className="grid grid-cols-1 gap-6 md:grid-cols-3">
-					{focuses.map((focus) => {
+					{filteredFocuses.map((focus) => {
 						const focusSlug = getFocusSlug(focus);
 						const focusTitle = getFocusTitle(focus.content);
 						const stats = statsBySlug[focusSlug] ?? {
 							programsCount: 0,
 							recipientsInProgramsCount: 0,
 							candidatesCount: 0,
+							countryIsoCodes: [],
 						};
 
 						return (

--- a/website/src/components/storyblok/storyblok-preview-focuses-overview-page.tsx
+++ b/website/src/components/storyblok/storyblok-preview-focuses-overview-page.tsx
@@ -30,6 +30,8 @@ export const StoryblokPreviewFocusesOverviewPage = async ({
 
 			return storyResult.success ? storyResult.data : null;
 		},
-		renderStory: (overview) => <FocusesOverviewPage overview={overview} lang={lang} region={region} />,
+		renderStory: (overview) => (
+			<FocusesOverviewPage overview={overview} lang={lang} region={region} searchParams={searchParams} />
+		),
 	});
 };

--- a/website/src/lib/i18n/locales/de/website-common.json
+++ b/website/src/lib/i18n/locales/de/website-common.json
@@ -78,6 +78,8 @@
 	},
 	"focuses-page": {
 		"empty": "Keine Schwerpunkte gefunden.",
+		"no-results": "Keine Schwerpunkte entsprechen den ausgewählten Filtern.",
+		"load-stats-error": "Statistiken zu den Schwerpunkten konnten nicht geladen werden.",
 		"search-label": "Schwerpunkte suchen",
 		"search-placeholder": "Suchen",
 		"all-countries": "Alle Länder ({{count}})",

--- a/website/src/lib/i18n/locales/de/website-common.json
+++ b/website/src/lib/i18n/locales/de/website-common.json
@@ -94,7 +94,8 @@
 		"recipient-in-program-plural": "Empfänger:innen in einem Programm",
 		"candidate-singular": "Kandidat:in",
 		"candidate-plural": "Kandidat:innen",
-		"candidates-ready-to-enroll": "{{count}} Kandidat:innen bereit für die Einschreibung",
+		"candidates-ready-to-enroll_one": "{{count}} Kandidat:in bereit für die Einschreibung",
+		"candidates-ready-to-enroll_other": "{{count}} Kandidat:innen bereit für die Einschreibung",
 		"about": "Über"
 	},
 	"programs-page": {

--- a/website/src/lib/i18n/locales/de/website-common.json
+++ b/website/src/lib/i18n/locales/de/website-common.json
@@ -78,6 +78,9 @@
 	},
 	"focuses-page": {
 		"empty": "Keine Schwerpunkte gefunden.",
+		"search-label": "Schwerpunkte suchen",
+		"search-placeholder": "Suchen",
+		"all-countries": "Alle Länder ({{count}})",
 		"recipients": "Empfänger:innen",
 		"programs": "Programme",
 		"sdgs": "SDGs",

--- a/website/src/lib/i18n/locales/de/website-common.json
+++ b/website/src/lib/i18n/locales/de/website-common.json
@@ -78,6 +78,9 @@
 	},
 	"focuses-page": {
 		"empty": "Keine Schwerpunkte gefunden.",
+		"recipients": "Empfänger:innen",
+		"programs": "Programme",
+		"sdgs": "SDGs",
 		"program-singular": "Programm",
 		"program-plural": "Programme",
 		"active-program-singular": "aktives Programm",
@@ -86,6 +89,7 @@
 		"recipient-in-program-plural": "Empfänger:innen in einem Programm",
 		"candidate-singular": "Kandidat:in",
 		"candidate-plural": "Kandidat:innen",
+		"candidates-ready-to-enroll": "{{count}} Kandidat:innen bereit für die Einschreibung",
 		"about": "Über"
 	},
 	"programs-page": {

--- a/website/src/lib/i18n/locales/en/website-common.json
+++ b/website/src/lib/i18n/locales/en/website-common.json
@@ -78,6 +78,8 @@
 	},
 	"focuses-page": {
 		"empty": "No focuses found.",
+		"no-results": "No focuses match the selected filters.",
+		"load-stats-error": "Could not load focus statistics.",
 		"search-label": "Search focuses",
 		"search-placeholder": "Search",
 		"all-countries": "All countries ({{count}})",

--- a/website/src/lib/i18n/locales/en/website-common.json
+++ b/website/src/lib/i18n/locales/en/website-common.json
@@ -78,6 +78,9 @@
 	},
 	"focuses-page": {
 		"empty": "No focuses found.",
+		"search-label": "Search focuses",
+		"search-placeholder": "Search",
+		"all-countries": "All countries ({{count}})",
 		"recipients": "Recipients",
 		"programs": "Programs",
 		"sdgs": "SDGs",

--- a/website/src/lib/i18n/locales/en/website-common.json
+++ b/website/src/lib/i18n/locales/en/website-common.json
@@ -78,6 +78,9 @@
 	},
 	"focuses-page": {
 		"empty": "No focuses found.",
+		"recipients": "Recipients",
+		"programs": "Programs",
+		"sdgs": "SDGs",
 		"program-singular": "program",
 		"program-plural": "programs",
 		"active-program-singular": "active program",
@@ -86,6 +89,7 @@
 		"recipient-in-program-plural": "recipients in a program",
 		"candidate-singular": "candidate",
 		"candidate-plural": "candidates",
+		"candidates-ready-to-enroll": "{{count}} candidates ready to enroll",
 		"about": "About"
 	},
 	"programs-page": {

--- a/website/src/lib/i18n/locales/en/website-common.json
+++ b/website/src/lib/i18n/locales/en/website-common.json
@@ -94,7 +94,8 @@
 		"recipient-in-program-plural": "recipients in a program",
 		"candidate-singular": "candidate",
 		"candidate-plural": "candidates",
-		"candidates-ready-to-enroll": "{{count}} candidates ready to enroll",
+		"candidates-ready-to-enroll_one": "{{count}} candidate ready to enroll",
+		"candidates-ready-to-enroll_other": "{{count}} candidates ready to enroll",
 		"about": "About"
 	},
 	"programs-page": {

--- a/website/src/lib/i18n/locales/fr/website-common.json
+++ b/website/src/lib/i18n/locales/fr/website-common.json
@@ -94,7 +94,8 @@
 		"recipient-in-program-plural": "bénéficiaires dans un programme",
 		"candidate-singular": "candidat",
 		"candidate-plural": "candidats",
-		"candidates-ready-to-enroll": "{{count}} candidats prêts à s'inscrire",
+		"candidates-ready-to-enroll_one": "{{count}} candidat prêt à s'inscrire",
+		"candidates-ready-to-enroll_other": "{{count}} candidats prêts à s'inscrire",
 		"about": "À propos de"
 	},
 	"programs-page": {

--- a/website/src/lib/i18n/locales/fr/website-common.json
+++ b/website/src/lib/i18n/locales/fr/website-common.json
@@ -78,6 +78,9 @@
 	},
 	"focuses-page": {
 		"empty": "Aucun axe trouvé.",
+		"recipients": "Bénéficiaires",
+		"programs": "Programmes",
+		"sdgs": "ODD",
 		"program-singular": "programme",
 		"program-plural": "programmes",
 		"active-program-singular": "programme actif",
@@ -86,6 +89,7 @@
 		"recipient-in-program-plural": "bénéficiaires dans un programme",
 		"candidate-singular": "candidat",
 		"candidate-plural": "candidats",
+		"candidates-ready-to-enroll": "{{count}} candidats prêts à s'inscrire",
 		"about": "À propos de"
 	},
 	"programs-page": {

--- a/website/src/lib/i18n/locales/fr/website-common.json
+++ b/website/src/lib/i18n/locales/fr/website-common.json
@@ -78,6 +78,9 @@
 	},
 	"focuses-page": {
 		"empty": "Aucun axe trouvé.",
+		"search-label": "Rechercher des axes",
+		"search-placeholder": "Rechercher",
+		"all-countries": "Tous les pays ({{count}})",
 		"recipients": "Bénéficiaires",
 		"programs": "Programmes",
 		"sdgs": "ODD",

--- a/website/src/lib/i18n/locales/fr/website-common.json
+++ b/website/src/lib/i18n/locales/fr/website-common.json
@@ -78,6 +78,8 @@
 	},
 	"focuses-page": {
 		"empty": "Aucun axe trouvé.",
+		"no-results": "Aucun axe ne correspond aux filtres sélectionnés.",
+		"load-stats-error": "Impossible de charger les statistiques des axes.",
 		"search-label": "Rechercher des axes",
 		"search-placeholder": "Rechercher",
 		"all-countries": "Tous les pays ({{count}})",

--- a/website/src/lib/i18n/locales/it/website-common.json
+++ b/website/src/lib/i18n/locales/it/website-common.json
@@ -78,6 +78,9 @@
 	},
 	"focuses-page": {
 		"empty": "Nessun focus trovato.",
+		"recipients": "Beneficiari",
+		"programs": "Programmi",
+		"sdgs": "SDG",
 		"program-singular": "programma",
 		"program-plural": "programmi",
 		"active-program-singular": "programma attivo",
@@ -86,6 +89,7 @@
 		"recipient-in-program-plural": "beneficiari in un programma",
 		"candidate-singular": "candidato",
 		"candidate-plural": "candidati",
+		"candidates-ready-to-enroll": "{{count}} candidati pronti per l'iscrizione",
 		"about": "Informazioni su"
 	},
 	"programs-page": {

--- a/website/src/lib/i18n/locales/it/website-common.json
+++ b/website/src/lib/i18n/locales/it/website-common.json
@@ -94,7 +94,8 @@
 		"recipient-in-program-plural": "beneficiari in un programma",
 		"candidate-singular": "candidato",
 		"candidate-plural": "candidati",
-		"candidates-ready-to-enroll": "{{count}} candidati pronti per l'iscrizione",
+		"candidates-ready-to-enroll_one": "{{count}} candidato pronto per l'iscrizione",
+		"candidates-ready-to-enroll_other": "{{count}} candidati pronti per l'iscrizione",
 		"about": "Informazioni su"
 	},
 	"programs-page": {

--- a/website/src/lib/i18n/locales/it/website-common.json
+++ b/website/src/lib/i18n/locales/it/website-common.json
@@ -78,6 +78,9 @@
 	},
 	"focuses-page": {
 		"empty": "Nessun focus trovato.",
+		"search-label": "Cerca focus",
+		"search-placeholder": "Cerca",
+		"all-countries": "Tutti i paesi ({{count}})",
 		"recipients": "Beneficiari",
 		"programs": "Programmi",
 		"sdgs": "SDG",

--- a/website/src/lib/i18n/locales/it/website-common.json
+++ b/website/src/lib/i18n/locales/it/website-common.json
@@ -78,6 +78,8 @@
 	},
 	"focuses-page": {
 		"empty": "Nessun focus trovato.",
+		"no-results": "Nessun focus corrisponde ai filtri selezionati.",
+		"load-stats-error": "Impossibile caricare le statistiche dei focus.",
 		"search-label": "Cerca focus",
 		"search-placeholder": "Cerca",
 		"all-countries": "Tutti i paesi ({{count}})",

--- a/website/src/lib/services/focus/focus-read.service.test.ts
+++ b/website/src/lib/services/focus/focus-read.service.test.ts
@@ -1,0 +1,96 @@
+import { type PrismaClient } from '@/generated/prisma/client';
+import type { ServiceResult } from '../core/base.types';
+import { FocusReadService } from './focus-read.service';
+import type { PublicFocusStatsBySlugMap } from './focus.types';
+
+jest.mock('@/generated/prisma/client', () => ({
+	Prisma: {},
+	PrismaClient: class {},
+}));
+
+const expectSuccess = <T>(result: ServiceResult<T>) => {
+	expect(result.success).toBe(true);
+	if (!result.success) {
+		throw new Error(result.error);
+	}
+
+	return result.data;
+};
+
+const createService = ({
+	focuses = [
+		{
+			id: 'focus-health',
+			slug: 'health',
+			programs: [{ programId: 'program-1' }, { programId: 'program-1' }, { programId: 'program-2' }],
+		},
+	],
+	recipientsInProgramsCount = 7,
+	candidatesCount = 3,
+}: {
+	focuses?: { id: string; slug: string; programs: { programId: string }[] }[];
+	recipientsInProgramsCount?: number;
+	candidatesCount?: number;
+} = {}) => {
+	const findMany = jest.fn().mockResolvedValue(focuses);
+	const count = jest.fn().mockResolvedValueOnce(recipientsInProgramsCount).mockResolvedValueOnce(candidatesCount);
+	const db = {
+		focus: { findMany },
+		recipient: { count },
+	};
+	const service = new FocusReadService(db as unknown as PrismaClient, {} as never);
+
+	return { service, findMany, count };
+};
+
+describe('FocusReadService public focus stats', () => {
+	test('getPublicFocusStatsBySlugs returns slug-keyed stats with deduplicated program counts', async () => {
+		const { service, findMany, count } = createService();
+
+		const result = await service.getPublicFocusStatsBySlugs(['health', ' health ', '', 'missing']);
+		const data = expectSuccess<PublicFocusStatsBySlugMap>(result);
+
+		expect(findMany).toHaveBeenCalledWith({
+			where: { slug: { in: ['health', 'missing'] } },
+			select: {
+				id: true,
+				slug: true,
+				programs: { select: { programId: true } },
+			},
+		});
+		expect(data).toEqual({
+			health: {
+				programsCount: 2,
+				recipientsInProgramsCount: 7,
+				candidatesCount: 3,
+			},
+		});
+		expect(count).toHaveBeenCalledWith({
+			where: {
+				programId: { in: ['program-1', 'program-2'] },
+			},
+		});
+		expect(count).toHaveBeenCalledWith({
+			where: {
+				programId: null,
+				localPartner: {
+					focuses: {
+						some: {
+							focusId: 'focus-health',
+						},
+					},
+				},
+			},
+		});
+	});
+
+	test('getPublicFocusStatsBySlugs omits missing database focuses', async () => {
+		const { service, count } = createService({ focuses: [] });
+
+		const result = await service.getPublicFocusStatsBySlugs(['missing']);
+		const data = expectSuccess<PublicFocusStatsBySlugMap>(result);
+
+		expect(data).toEqual({});
+		expect(count).not.toHaveBeenCalled();
+	});
+});

--- a/website/src/lib/services/focus/focus-read.service.test.ts
+++ b/website/src/lib/services/focus/focus-read.service.test.ts
@@ -22,13 +22,17 @@ const createService = ({
 		{
 			id: 'focus-health',
 			slug: 'health',
-			programs: [{ programId: 'program-1' }, { programId: 'program-1' }, { programId: 'program-2' }],
+			programs: [
+				{ programId: 'program-1', program: { country: { isoCode: 'KE' } } },
+				{ programId: 'program-1', program: { country: { isoCode: 'KE' } } },
+				{ programId: 'program-2', program: { country: { isoCode: 'SL' } } },
+			],
 		},
 	],
 	recipientsInProgramsCount = 7,
 	candidatesCount = 3,
 }: {
-	focuses?: { id: string; slug: string; programs: { programId: string }[] }[];
+	focuses?: { id: string; slug: string; programs: { programId: string; program?: { country: { isoCode: string } } }[] }[];
 	recipientsInProgramsCount?: number;
 	candidatesCount?: number;
 } = {}) => {
@@ -55,7 +59,12 @@ describe('FocusReadService public focus stats', () => {
 			select: {
 				id: true,
 				slug: true,
-				programs: { select: { programId: true } },
+				programs: {
+					select: {
+						programId: true,
+						program: { select: { country: { select: { isoCode: true } } } },
+					},
+				},
 			},
 		});
 		expect(data).toEqual({
@@ -63,6 +72,7 @@ describe('FocusReadService public focus stats', () => {
 				programsCount: 2,
 				recipientsInProgramsCount: 7,
 				candidatesCount: 3,
+				countryIsoCodes: ['KE', 'SL'],
 			},
 		});
 		expect(count).toHaveBeenCalledWith({

--- a/website/src/lib/services/focus/focus-read.service.test.ts
+++ b/website/src/lib/services/focus/focus-read.service.test.ts
@@ -22,17 +22,25 @@ const createService = ({
 		{
 			id: 'focus-health',
 			slug: 'health',
+			_count: { programs: 3 },
 			programs: [
 				{ programId: 'program-1', program: { country: { isoCode: 'KE' } } },
 				{ programId: 'program-1', program: { country: { isoCode: 'KE' } } },
 				{ programId: 'program-2', program: { country: { isoCode: 'SL' } } },
 			],
+			localPartners: [{ localPartnerId: 'partner-1' }, { localPartnerId: 'partner-2' }],
 		},
 	],
 	recipientsInProgramsCount = 7,
 	candidatesCount = 3,
 }: {
-	focuses?: { id: string; slug: string; programs: { programId: string; program?: { country: { isoCode: string } } }[] }[];
+	focuses?: {
+		id: string;
+		slug: string;
+		_count: { programs: number };
+		programs: { programId: string; program?: { country: { isoCode: string } } }[];
+		localPartners: { localPartnerId: string }[];
+	}[];
 	recipientsInProgramsCount?: number;
 	candidatesCount?: number;
 } = {}) => {
@@ -59,17 +67,23 @@ describe('FocusReadService public focus stats', () => {
 			select: {
 				id: true,
 				slug: true,
+				_count: {
+					select: {
+						programs: true,
+					},
+				},
 				programs: {
 					select: {
 						programId: true,
 						program: { select: { country: { select: { isoCode: true } } } },
 					},
 				},
+				localPartners: { select: { localPartnerId: true } },
 			},
 		});
 		expect(data).toEqual({
 			health: {
-				programsCount: 2,
+				programsCount: 3,
 				recipientsInProgramsCount: 7,
 				candidatesCount: 3,
 				countryIsoCodes: ['KE', 'SL'],
@@ -78,18 +92,13 @@ describe('FocusReadService public focus stats', () => {
 		expect(count).toHaveBeenCalledWith({
 			where: {
 				programId: { in: ['program-1', 'program-2'] },
+				localPartnerId: { in: ['partner-1', 'partner-2'] },
 			},
 		});
 		expect(count).toHaveBeenCalledWith({
 			where: {
 				programId: null,
-				localPartner: {
-					focuses: {
-						some: {
-							focusId: 'focus-health',
-						},
-					},
-				},
+				localPartnerId: { in: ['partner-1', 'partner-2'] },
 			},
 		});
 	});

--- a/website/src/lib/services/focus/focus-read.service.ts
+++ b/website/src/lib/services/focus/focus-read.service.ts
@@ -18,7 +18,9 @@ import {
 type PublicFocusStatsSource = {
 	id: string;
 	slug?: string;
+	_count: { programs: number };
 	programs: { programId: string; program?: { country: { isoCode: CountryCode } } }[];
+	localPartners: { localPartnerId: string }[];
 };
 
 export class FocusReadService extends BaseService {
@@ -66,6 +68,7 @@ export class FocusReadService extends BaseService {
 		await Promise.all(
 			focuses.map(async (focus) => {
 				const programIds = [...new Set(focus.programs.map(({ programId }) => programId))];
+				const localPartnerIds = [...new Set(focus.localPartners.map(({ localPartnerId }) => localPartnerId))];
 				const countryIsoCodes = [
 					...new Set(
 						focus.programs
@@ -73,30 +76,28 @@ export class FocusReadService extends BaseService {
 							.filter((countryIsoCode): countryIsoCode is CountryCode => Boolean(countryIsoCode)),
 					),
 				];
+				const hasLocalPartners = localPartnerIds.length > 0;
 				const [recipientsInProgramsCount, candidatesCount] = await Promise.all([
-					programIds.length > 0
+					hasLocalPartners && programIds.length > 0
 						? this.db.recipient.count({
 								where: {
 									programId: { in: programIds },
+									localPartnerId: { in: localPartnerIds },
 								},
 							})
 						: 0,
-					this.db.recipient.count({
-						where: {
-							programId: null,
-							localPartner: {
-								focuses: {
-									some: {
-										focusId: focus.id,
-									},
+					hasLocalPartners
+						? this.db.recipient.count({
+								where: {
+									programId: null,
+									localPartnerId: { in: localPartnerIds },
 								},
-							},
-						},
-					}),
+							})
+						: 0,
 				]);
 
 				statsByKey[getKey(focus)] = {
-					programsCount: programIds.length,
+					programsCount: focus._count.programs,
 					recipientsInProgramsCount,
 					candidatesCount,
 					countryIsoCodes,
@@ -227,12 +228,18 @@ export class FocusReadService extends BaseService {
 				select: {
 					id: true,
 					slug: true,
+					_count: {
+						select: {
+							programs: true,
+						},
+					},
 					programs: {
 						select: {
 							programId: true,
 							program: { select: { country: { select: { isoCode: true } } } },
 						},
 					},
+					localPartners: { select: { localPartnerId: true } },
 				},
 			});
 
@@ -255,12 +262,18 @@ export class FocusReadService extends BaseService {
 				where: { id: { in: normalizedFocusIds } },
 				select: {
 					id: true,
+					_count: {
+						select: {
+							programs: true,
+						},
+					},
 					programs: {
 						select: {
 							programId: true,
 							program: { select: { country: { select: { isoCode: true } } } },
 						},
 					},
+					localPartners: { select: { localPartnerId: true } },
 				},
 			});
 

--- a/website/src/lib/services/focus/focus-read.service.ts
+++ b/website/src/lib/services/focus/focus-read.service.ts
@@ -11,8 +11,15 @@ import {
 	FocusTableQuery,
 	FocusTableViewRow,
 	PublicFocusStats,
+	PublicFocusStatsBySlugMap,
 	PublicFocusStatsMap,
 } from './focus.types';
+
+type PublicFocusStatsSource = {
+	id: string;
+	slug?: string;
+	programs: { programId: string }[];
+};
 
 export class FocusReadService extends BaseService {
 	constructor(
@@ -48,6 +55,48 @@ export class FocusReadService extends BaseService {
 		}
 
 		return this.resultOk(true);
+	}
+
+	private async buildPublicFocusStatsMap(
+		focuses: PublicFocusStatsSource[],
+		getKey: (focus: PublicFocusStatsSource) => string,
+	): Promise<PublicFocusStatsMap> {
+		const statsByKey: PublicFocusStatsMap = {};
+
+		await Promise.all(
+			focuses.map(async (focus) => {
+				const programIds = [...new Set(focus.programs.map(({ programId }) => programId))];
+				const [recipientsInProgramsCount, candidatesCount] = await Promise.all([
+					programIds.length > 0
+						? this.db.recipient.count({
+								where: {
+									programId: { in: programIds },
+								},
+							})
+						: 0,
+					this.db.recipient.count({
+						where: {
+							programId: null,
+							localPartner: {
+								focuses: {
+									some: {
+										focusId: focus.id,
+									},
+								},
+							},
+						},
+					}),
+				]);
+
+				statsByKey[getKey(focus)] = {
+					programsCount: programIds.length,
+					recipientsInProgramsCount,
+					candidatesCount,
+				};
+			}),
+		);
+
+		return statsByKey;
 	}
 
 	async get(userId: string, id: string): Promise<ServiceResult<FocusPayload>> {
@@ -158,6 +207,30 @@ export class FocusReadService extends BaseService {
 		}
 	}
 
+	async getPublicFocusStatsBySlugs(focusSlugs: string[]): Promise<ServiceResult<PublicFocusStatsBySlugMap>> {
+		try {
+			const normalizedFocusSlugs = [...new Set(focusSlugs.map((focusSlug) => focusSlug.trim()).filter(Boolean))];
+			if (!normalizedFocusSlugs.length) {
+				return this.resultOk({});
+			}
+
+			const focuses = await this.db.focus.findMany({
+				where: { slug: { in: normalizedFocusSlugs } },
+				select: {
+					id: true,
+					slug: true,
+					programs: { select: { programId: true } },
+				},
+			});
+
+			return this.resultOk(await this.buildPublicFocusStatsMap(focuses, (focus) => focus.slug ?? focus.id));
+		} catch (error) {
+			this.logger.error(error);
+
+			return this.resultFail(`Could not fetch focus stats by slug: ${JSON.stringify(error)}`);
+		}
+	}
+
 	async getPublicFocusStatsByIds(focusIds: string[]): Promise<ServiceResult<PublicFocusStatsMap>> {
 		try {
 			const normalizedFocusIds = [...new Set(focusIds.map((focusId) => focusId.trim()).filter(Boolean))];
@@ -169,51 +242,11 @@ export class FocusReadService extends BaseService {
 				where: { id: { in: normalizedFocusIds } },
 				select: {
 					id: true,
-					_count: {
-						select: {
-							programs: true,
-						},
-					},
-					// Note: `programs`/`localPartners` are relation tables (ProgramTargetFocus / LocalPartnerFocus).
 					programs: { select: { programId: true } },
-					localPartners: { select: { localPartnerId: true } },
 				},
 			});
 
-			const statsById: PublicFocusStatsMap = {};
-
-			for (const focus of focuses) {
-				const programIds = focus.programs.map((p) => p.programId);
-				const localPartnerIds = focus.localPartners.map((lp) => lp.localPartnerId);
-				const hasLocalPartners = localPartnerIds.length > 0;
-
-				const recipientsInProgramsCount =
-					hasLocalPartners && programIds.length > 0
-						? await this.db.recipient.count({
-								where: {
-									programId: { in: programIds },
-									localPartnerId: { in: localPartnerIds },
-								},
-							})
-						: 0;
-
-				const candidatesCount = hasLocalPartners
-					? await this.db.recipient.count({
-							where: {
-								programId: null,
-								localPartnerId: { in: localPartnerIds },
-							},
-						})
-					: 0;
-
-				statsById[focus.id] = {
-					programsCount: focus._count.programs,
-					recipientsInProgramsCount,
-					candidatesCount,
-				};
-			}
-
-			return this.resultOk(statsById);
+			return this.resultOk(await this.buildPublicFocusStatsMap(focuses, (focus) => focus.id));
 		} catch (error) {
 			this.logger.error(error);
 

--- a/website/src/lib/services/focus/focus-read.service.ts
+++ b/website/src/lib/services/focus/focus-read.service.ts
@@ -1,4 +1,4 @@
-import { Prisma, PrismaClient } from '@/generated/prisma/client';
+import { Prisma, PrismaClient, type CountryCode } from '@/generated/prisma/client';
 import { logger } from '@/lib/utils/logger';
 import { toSortKey } from '@/lib/utils/to-sort-key';
 import { BaseService } from '../core/base.service';
@@ -18,7 +18,7 @@ import {
 type PublicFocusStatsSource = {
 	id: string;
 	slug?: string;
-	programs: { programId: string }[];
+	programs: { programId: string; program?: { country: { isoCode: CountryCode } } }[];
 };
 
 export class FocusReadService extends BaseService {
@@ -66,6 +66,13 @@ export class FocusReadService extends BaseService {
 		await Promise.all(
 			focuses.map(async (focus) => {
 				const programIds = [...new Set(focus.programs.map(({ programId }) => programId))];
+				const countryIsoCodes = [
+					...new Set(
+						focus.programs
+							.map(({ program }) => program?.country.isoCode)
+							.filter((countryIsoCode): countryIsoCode is CountryCode => Boolean(countryIsoCode)),
+					),
+				];
 				const [recipientsInProgramsCount, candidatesCount] = await Promise.all([
 					programIds.length > 0
 						? this.db.recipient.count({
@@ -92,6 +99,7 @@ export class FocusReadService extends BaseService {
 					programsCount: programIds.length,
 					recipientsInProgramsCount,
 					candidatesCount,
+					countryIsoCodes,
 				};
 			}),
 		);
@@ -219,7 +227,12 @@ export class FocusReadService extends BaseService {
 				select: {
 					id: true,
 					slug: true,
-					programs: { select: { programId: true } },
+					programs: {
+						select: {
+							programId: true,
+							program: { select: { country: { select: { isoCode: true } } } },
+						},
+					},
 				},
 			});
 
@@ -242,7 +255,12 @@ export class FocusReadService extends BaseService {
 				where: { id: { in: normalizedFocusIds } },
 				select: {
 					id: true,
-					programs: { select: { programId: true } },
+					programs: {
+						select: {
+							programId: true,
+							program: { select: { country: { select: { isoCode: true } } } },
+						},
+					},
 				},
 			});
 

--- a/website/src/lib/services/focus/focus.types.ts
+++ b/website/src/lib/services/focus/focus.types.ts
@@ -1,3 +1,5 @@
+import type { CountryCode } from '@/generated/prisma/client';
+
 export type FocusTableViewRow = {
 	id: string;
 	name: string;
@@ -34,6 +36,7 @@ export type PublicFocusStats = {
 	programsCount: number;
 	recipientsInProgramsCount: number;
 	candidatesCount: number;
+	countryIsoCodes: CountryCode[];
 };
 
 export type PublicFocusStatsMap = Record<string, PublicFocusStats>;

--- a/website/src/lib/services/focus/focus.types.ts
+++ b/website/src/lib/services/focus/focus.types.ts
@@ -37,3 +37,4 @@ export type PublicFocusStats = {
 };
 
 export type PublicFocusStatsMap = Record<string, PublicFocusStats>;
+export type PublicFocusStatsBySlugMap = Record<string, PublicFocusStats>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added search and country filtering to the Focuses Overview, with results driven by URL query parameters.
  * Upgraded the Focus list to rich cards that display translated stats and an optional “candidates ready” notice.
* **Bug Fixes**
  * Improved focus browsing reliability by handling stats-loading failures and empty/no-results states.
* **Tests**
  * Added coverage for server-side filtering, query normalization, and country/search matching.
* **Documentation**
  * Added/updated translated UI text for the new filters, messages, and card labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->