### PR TITLE
feat: prefill login form after contribute

### DIFF
--- a/website/src/app/[lang]/[region]/login/login-page-content.tsx
+++ b/website/src/app/[lang]/[region]/login/login-page-content.tsx
@@ -4,9 +4,10 @@ import { WebsiteLanguage } from '@/lib/i18n/utils';
 
 type Props = {
 	lang: WebsiteLanguage;
+	prefilledEmail: string;
 };
 
-export const LoginPageContent = async ({ lang }: Props) => {
+export const LoginPageContent = async ({ lang, prefilledEmail }: Props) => {
 	const translator = await Translator.getInstance({
 		language: lang,
 		namespaces: ['website-login'],
@@ -16,7 +17,7 @@ export const LoginPageContent = async ({ lang }: Props) => {
 		<div className="flex min-h-[40vh] flex-1 flex-col items-center justify-center px-4">
 			<div className="border-border mx-auto w-full max-w-[400px] rounded-3xl border bg-white px-4 pt-4 pb-6 shadow-[0_2px_4px_rgba(0,0,0,0.05)] sm:px-6 sm:pt-5 sm:pb-7 md:px-9 md:py-9">
 				<h1 className="text-foreground mb-5 text-xl font-semibold">{translator.t('title')}</h1>
-				<MagicLinkLoginForm lang={lang} />
+				<MagicLinkLoginForm lang={lang} prefilledEmail={prefilledEmail} />
 			</div>
 		</div>
 	);

--- a/website/src/app/[lang]/[region]/login/page.tsx
+++ b/website/src/app/[lang]/[region]/login/page.tsx
@@ -32,7 +32,10 @@ const LoginPage = async ({ params, searchParams }: DefaultPageProps) => {
 		}
 	}
 
-	return <LoginPageContent lang={lang as WebsiteLanguage} />;
+	const emailParam = resolvedSearchParams.email;
+	const prefilledEmail = typeof emailParam === 'string' ? emailParam : '';
+
+	return <LoginPageContent lang={lang as WebsiteLanguage} prefilledEmail={prefilledEmail} />;
 };
 
 export default LoginPage;

--- a/website/src/components/donation-wizard/steps/step-onboarding/onboarding-step.tsx
+++ b/website/src/components/donation-wizard/steps/step-onboarding/onboarding-step.tsx
@@ -39,7 +39,7 @@ export const OnboardingStep = ({ state, send }: DonationWizardStepProps) => {
 
 	const values = useWatch({ control: form.control });
 	const canSubmit = isOnboardingPersonalValid(values ?? {});
-	const skipToThankYou = () => send({ type: 'DONATION_ONBOARDING_SKIP_TO_THANK_YOU' });
+	const skipToThankYou = () => send({ type: 'DONATION_ONBOARDING_SKIP_TO_THANK_YOU', email: emailLocked });
 
 	const hasStripeOnboardingContext = wizardPaymentSource === 'stripe' && Boolean(stripeCheckoutSessionId);
 	const hasQrOnboardingContext = wizardPaymentSource === 'qr' && Boolean(qrContributorReferenceId);
@@ -74,7 +74,7 @@ export const OnboardingStep = ({ state, send }: DonationWizardStepProps) => {
 			}
 
 			if (!result.data.needsOnboarding) {
-				send({ type: 'DONATION_ONBOARDING_SKIP_TO_THANK_YOU' });
+				send({ type: 'DONATION_ONBOARDING_SKIP_TO_THANK_YOU', email: result.data.email });
 
 				return;
 			}
@@ -145,7 +145,7 @@ export const OnboardingStep = ({ state, send }: DonationWizardStepProps) => {
 					language: language as SupportedLanguage,
 				});
 
-				send({ type: 'DONATION_ONBOARDING_PERSONAL_COMPLETE' });
+				send({ type: 'DONATION_ONBOARDING_PERSONAL_COMPLETE', email: submitted.email });
 			} catch {
 				toast.error(t('onboarding.updateError'));
 				setSubmitting(false);
@@ -188,7 +188,7 @@ export const OnboardingStep = ({ state, send }: DonationWizardStepProps) => {
 					language: language as SupportedLanguage,
 				});
 
-				send({ type: 'DONATION_ONBOARDING_PERSONAL_COMPLETE' });
+				send({ type: 'DONATION_ONBOARDING_PERSONAL_COMPLETE', email: submitted.email });
 			} catch {
 				toast.error(t('onboarding.updateError'));
 				setSubmitting(false);

--- a/website/src/components/donation-wizard/steps/step-thank-you/donation-login-prompt.tsx
+++ b/website/src/components/donation-wizard/steps/step-thank-you/donation-login-prompt.tsx
@@ -7,8 +7,14 @@ import Link from 'next/link';
 
 const SUPPORT_EMAIL = 'support@socialincome.org';
 
-export const DonationLoginPrompt = () => {
+type Props = {
+	prefilledEmail: string;
+	onLoginClick: () => void;
+};
+
+export const DonationLoginPrompt = ({ prefilledEmail, onLoginClick }: Props) => {
 	const { t } = useRouteTranslator({ namespace: 'donation-wizard' });
+	const loginHref = prefilledEmail ? `/login?email=${encodeURIComponent(prefilledEmail)}` : '/login';
 
 	return (
 		<div className="flex w-full flex-col items-center gap-6 px-9 pt-6 pb-7" data-testid="donation-wizard-step-thank-you">
@@ -24,7 +30,7 @@ export const DonationLoginPrompt = () => {
 
 			<div className="flex w-full flex-col items-center gap-3">
 				<Button asChild className="min-w-32">
-					<Link href="/login" data-testid="donation-wizard-login-link">
+					<Link href={loginHref} onClick={onLoginClick} data-testid="donation-wizard-login-link">
 						{t('thankYou.loginPrompt.loginButton')}
 					</Link>
 				</Button>

--- a/website/src/components/donation-wizard/steps/step-thank-you/thank-you-step.tsx
+++ b/website/src/components/donation-wizard/steps/step-thank-you/thank-you-step.tsx
@@ -1,5 +1,10 @@
 'use client';
 
+import type { DonationWizardStepProps } from '../../wizard/types';
 import { DonationLoginPrompt } from './donation-login-prompt';
 
-export const ThankYouStep = () => <DonationLoginPrompt />;
+export const ThankYouStep = ({ state, send }: DonationWizardStepProps) => {
+	const prefilledEmail = state.context.loginEmail ?? state.context.qrDonor?.email ?? '';
+
+	return <DonationLoginPrompt prefilledEmail={prefilledEmail} onLoginClick={() => send({ type: 'CLOSE' })} />;
+};

--- a/website/src/components/donation-wizard/wizard/donation-machine.ts
+++ b/website/src/components/donation-wizard/wizard/donation-machine.ts
@@ -56,8 +56,8 @@ export const donationWizardMachine = setup({
 			| { type: 'STRIPE_CHECKOUT_RETRY' }
 			| { type: 'STRIPE_CHECKOUT_BACK' }
 			| { type: 'STRIPE_CHECKOUT_COMPLETE' }
-			| { type: 'DONATION_ONBOARDING_PERSONAL_COMPLETE' }
-			| { type: 'DONATION_ONBOARDING_SKIP_TO_THANK_YOU' }
+			| { type: 'DONATION_ONBOARDING_PERSONAL_COMPLETE'; email: string }
+			| { type: 'DONATION_ONBOARDING_SKIP_TO_THANK_YOU'; email?: string }
 			| { type: 'DONATION_ONBOARDING_REFERRAL_COMPLETE' }
 			| { type: 'BACK' };
 	},
@@ -460,9 +460,15 @@ export const donationWizardMachine = setup({
 			on: {
 				DONATION_ONBOARDING_PERSONAL_COMPLETE: {
 					target: 'stepOnboardingReferral',
+					actions: assign({
+						loginEmail: ({ event }) => event.email,
+					}),
 				},
 				DONATION_ONBOARDING_SKIP_TO_THANK_YOU: {
 					target: 'stepThankYou',
+					actions: assign({
+						loginEmail: ({ context, event }) => event.email ?? context.loginEmail,
+					}),
 				},
 				CLOSE: {
 					target: 'closed',
@@ -477,6 +483,9 @@ export const donationWizardMachine = setup({
 				},
 				DONATION_ONBOARDING_SKIP_TO_THANK_YOU: {
 					target: 'stepThankYou',
+					actions: assign({
+						loginEmail: ({ context, event }) => event.email ?? context.loginEmail,
+					}),
 				},
 				CLOSE: {
 					target: 'closed',

--- a/website/src/components/donation-wizard/wizard/donation-steps.tsx
+++ b/website/src/components/donation-wizard/wizard/donation-steps.tsx
@@ -53,7 +53,7 @@ export const DonationSteps = ({ state, send }: DonationWizardStepProps) => {
 	}
 
 	if (activeStep === 'stepThankYou') {
-		return <ThankYouStep />;
+		return <ThankYouStep state={state} send={send} />;
 	}
 
 	return null;

--- a/website/src/components/donation-wizard/wizard/donation-wizard-context.ts
+++ b/website/src/components/donation-wizard/wizard/donation-wizard-context.ts
@@ -26,6 +26,7 @@ export type DonationWizardContext = DonationAmountContext & {
 	stripeCheckoutStatus: StripeCheckoutStatus;
 	stripeCheckoutError: string | null;
 	completedDonationSummary: CompletedDonationSummary | null;
+	loginEmail: string | null;
 	wizardPaymentSource: WizardPaymentSource;
 	qrDonor: QrDonorContext | null;
 	qrContributorReferenceId: string | null;
@@ -58,6 +59,7 @@ export const getInitialWizardContext = (): DonationWizardContext => ({
 	pendingStep: null,
 	...resetStripeCheckoutContext,
 	completedDonationSummary: null,
+	loginEmail: null,
 	wizardPaymentSource: null,
 	...resetQrBillContext,
 });

--- a/website/src/components/login/magic-link-login-form.tsx
+++ b/website/src/components/login/magic-link-login-form.tsx
@@ -21,9 +21,10 @@ const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 type Props = {
 	lang: WebsiteLanguage;
+	prefilledEmail?: string;
 };
 
-export const MagicLinkLoginForm = ({ lang }: Props) => {
+export const MagicLinkLoginForm = ({ lang, prefilledEmail = '' }: Props) => {
 	const { auth } = useAuth();
 	const translator = useTranslator(lang, 'website-login');
 
@@ -39,7 +40,7 @@ export const MagicLinkLoginForm = ({ lang }: Props) => {
 
 	const form = useForm<FormValues>({
 		resolver: zodResolver(formSchema),
-		defaultValues: { email: '' },
+		defaultValues: { email: prefilledEmail },
 	});
 
 	const handleSend = async ({ email }: FormValues) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login pages can now prefill the email field from a shared email value, making sign-in faster.
  * The donation flow now carries the donor’s email through to the final login prompt when available.

* **Bug Fixes**
  * Improved email handling across donation onboarding and completion so the correct email is preserved between steps.
  * The login link in the donation thank-you screen now routes with or without a prefilled email as appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->