### PR TITLE
fix: remove pages folder from richtext links

### DIFF
--- a/website/src/components/storyblok/rich-text/shared-resolvers.tsx
+++ b/website/src/components/storyblok/rich-text/shared-resolvers.tsx
@@ -37,6 +37,8 @@ const buildLinkRel = (target?: string, rel?: string) => {
 	return [...tokens].join(' ');
 };
 
+const removeStoryblokPagesFolder = (href: string) => href.replace(/^(https?:\/\/[^/]+)?\/?pages(?=\/|$)/, '$1');
+
 export const storyblokRichTextMarkResolvers = {
 	[MARK_LINK]: (children: ReactNode, props: RichTextLinkProps) => {
 		const href = props.href?.trim();
@@ -47,7 +49,7 @@ export const storyblokRichTextMarkResolvers = {
 
 		return (
 			<NextLink
-				href={href}
+				href={removeStoryblokPagesFolder(href)}
 				className={cn(linkClassName, 'hover:underline')}
 				target={props.target}
 				rel={buildLinkRel(props.target, props.rel)}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Storyblok link handling so links with an initial `/pages` segment are cleaned up before being shown.
  * Kept link validation in place while ensuring the displayed destination uses the corrected path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->