### PR TITLE
feat: add sorting by candidates count and alert for no candidates message

### DIFF
--- a/website/src/components/storyblok/focus/focus-detail-card.tsx
+++ b/website/src/components/storyblok/focus/focus-detail-card.tsx
@@ -1,5 +1,5 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/tool-tip';
-import { CircleDot, InfoIcon } from 'lucide-react';
+import { InfoIcon } from 'lucide-react';
 import NextLink from 'next/link';
 import { getSdg, type SdgValue } from './sdgs';
 
@@ -93,7 +93,10 @@ const FocusDetailCardSdgs = ({ values = [], label }: FocusDetailCardSdgsProps) =
 
 const AlertSection = ({ text }: { text: string }) => (
 	<div className="flex items-center gap-2 rounded-b-2xl px-4 py-2">
-		<CircleDot className="size-4 shrink-0 text-emerald-500" aria-hidden />
+		<span className="relative flex size-2 shrink-0" aria-hidden>
+			<span className="bg-confirm animation-duration-[2s] absolute inline-flex size-full animate-ping rounded-full opacity-75" />
+			<span className="bg-confirm relative inline-flex size-2 rounded-full" />
+		</span>
 		<p className="text-xs font-semibold text-slate-950">{text}</p>
 	</div>
 );

--- a/website/src/components/storyblok/focus/focus-detail-card.tsx
+++ b/website/src/components/storyblok/focus/focus-detail-card.tsx
@@ -1,7 +1,10 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/tool-tip';
+import { cn } from '@/lib/utils/cn';
 import { InfoIcon } from 'lucide-react';
 import NextLink from 'next/link';
 import { getSdg, type SdgValue } from './sdgs';
+
+type AlertVariant = 'confirm' | 'secondary';
 
 type FocusDetailCardLabels = {
 	recipients: string;
@@ -16,6 +19,7 @@ type FocusDetailCardProps = {
 	recipientsCount: number;
 	programsCount: number;
 	sdgValues?: SdgValue[];
+	alertVariant?: AlertVariant;
 	labels: FocusDetailCardLabels;
 };
 
@@ -91,12 +95,14 @@ const FocusDetailCardSdgs = ({ values = [], label }: FocusDetailCardSdgsProps) =
 	);
 };
 
