### PR TITLE
chore: change triggers back to main branch

### DIFF
--- a/.github/workflows/deploy-terraform-to-gcp-staging.yml
+++ b/.github/workflows/deploy-terraform-to-gcp-staging.yml
@@ -3,7 +3,7 @@ name: Website / Deploy with Terraform to GCP / Staging
 on:
   push:
     branches:
-      - develop
+      - main
 
 concurrency:
   group: deploy-terraform-gcp-staging

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - develop
     paths-ignore:
       - "recipients_app/**"
 jobs:

--- a/README.md
+++ b/README.md
@@ -172,24 +172,24 @@ http://localhost:4000/logs
 
 ## Development Flow
 
-The main integration branch for active development is `develop`.
+The main integration branch for active development is `main`.
 
-1. Create your feature branch from `develop`.
+1. Create your feature branch from `main`.
 2. Keep your changes focused on one issue or feature.
 3. Run the relevant checks locally.
-4. Open a pull request back into `develop`.
+4. Open a pull request back into `main`.
 5. Wait for CI and review.
 
 Example:
 
 ```bash
-git checkout develop
+git checkout main
 git pull
 git checkout -b fix/issue-2064-short-description
 ```
 
-Website checks run for pull requests and for pushes to `develop` and `main`.
-Staging deployment is connected to `develop`; production releases are handled
+Website checks run for pull requests and for pushes to `main`.
+Staging deployment is connected to `main`; production releases are handled
 by maintainers.
 
 Useful local checks for website changes:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the development flow guidance to use `main` as the primary integration branch.
  * Refreshed examples and CI wording to match current branch behavior.

* **Chores**
  * Adjusted automation triggers so website checks and staging deployment now run from pushes to `main` instead of `develop`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->