### PR TITLE
feat: add sdg to focus overview page

### DIFF
--- a/website/src/components/storyblok/focus/focus-detail-card.tsx
+++ b/website/src/components/storyblok/focus/focus-detail-card.tsx
@@ -1,6 +1,7 @@
-import { CircleDot } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/tool-tip';
+import { CircleDot, InfoIcon } from 'lucide-react';
 import NextLink from 'next/link';
-import type { ReactNode } from 'react';
+import { getSdg, type SdgValue } from './sdgs';
 
 type FocusDetailCardLabels = {
 	recipients: string;
@@ -14,12 +15,17 @@ type FocusDetailCardProps = {
 	focusTitle: string;
 	recipientsCount: number;
 	programsCount: number;
-	sdgsValue: ReactNode;
+	sdgValues?: SdgValue[];
 	labels: FocusDetailCardLabels;
 };
 
 type FocusDetailCardStatProps = {
-	value: ReactNode;
+	value: number;
+	label: string;
+};
+
+type FocusDetailCardSdgsProps = {
+	values?: SdgValue[];
 	label: string;
 };
 
@@ -29,6 +35,61 @@ const FocusDetailCardStat = ({ value, label }: FocusDetailCardStatProps) => (
 		<div className="text-sm font-medium text-slate-600">{label}</div>
 	</div>
 );
+
+const FocusDetailCardSdgs = ({ values = [], label }: FocusDetailCardSdgsProps) => {
+	const validSdgs = values.flatMap((value) => {
+		const sdg = getSdg(value);
+
+		return sdg ? [sdg] : [];
+	});
+
+	return (
+		<div className="flex flex-col gap-0">
+			<div className="flex min-h-7 items-center gap-1">
+				{validSdgs.length > 0 ? (
+					validSdgs.map((sdg) => (
+						<span
+							key={sdg.number}
+							className="flex size-5 items-center justify-center rounded-full text-xs leading-none font-semibold text-white"
+							style={{ backgroundColor: sdg.color }}
+							title={sdg.title}
+							aria-label={`SDG ${sdg.number}: ${sdg.title}`}
+						>
+							{sdg.number}
+						</span>
+					))
+				) : (
+					<span className="text-2xl font-semibold text-slate-600" aria-hidden>
+						-
+					</span>
+				)}
+			</div>
+			<div className="flex items-center gap-1 text-sm font-medium text-slate-600">
+				<span>{label}</span>
+				{validSdgs.length > 0 ? (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<button
+								type="button"
+								className="inline-flex text-slate-600 hover:text-slate-950"
+								aria-label={`${label} information`}
+							>
+								<InfoIcon className="size-[12px]" aria-hidden />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent sideOffset={8} className="max-w-[280px]">
+							<ul>
+								{validSdgs.map((sdg) => (
+									<li key={sdg.number}>{`SDG ${sdg.number}: ${sdg.title}`}</li>
+								))}
+							</ul>
+						</TooltipContent>
+					</Tooltip>
+				) : null}
+			</div>
+		</div>
+	);
+};
 
 const AlertSection = ({ text }: { text: string }) => (
 	<div className="flex items-center gap-2 rounded-b-2xl px-4 py-2">
@@ -42,7 +103,7 @@ export const FocusDetailCard = ({
 	focusTitle,
 	recipientsCount,
 	programsCount,
-	sdgsValue,
+	sdgValues,
 	labels,
 }: FocusDetailCardProps) => (
 	<div className="bg-confirm-foreground flex h-full flex-col rounded-2xl drop-shadow-md">
@@ -56,7 +117,7 @@ export const FocusDetailCard = ({
 			<div className="grid grid-cols-3 gap-3">
 				<FocusDetailCardStat value={recipientsCount} label={labels.recipients} />
 				<FocusDetailCardStat value={programsCount} label={labels.programs} />
-				<FocusDetailCardStat value={sdgsValue} label={labels.sdgs} />
+				<FocusDetailCardSdgs values={sdgValues} label={labels.sdgs} />
 			</div>
 		</NextLink>
 		{labels.candidatesReady ? <AlertSection text={labels.candidatesReady} /> : null}

--- a/website/src/components/storyblok/focus/focus-detail-card.tsx
+++ b/website/src/components/storyblok/focus/focus-detail-card.tsx
@@ -69,13 +69,9 @@ const FocusDetailCardSdgs = ({ values = [], label }: FocusDetailCardSdgsProps) =
 				{validSdgs.length > 0 ? (
 					<Tooltip>
 						<TooltipTrigger asChild>
-							<button
-								type="button"
-								className="inline-flex text-slate-600 hover:text-slate-950"
-								aria-label={`${label} information`}
-							>
+							<span className="inline-flex cursor-help text-slate-600 hover:text-slate-950">
 								<InfoIcon className="size-[12px]" aria-hidden />
-							</button>
+							</span>
 						</TooltipTrigger>
 						<TooltipContent sideOffset={8} className="max-w-[280px]">
 							<ul>

--- a/website/src/components/storyblok/focus/focus-detail-card.tsx
+++ b/website/src/components/storyblok/focus/focus-detail-card.tsx
@@ -69,9 +69,13 @@ const FocusDetailCardSdgs = ({ values = [], label }: FocusDetailCardSdgsProps) =
 				{validSdgs.length > 0 ? (
 					<Tooltip>
 						<TooltipTrigger asChild>
-							<span className="inline-flex cursor-help text-slate-600 hover:text-slate-950">
+							<button
+								type="button"
+								className="relative z-10 inline-flex text-slate-600 hover:text-slate-950"
+								aria-label={`${label} information`}
+							>
 								<InfoIcon className="size-[12px]" aria-hidden />
-							</span>
+							</button>
 						</TooltipTrigger>
 						<TooltipContent sideOffset={8} className="max-w-[280px]">
 							<ul>
@@ -101,21 +105,30 @@ export const FocusDetailCard = ({
 	programsCount,
 	sdgValues,
 	labels,
-}: FocusDetailCardProps) => (
-	<div className="bg-confirm-foreground flex h-full flex-col rounded-2xl drop-shadow-md">
-		<NextLink
-			href={href}
-			className="border-border flex min-w-0 flex-1 flex-col gap-3 rounded-2xl border bg-white p-6 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-950"
-		>
-			<h2 className="line-clamp-2 min-h-18 min-w-0 font-sans text-3xl leading-9 font-medium wrap-break-word text-cyan-950">
-				{focusTitle}
-			</h2>
-			<div className="grid grid-cols-3 gap-3">
-				<FocusDetailCardStat value={recipientsCount} label={labels.recipients} />
-				<FocusDetailCardStat value={programsCount} label={labels.programs} />
-				<FocusDetailCardSdgs values={sdgValues} label={labels.sdgs} />
+}: FocusDetailCardProps) => {
+	const titleId = `focus-card-title-${href}`;
+
+	return (
+		<div className="bg-confirm-foreground flex h-full flex-col rounded-2xl drop-shadow-md">
+			<div className="border-border relative flex min-w-0 flex-1 flex-col gap-3 rounded-2xl border bg-white p-6">
+				<NextLink
+					href={href}
+					className="absolute inset-0 z-0 rounded-2xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-950"
+					aria-labelledby={titleId}
+				/>
+				<h2
+					id={titleId}
+					className="relative line-clamp-2 min-h-18 min-w-0 font-sans text-3xl leading-9 font-medium wrap-break-word text-cyan-950"
+				>
+					{focusTitle}
+				</h2>
+				<div className="relative grid grid-cols-3 gap-3">
+					<FocusDetailCardStat value={recipientsCount} label={labels.recipients} />
+					<FocusDetailCardStat value={programsCount} label={labels.programs} />
+					<FocusDetailCardSdgs values={sdgValues} label={labels.sdgs} />
+				</div>
 			</div>
-		</NextLink>
-		{labels.candidatesReady ? <AlertSection text={labels.candidatesReady} /> : null}
-	</div>
-);
+			{labels.candidatesReady ? <AlertSection text={labels.candidatesReady} /> : null}
+		</div>
+	);
+};

--- a/website/src/components/storyblok/focus/focuses-overview-country-filter.tsx
+++ b/website/src/components/storyblok/focus/focuses-overview-country-filter.tsx
@@ -1,10 +1,4 @@
-'use client';
-
-import { Button } from '@/components/button';
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/dropdown-menu';
-import { cn } from '@/lib/utils/cn';
-import { ChevronDown } from 'lucide-react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { FocusesOverviewDropdownFilter } from './focuses-overview-dropdown-filter';
 import { COUNTRY_QUERY_KEY } from './focuses-overview-query';
 import type { FilterOption } from './focuses-overview.server';
 
@@ -14,50 +8,11 @@ type Props = {
 	selectedCountryIsoCode?: string;
 };
 
-export const FocusesOverviewCountryFilter = ({ allCountriesLabel, countryOptions, selectedCountryIsoCode }: Props) => {
-	const router = useRouter();
-	const pathname = usePathname();
-	const searchParams = useSearchParams();
-	const selectedOption = countryOptions.find((option) => option.value === selectedCountryIsoCode);
-	const isActive = Boolean(selectedOption);
-	const buttonLabel = selectedOption?.label ?? allCountriesLabel;
-
-	const updateFilter = (value: string | undefined) => {
-		const nextParams = new URLSearchParams(searchParams.toString());
-
-		if (value) {
-			nextParams.set(COUNTRY_QUERY_KEY, value);
-		} else {
-			nextParams.delete(COUNTRY_QUERY_KEY);
-		}
-
-		const nextQuery = nextParams.toString();
-		router.replace(nextQuery.length > 0 ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
-	};
-
-	return (
-		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button
-					type="button"
-					variant="outline"
-					className={cn(
-						'text-foreground border-border bg-card hover:bg-card h-10 px-4 text-sm font-medium',
-						isActive && 'bg-input hover:bg-input',
-					)}
-				>
-					{buttonLabel}
-					<ChevronDown className="text-foreground size-4 opacity-70" />
-				</Button>
-			</DropdownMenuTrigger>
-			<DropdownMenuContent align="start" className="bg-popover w-56">
-				<DropdownMenuItem onSelect={() => updateFilter(undefined)}>{allCountriesLabel}</DropdownMenuItem>
-				{countryOptions.map((option) => (
-					<DropdownMenuItem key={option.value} onSelect={() => updateFilter(option.value)}>
-						{option.label}
-					</DropdownMenuItem>
-				))}
-			</DropdownMenuContent>
-		</DropdownMenu>
-	);
-};
+export const FocusesOverviewCountryFilter = ({ allCountriesLabel, countryOptions, selectedCountryIsoCode }: Props) => (
+	<FocusesOverviewDropdownFilter
+		allOptionsLabel={allCountriesLabel}
+		options={countryOptions}
+		queryKey={COUNTRY_QUERY_KEY}
+		selectedValue={selectedCountryIsoCode}
+	/>
+);

--- a/website/src/components/storyblok/focus/focuses-overview-dropdown-filter.tsx
+++ b/website/src/components/storyblok/focus/focuses-overview-dropdown-filter.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { Button } from '@/components/button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/dropdown-menu';
+import { cn } from '@/lib/utils/cn';
+import { ChevronDown } from 'lucide-react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import type { FilterOption } from './focuses-overview.server';
+
+type Props = {
+	allOptionsLabel: string;
+	options: FilterOption[];
+	queryKey: string;
+	selectedValue?: string;
+};
+
+export const FocusesOverviewDropdownFilter = ({ allOptionsLabel, options, queryKey, selectedValue }: Props) => {
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const selectedOption = options.find((option) => option.value === selectedValue);
+	const isActive = Boolean(selectedOption);
+	const buttonLabel = selectedOption?.label ?? allOptionsLabel;
+
+	const updateFilter = (value: string | undefined) => {
+		const nextParams = new URLSearchParams(searchParams.toString());
+
+		if (value) {
+			nextParams.set(queryKey, value);
+		} else {
+			nextParams.delete(queryKey);
+		}
+
+		const nextQuery = nextParams.toString();
+		router.replace(nextQuery.length > 0 ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
+	};
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					type="button"
+					variant="outline"
+					className={cn(
+						'text-foreground border-border bg-card hover:bg-card h-10 px-4 text-sm font-medium',
+						isActive && 'bg-input hover:bg-input',
+					)}
+				>
+					{buttonLabel}
+					<ChevronDown className="text-foreground size-4 opacity-70" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start" className="bg-popover w-56">
+				<DropdownMenuItem onSelect={() => updateFilter(undefined)}>{allOptionsLabel}</DropdownMenuItem>
+				{options.map((option) => (
+					<DropdownMenuItem key={option.value} onSelect={() => updateFilter(option.value)}>
+						{option.label}
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+};

--- a/website/src/components/storyblok/focus/focuses-overview-query.ts
+++ b/website/src/components/storyblok/focus/focuses-overview-query.ts
@@ -1,2 +1,3 @@
 export const COUNTRY_QUERY_KEY = 'country';
 export const SEARCH_QUERY_KEY = 'search';
+export const SDG_QUERY_KEY = 'sdg';

--- a/website/src/components/storyblok/focus/focuses-overview-sdg-filter.tsx
+++ b/website/src/components/storyblok/focus/focuses-overview-sdg-filter.tsx
@@ -5,30 +5,30 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { cn } from '@/lib/utils/cn';
 import { ChevronDown } from 'lucide-react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { COUNTRY_QUERY_KEY } from './focuses-overview-query';
+import { SDG_QUERY_KEY } from './focuses-overview-query';
 import type { FilterOption } from './focuses-overview.server';
 
 type Props = {
-	allCountriesLabel: string;
-	countryOptions: FilterOption[];
-	selectedCountryIsoCode?: string;
+	allSdgsLabel: string;
+	sdgOptions: FilterOption[];
+	selectedSdg?: string;
 };
 
-export const FocusesOverviewCountryFilter = ({ allCountriesLabel, countryOptions, selectedCountryIsoCode }: Props) => {
+export const FocusesOverviewSdgFilter = ({ allSdgsLabel, sdgOptions, selectedSdg }: Props) => {
 	const router = useRouter();
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
-	const selectedOption = countryOptions.find((option) => option.value === selectedCountryIsoCode);
+	const selectedOption = sdgOptions.find((option) => option.value === selectedSdg);
 	const isActive = Boolean(selectedOption);
-	const buttonLabel = selectedOption?.label ?? allCountriesLabel;
+	const buttonLabel = selectedOption?.label ?? allSdgsLabel;
 
 	const updateFilter = (value: string | undefined) => {
 		const nextParams = new URLSearchParams(searchParams.toString());
 
 		if (value) {
-			nextParams.set(COUNTRY_QUERY_KEY, value);
+			nextParams.set(SDG_QUERY_KEY, value);
 		} else {
-			nextParams.delete(COUNTRY_QUERY_KEY);
+			nextParams.delete(SDG_QUERY_KEY);
 		}
 
 		const nextQuery = nextParams.toString();
@@ -51,8 +51,8 @@ export const FocusesOverviewCountryFilter = ({ allCountriesLabel, countryOptions
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="start" className="bg-popover w-56">
-				<DropdownMenuItem onSelect={() => updateFilter(undefined)}>{allCountriesLabel}</DropdownMenuItem>
-				{countryOptions.map((option) => (
+				<DropdownMenuItem onSelect={() => updateFilter(undefined)}>{allSdgsLabel}</DropdownMenuItem>
+				{sdgOptions.map((option) => (
 					<DropdownMenuItem key={option.value} onSelect={() => updateFilter(option.value)}>
 						{option.label}
 					</DropdownMenuItem>

--- a/website/src/components/storyblok/focus/focuses-overview-sdg-filter.tsx
+++ b/website/src/components/storyblok/focus/focuses-overview-sdg-filter.tsx
@@ -1,10 +1,4 @@
-'use client';
-
-import { Button } from '@/components/button';
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/dropdown-menu';
-import { cn } from '@/lib/utils/cn';
-import { ChevronDown } from 'lucide-react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { FocusesOverviewDropdownFilter } from './focuses-overview-dropdown-filter';
 import { SDG_QUERY_KEY } from './focuses-overview-query';
 import type { FilterOption } from './focuses-overview.server';
 
@@ -14,50 +8,11 @@ type Props = {
 	selectedSdg?: string;
 };
 
-export const FocusesOverviewSdgFilter = ({ allSdgsLabel, sdgOptions, selectedSdg }: Props) => {
-	const router = useRouter();
-	const pathname = usePathname();
-	const searchParams = useSearchParams();
-	const selectedOption = sdgOptions.find((option) => option.value === selectedSdg);
-	const isActive = Boolean(selectedOption);
-	const buttonLabel = selectedOption?.label ?? allSdgsLabel;
-
-	const updateFilter = (value: string | undefined) => {
-		const nextParams = new URLSearchParams(searchParams.toString());
-
-		if (value) {
-			nextParams.set(SDG_QUERY_KEY, value);
-		} else {
-			nextParams.delete(SDG_QUERY_KEY);
-		}
-
-		const nextQuery = nextParams.toString();
-		router.replace(nextQuery.length > 0 ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
-	};
-
-	return (
-		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button
-					type="button"
-					variant="outline"
-					className={cn(
-						'text-foreground border-border bg-card hover:bg-card h-10 px-4 text-sm font-medium',
-						isActive && 'bg-input hover:bg-input',
-					)}
-				>
-					{buttonLabel}
-					<ChevronDown className="text-foreground size-4 opacity-70" />
-				</Button>
-			</DropdownMenuTrigger>
-			<DropdownMenuContent align="start" className="bg-popover w-56">
-				<DropdownMenuItem onSelect={() => updateFilter(undefined)}>{allSdgsLabel}</DropdownMenuItem>
-				{sdgOptions.map((option) => (
-					<DropdownMenuItem key={option.value} onSelect={() => updateFilter(option.value)}>
-						{option.label}
-					</DropdownMenuItem>
-				))}
-			</DropdownMenuContent>
-		</DropdownMenu>
-	);
-};
+export const FocusesOverviewSdgFilter = ({ allSdgsLabel, sdgOptions, selectedSdg }: Props) => (
+	<FocusesOverviewDropdownFilter
+		allOptionsLabel={allSdgsLabel}
+		options={sdgOptions}
+		queryKey={SDG_QUERY_KEY}
+		selectedValue={selectedSdg}
+	/>
+);

--- a/website/src/components/storyblok/focus/focuses-overview.server.test.ts
+++ b/website/src/components/storyblok/focus/focuses-overview.server.test.ts
@@ -2,13 +2,24 @@ import type { PublicFocusStatsBySlugMap } from '@/lib/services/focus/focus.types
 import type { FocusStory } from './focus.types';
 import {
 	focusMatchesCountryQuery,
+	focusMatchesSdgQuery,
 	focusMatchesSearchQuery,
 	getCountryFilterOptions,
 	getCountryQuery,
+	getSdgFilterOptions,
+	getSdgQuery,
 	getSearchQuery,
 } from './focuses-overview.server';
 
-const createFocus = ({ slug, portalSlug, title, text }: { slug: string; portalSlug: string; title: string; text: string }) =>
+type CreateFocusInput = {
+	slug: string;
+	portalSlug: string;
+	title: string;
+	text: string;
+	sdgs?: (number | string)[];
+};
+
+const createFocus = ({ slug, portalSlug, title, text, sdgs }: CreateFocusInput) =>
 	({
 		uuid: slug,
 		slug,
@@ -19,6 +30,7 @@ const createFocus = ({ slug, portalSlug, title, text }: { slug: string; portalSl
 			portalSlug,
 			title,
 			text,
+			sdgs,
 		},
 	}) as unknown as FocusStory;
 
@@ -28,12 +40,14 @@ const focuses = [
 		portalSlug: 'health',
 		title: 'Healthcare access',
 		text: 'Cash transfers for medical support',
+		sdgs: [3, '1', 'unknown'],
 	}),
 	createFocus({
 		slug: 'education',
 		portalSlug: 'education',
 		title: 'Education',
 		text: 'School access support',
+		sdgs: ['4', 3],
 	}),
 ];
 
@@ -56,6 +70,7 @@ describe('focuses overview server helpers', () => {
 	it('reads search and country query params', () => {
 		expect(getSearchQuery({ search: ' health ' })).toBe('health');
 		expect(getCountryQuery({ country: ['KE', 'CH'] })).toBe('KE');
+		expect(getSdgQuery({ sdg: ' 3 ' })).toBe('3');
 	});
 
 	it('derives country options from focus stats', () => {
@@ -64,10 +79,28 @@ describe('focuses overview server helpers', () => {
 		expect(countryOptions.map((option) => option.value).sort()).toEqual(['CH', 'KE', 'SL']);
 	});
 
+	it('derives SDG options from assigned focus SDGs', () => {
+		const sdgOptions = getSdgFilterOptions(focuses);
+
+		expect(sdgOptions).toEqual([
+			{ value: '1', label: 'SDG 1: No Poverty' },
+			{ value: '3', label: 'SDG 3: Good Health and Well-being' },
+			{ value: '4', label: 'SDG 4: Quality Education' },
+		]);
+	});
+
 	it('filters focuses by assigned program country', () => {
 		const kenyaFocuses = focuses.filter((focus) => focusMatchesCountryQuery(focus, statsBySlug, 'KE'));
 
 		expect(kenyaFocuses.map((focus) => focus.content.portalSlug)).toEqual(['health']);
+	});
+
+	it('filters focuses by assigned SDG', () => {
+		const healthFocuses = focuses.filter((focus) => focusMatchesSdgQuery(focus, '1'));
+		const sharedSdgFocuses = focuses.filter((focus) => focusMatchesSdgQuery(focus, '3'));
+
+		expect(healthFocuses.map((focus) => focus.content.portalSlug)).toEqual(['health']);
+		expect(sharedSdgFocuses.map((focus) => focus.content.portalSlug)).toEqual(['health', 'education']);
 	});
 
 	it('searches focus title, slug, portal slug, and text', () => {

--- a/website/src/components/storyblok/focus/focuses-overview.server.ts
+++ b/website/src/components/storyblok/focus/focuses-overview.server.ts
@@ -3,7 +3,8 @@ import { getCountryNameByCode } from '@/lib/types/country';
 import type { AnySearchParams } from '@/lib/types/page-props';
 import type { FocusStory } from './focus.types';
 import { getFocusSlug, getFocusText, getFocusTitle } from './focus.utils';
-import { COUNTRY_QUERY_KEY, SEARCH_QUERY_KEY } from './focuses-overview-query';
+import { COUNTRY_QUERY_KEY, SDG_QUERY_KEY, SEARCH_QUERY_KEY } from './focuses-overview-query';
+import { getSdg } from './sdgs';
 
 export type FilterOption = {
 	value: string;
@@ -23,6 +24,10 @@ export const getSearchQuery = (searchParams?: AnySearchParams) => {
 
 export const getCountryQuery = (searchParams?: AnySearchParams) => {
 	return getQueryValue(searchParams, COUNTRY_QUERY_KEY);
+};
+
+export const getSdgQuery = (searchParams?: AnySearchParams) => {
+	return getQueryValue(searchParams, SDG_QUERY_KEY);
 };
 
 const normalizeSearchValue = (value: string) => value.toLowerCase();
@@ -52,6 +57,14 @@ export const focusMatchesCountryQuery = (
 	);
 };
 
+export const focusMatchesSdgQuery = (focus: FocusStory, selectedSdg: string | undefined) => {
+	if (!selectedSdg) {
+		return true;
+	}
+
+	return focus.content.sdgs?.some((value) => String(getSdg(value)?.number) === selectedSdg) ?? false;
+};
+
 export const getCountryFilterOptions = (focuses: FocusStory[], statsBySlug: PublicFocusStatsBySlugMap): FilterOption[] => {
 	const optionsByCountryIsoCode = new Map<string, FilterOption>();
 
@@ -68,4 +81,23 @@ export const getCountryFilterOptions = (focuses: FocusStory[], statsBySlug: Publ
 	});
 
 	return [...optionsByCountryIsoCode.values()].sort((optionA, optionB) => optionA.label.localeCompare(optionB.label));
+};
+
+export const getSdgFilterOptions = (focuses: FocusStory[]): FilterOption[] => {
+	const optionsBySdgNumber = new Map<number, FilterOption>();
+
+	focuses.forEach((focus) => {
+		focus.content.sdgs?.forEach((value) => {
+			const sdg = getSdg(value);
+
+			if (sdg) {
+				optionsBySdgNumber.set(sdg.number, {
+					value: String(sdg.number),
+					label: `SDG ${sdg.number}: ${sdg.title}`,
+				});
+			}
+		});
+	});
+
+	return [...optionsBySdgNumber.entries()].sort(([numberA], [numberB]) => numberA - numberB).map(([, option]) => option);
 };

--- a/website/src/components/storyblok/focus/focuses-overview.tsx
+++ b/website/src/components/storyblok/focus/focuses-overview.tsx
@@ -7,12 +7,16 @@ import { FocusDetailCard } from './focus-detail-card';
 import type { FocusStory } from './focus.types';
 import { getFocusSlug, getFocusTitle } from './focus.utils';
 import { FocusesOverviewCountryFilter } from './focuses-overview-country-filter';
+import { FocusesOverviewSdgFilter } from './focuses-overview-sdg-filter';
 import { FocusesOverviewSearch } from './focuses-overview-search';
 import {
 	focusMatchesCountryQuery,
+	focusMatchesSdgQuery,
 	focusMatchesSearchQuery,
 	getCountryFilterOptions,
 	getCountryQuery,
+	getSdgFilterOptions,
+	getSdgQuery,
 	getSearchQuery,
 } from './focuses-overview.server';
 
@@ -33,27 +37,40 @@ export const FocusesOverview = async ({ focuses, lang, region, title, text, sear
 	const hasStatsError = !statsResult.success;
 	const searchQuery = getSearchQuery(searchParams);
 	const countryQuery = getCountryQuery(searchParams);
+	const sdgQuery = getSdgQuery(searchParams);
 	const countryOptions = getCountryFilterOptions(focuses, statsBySlug);
+	const sdgOptions = getSdgFilterOptions(focuses);
 	const selectedCountryIsoCode = countryOptions.some((option) => option.value === countryQuery) ? countryQuery : undefined;
-	const hasActiveFilters = Boolean(searchQuery || selectedCountryIsoCode);
+	const selectedSdg = sdgOptions.some((option) => option.value === sdgQuery) ? sdgQuery : undefined;
+	const hasActiveFilters = Boolean(searchQuery) || Boolean(selectedCountryIsoCode) || Boolean(selectedSdg);
 	const countryFilteredFocuses = focuses.filter((focus) =>
 		focusMatchesCountryQuery(focus, statsBySlug, selectedCountryIsoCode),
 	);
+	const sdgFilteredFocuses = countryFilteredFocuses.filter((focus) => focusMatchesSdgQuery(focus, selectedSdg));
 	const filteredFocuses = searchQuery
-		? countryFilteredFocuses.filter((focus) => focusMatchesSearchQuery(focus, searchQuery))
-		: countryFilteredFocuses;
+		? sdgFilteredFocuses.filter((focus) => focusMatchesSearchQuery(focus, searchQuery))
+		: sdgFilteredFocuses;
 
 	return (
 		<div className="flex w-full flex-col gap-8">
 			<CmsHeader title={title} text={text} />
 			<div className="flex flex-wrap items-center justify-between gap-4">
-				<FocusesOverviewCountryFilter
-					allCountriesLabel={translator.t('focuses-page.all-countries', {
-						context: { count: countryOptions.length },
-					})}
-					countryOptions={countryOptions}
-					selectedCountryIsoCode={selectedCountryIsoCode}
-				/>
+				<div className="flex min-h-10 flex-1 flex-wrap items-center gap-2">
+					<FocusesOverviewCountryFilter
+						allCountriesLabel={translator.t('focuses-page.all-countries', {
+							context: { count: countryOptions.length },
+						})}
+						countryOptions={countryOptions}
+						selectedCountryIsoCode={selectedCountryIsoCode}
+					/>
+					<FocusesOverviewSdgFilter
+						allSdgsLabel={translator.t('focuses-page.all-sdgs', {
+							context: { count: sdgOptions.length },
+						})}
+						sdgOptions={sdgOptions}
+						selectedSdg={selectedSdg}
+					/>
+				</div>
 				<FocusesOverviewSearch
 					defaultValue={searchQuery}
 					label={translator.t('focuses-page.search-label')}
@@ -84,7 +101,7 @@ export const FocusesOverview = async ({ focuses, lang, region, title, text, sear
 									focusTitle={focusTitle}
 									recipientsCount={stats.recipientsInProgramsCount}
 									programsCount={stats.programsCount}
-									sdgsValue="-"
+									sdgValues={focus.content.sdgs}
 									labels={{
 										recipients: translator.t('focuses-page.recipients'),
 										programs: translator.t('focuses-page.programs'),

--- a/website/src/components/storyblok/focus/sdgs.ts
+++ b/website/src/components/storyblok/focus/sdgs.ts
@@ -1,4 +1,4 @@
-export const sdgs = {
+const sdgs = {
 	'1': {
 		number: 1,
 		title: 'No Poverty',

--- a/website/src/components/storyblok/focus/sdgs.ts
+++ b/website/src/components/storyblok/focus/sdgs.ts
@@ -1,0 +1,99 @@
+export const sdgs = {
+	'1': {
+		number: 1,
+		title: 'No Poverty',
+		color: '#E5243B',
+	},
+	'2': {
+		number: 2,
+		title: 'Zero Hunger',
+		color: '#DDA63A',
+	},
+	'3': {
+		number: 3,
+		title: 'Good Health and Well-being',
+		color: '#4C9F38',
+	},
+	'4': {
+		number: 4,
+		title: 'Quality Education',
+		color: '#C5192D',
+	},
+	'5': {
+		number: 5,
+		title: 'Gender Equality',
+		color: '#FF3A21',
+	},
+	'6': {
+		number: 6,
+		title: 'Clean Water and Sanitation',
+		color: '#26BDE2',
+	},
+	'7': {
+		number: 7,
+		title: 'Affordable and Clean Energy',
+		color: '#FCC30B',
+	},
+	'8': {
+		number: 8,
+		title: 'Decent Work and Economic Growth',
+		color: '#A21942',
+	},
+	'9': {
+		number: 9,
+		title: 'Industry, Innovation and Infrastructure',
+		color: '#FD6925',
+	},
+	'10': {
+		number: 10,
+		title: 'Reduced Inequalities',
+		color: '#DD1367',
+	},
+	'11': {
+		number: 11,
+		title: 'Sustainable Cities and Communities',
+		color: '#FD9D24',
+	},
+	'12': {
+		number: 12,
+		title: 'Responsible Consumption and Production',
+		color: '#BF8B2E',
+	},
+	'13': {
+		number: 13,
+		title: 'Climate Action',
+		color: '#3F7E44',
+	},
+	'14': {
+		number: 14,
+		title: 'Life Below Water',
+		color: '#0A97D9',
+	},
+	'15': {
+		number: 15,
+		title: 'Life on Land',
+		color: '#56C02B',
+	},
+	'16': {
+		number: 16,
+		title: 'Peace, Justice and Strong Institutions',
+		color: '#00689D',
+	},
+	'17': {
+		number: 17,
+		title: 'Partnerships for the Goals',
+		color: '#19486A',
+	},
+} as const;
+
+type SdgKey = keyof typeof sdgs;
+
+export type SdgValue = number | string;
+
+const isSdgKey = (value: string): value is SdgKey => value in sdgs;
+
+export const getSdg = (value: SdgValue) => {
+	const key = String(value).trim();
+
+	return isSdgKey(key) ? sdgs[key] : undefined;
+};

--- a/website/src/components/storyblok/focus/sdgs.ts
+++ b/website/src/components/storyblok/focus/sdgs.ts
@@ -90,7 +90,7 @@ type SdgKey = keyof typeof sdgs;
 
 export type SdgValue = number | string;
 
-const isSdgKey = (value: string): value is SdgKey => value in sdgs;
+const isSdgKey = (value: string): value is SdgKey => Object.prototype.hasOwnProperty.call(sdgs, value);
 
 export const getSdg = (value: SdgValue) => {
 	const key = String(value).trim();

--- a/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
+++ b/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
@@ -179,6 +179,7 @@ export interface Focus {
   impactMeasurementTitle?: string;
   impactMeasurementTeaserText?: string;
   impactMeasurementTeaserButtonLabel?: string;
+  sdgs?: (number | string)[];
   component: "Focus";
   _uid: string;
   [k: string]: unknown;

--- a/website/src/lib/i18n/locales/de/website-common.json
+++ b/website/src/lib/i18n/locales/de/website-common.json
@@ -83,6 +83,7 @@
 		"search-label": "Schwerpunkte suchen",
 		"search-placeholder": "Suchen",
 		"all-countries": "Alle Länder ({{count}})",
+		"all-sdgs": "Alle SDGs ({{count}})",
 		"recipients": "Empfänger:innen",
 		"programs": "Programme",
 		"sdgs": "SDGs",

--- a/website/src/lib/i18n/locales/en/website-common.json
+++ b/website/src/lib/i18n/locales/en/website-common.json
@@ -83,6 +83,7 @@
 		"search-label": "Search focuses",
 		"search-placeholder": "Search",
 		"all-countries": "All countries ({{count}})",
+		"all-sdgs": "All SDGs ({{count}})",
 		"recipients": "Recipients",
 		"programs": "Programs",
 		"sdgs": "SDGs",

--- a/website/src/lib/i18n/locales/fr/website-common.json
+++ b/website/src/lib/i18n/locales/fr/website-common.json
@@ -83,6 +83,7 @@
 		"search-label": "Rechercher des axes",
 		"search-placeholder": "Rechercher",
 		"all-countries": "Tous les pays ({{count}})",
+		"all-sdgs": "Tous les ODD ({{count}})",
 		"recipients": "Bénéficiaires",
 		"programs": "Programmes",
 		"sdgs": "ODD",

--- a/website/src/lib/i18n/locales/it/website-common.json
+++ b/website/src/lib/i18n/locales/it/website-common.json
@@ -83,6 +83,7 @@
 		"search-label": "Cerca focus",
 		"search-placeholder": "Cerca",
 		"all-countries": "Tutti i paesi ({{count}})",
+		"all-sdgs": "Tutti gli SDG ({{count}})",
 		"recipients": "Beneficiari",
 		"programs": "Programmi",
 		"sdgs": "SDG",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SDG filtering to the focuses overview, including a new SDG dropdown control and a translated “All SDGs” label.
  * Focus detail cards now display SDG badge(s) with an info tooltip, and SDG filtering is reflected in the URL for shareable, persistent results.
* **Bug Fixes**
  * Improved combined filtering behavior so country, SDG, and search work together reliably.
  * SDG values are validated before display; unrecognized SDGs are ignored and a placeholder is shown when none are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->