-const AlertSection = ({ text }: { text: string }) => (
+const AlertSection = ({ text, variant }: { text: string; variant: AlertVariant }) => (
 	<div className="flex items-center gap-2 rounded-b-2xl px-4 py-2">
-		<span className="relative flex size-2 shrink-0" aria-hidden>
-			<span className="bg-confirm animation-duration-[2s] absolute inline-flex size-full animate-ping rounded-full opacity-75" />
-			<span className="bg-confirm relative inline-flex size-2 rounded-full" />
-		</span>
+		{variant === 'confirm' ? (
+			<span className="relative flex size-2 shrink-0" aria-hidden>
+				<span className="bg-confirm animation-duration-[2s] absolute inline-flex size-full animate-ping rounded-full opacity-75" />
+				<span className="bg-confirm relative inline-flex size-2 rounded-full" />
+			</span>
+		) : null}
 		<p className="text-xs font-semibold text-slate-950">{text}</p>
 	</div>
 );
@@ -107,12 +113,18 @@ export const FocusDetailCard = ({
 	recipientsCount,
 	programsCount,
 	sdgValues,
+	alertVariant = 'confirm',
 	labels,
 }: FocusDetailCardProps) => {
 	const titleId = `focus-card-title-${href}`;
 
 	return (
-		<div className="bg-confirm-foreground flex h-full flex-col rounded-2xl drop-shadow-md">
+		<div
+			className={cn(
+				'flex h-full flex-col rounded-2xl drop-shadow-md',
+				alertVariant === 'confirm' ? 'bg-confirm-foreground' : 'bg-secondary',
+			)}
+		>
 			<div className="border-border relative flex min-w-0 flex-1 flex-col gap-3 rounded-2xl border bg-white p-6">
 				<NextLink
 					href={href}
@@ -133,7 +145,7 @@ export const FocusDetailCard = ({
 					</div>
 				</div>
 			</div>
-			{labels.candidatesReady ? <AlertSection text={labels.candidatesReady} /> : null}
+			{labels.candidatesReady ? <AlertSection text={labels.candidatesReady} variant={alertVariant} /> : null}
 		</div>
 	);
 };

--- a/website/src/components/storyblok/focus/focuses-overview.server.test.ts
+++ b/website/src/components/storyblok/focus/focuses-overview.server.test.ts
@@ -9,6 +9,7 @@ import {
 	getSdgFilterOptions,
 	getSdgQuery,
 	getSearchQuery,
+	sortFocusesByCandidatesCountDesc,
 } from './focuses-overview.server';
 
 type CreateFocusInput = {
@@ -107,5 +108,17 @@ describe('focuses overview server helpers', () => {
 		const searchFilteredFocuses = focuses.filter((focus) => focusMatchesSearchQuery(focus, 'medical health'));
 
 		expect(searchFilteredFocuses.map((focus) => focus.content.portalSlug)).toEqual(['health']);
+	});
+
+	it('sorts focuses by candidates count descending', () => {
+		const missingStatsFocus = createFocus({
+			slug: 'livelihood',
+			portalSlug: 'livelihood',
+			title: 'Livelihood',
+			text: 'Cash transfers for livelihood support',
+		});
+		const sortedFocuses = sortFocusesByCandidatesCountDesc([...focuses, missingStatsFocus], statsBySlug);
+
+		expect(sortedFocuses.map((focus) => focus.content.portalSlug)).toEqual(['health', 'education', 'livelihood']);
 	});
 });

--- a/website/src/components/storyblok/focus/focuses-overview.server.ts
+++ b/website/src/components/storyblok/focus/focuses-overview.server.ts
@@ -65,6 +65,14 @@ export const focusMatchesSdgQuery = (focus: FocusStory, selectedSdg: string | un
 	return focus.content.sdgs?.some((value) => String(getSdg(value)?.number) === selectedSdg) ?? false;
 };
 
+export const sortFocusesByCandidatesCountDesc = (focuses: FocusStory[], statsBySlug: PublicFocusStatsBySlugMap) =>
+	[...focuses].sort((focusA, focusB) => {
+		const candidatesCountA = statsBySlug[getFocusSlug(focusA)]?.candidatesCount ?? 0;
+		const candidatesCountB = statsBySlug[getFocusSlug(focusB)]?.candidatesCount ?? 0;
+
+		return candidatesCountB - candidatesCountA;
+	});
+
 export const getCountryFilterOptions = (focuses: FocusStory[], statsBySlug: PublicFocusStatsBySlugMap): FilterOption[] => {
 	const optionsByCountryIsoCode = new Map<string, FilterOption>();
 

--- a/website/src/components/storyblok/focus/focuses-overview.tsx
+++ b/website/src/components/storyblok/focus/focuses-overview.tsx
@@ -18,6 +18,7 @@ import {
 	getSdgFilterOptions,
 	getSdgQuery,
 	getSearchQuery,
+	sortFocusesByCandidatesCountDesc,
 } from './focuses-overview.server';
 
 type Props = {
@@ -50,6 +51,7 @@ export const FocusesOverview = async ({ focuses, lang, region, title, text, sear
 	const filteredFocuses = searchQuery
 		? sdgFilteredFocuses.filter((focus) => focusMatchesSearchQuery(focus, searchQuery))
 		: sdgFilteredFocuses;
+	const sortedFocuses = sortFocusesByCandidatesCountDesc(filteredFocuses, statsBySlug);
 
 	return (
 		<div className="flex w-full flex-col gap-8">
@@ -78,13 +80,13 @@ export const FocusesOverview = async ({ focuses, lang, region, title, text, sear
 				/>
 			</div>
 			{hasStatsError ? <p className="text-destructive">{translator.t('focuses-page.load-stats-error')}</p> : null}
-			{filteredFocuses.length === 0 ? (
+			{sortedFocuses.length === 0 ? (
 				<p className="text-muted-foreground">
 					{translator.t(hasActiveFilters ? 'focuses-page.no-results' : 'focuses-page.empty')}
 				</p>
 			) : (
 				<ul className="grid grid-cols-1 gap-6 md:grid-cols-3">
-					{filteredFocuses.map((focus) => {
+					{sortedFocuses.map((focus) => {
 						const focusSlug = getFocusSlug(focus);
 						const focusTitle = getFocusTitle(focus.content);
 						const stats = statsBySlug[focusSlug] ?? {
@@ -102,6 +104,7 @@ export const FocusesOverview = async ({ focuses, lang, region, title, text, sear
 									recipientsCount={stats.recipientsInProgramsCount}
 									programsCount={stats.programsCount}
 									sdgValues={focus.content.sdgs}
+									alertVariant={stats.candidatesCount > 0 ? 'confirm' : 'secondary'}
 									labels={{
 										recipients: translator.t('focuses-page.recipients'),
 										programs: translator.t('focuses-page.programs'),
@@ -114,7 +117,7 @@ export const FocusesOverview = async ({ focuses, lang, region, title, text, sear
 															: 'focuses-page.candidates-ready-to-enroll_other',
 														{ context: { count: stats.candidatesCount } },
 													)
-												: undefined,
+												: translator.t('focuses-page.no-candidates'),
 									}}
 								/>
 							</li>

--- a/website/src/lib/i18n/locales/de/website-common.json
+++ b/website/src/lib/i18n/locales/de/website-common.json
@@ -97,6 +97,7 @@
 		"candidate-plural": "Kandidat:innen",
 		"candidates-ready-to-enroll_one": "{{count}} Kandidat:in bereit für die Einschreibung",
 		"candidates-ready-to-enroll_other": "{{count}} Kandidat:innen bereit für die Einschreibung",
+		"no-candidates": "Derzeit gibt es keine Kandidat:innen",
 		"about": "Über"
 	},
 	"programs-page": {

--- a/website/src/lib/i18n/locales/en/website-common.json
+++ b/website/src/lib/i18n/locales/en/website-common.json
@@ -97,6 +97,7 @@
 		"candidate-plural": "candidates",
 		"candidates-ready-to-enroll_one": "{{count}} candidate ready to enroll",
 		"candidates-ready-to-enroll_other": "{{count}} candidates ready to enroll",
+		"no-candidates": "There are currently no candidates",
 		"about": "About"
 	},
 	"programs-page": {

--- a/website/src/lib/i18n/locales/fr/website-common.json
+++ b/website/src/lib/i18n/locales/fr/website-common.json
@@ -97,6 +97,7 @@
 		"candidate-plural": "candidats",
 		"candidates-ready-to-enroll_one": "{{count}} candidat prêt à s'inscrire",
 		"candidates-ready-to-enroll_other": "{{count}} candidats prêts à s'inscrire",
+		"no-candidates": "Il n'y a actuellement aucun candidat",
 		"about": "À propos de"
 	},
 	"programs-page": {

--- a/website/src/lib/i18n/locales/it/website-common.json
+++ b/website/src/lib/i18n/locales/it/website-common.json
@@ -97,6 +97,7 @@
 		"candidate-plural": "candidati",
 		"candidates-ready-to-enroll_one": "{{count}} candidato pronto per l'iscrizione",
 		"candidates-ready-to-enroll_other": "{{count}} candidati pronti per l'iscrizione",
+		"no-candidates": "Al momento non ci sono candidati",
 		"about": "Informazioni su"
 	},
 	"programs-page": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Focus overview items are now sorted by candidate count, so the most active entries appear first.
  * Focus cards can now display different alert styles depending on whether candidates are available.

* **Bug Fixes**
  * Improved the empty-state experience with a clearer “no candidates” message when none are available.

* **Documentation**
  * Added the new “no candidates” message across supported languages, including English, German, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->