### PR TITLE
Fix : donation wizard currency label : #2163

### DIFF
--- a/website/src/components/donation-wizard/steps/step-amount/donation-amount-fields.tsx
+++ b/website/src/components/donation-wizard/steps/step-amount/donation-amount-fields.tsx
@@ -76,7 +76,7 @@ export const DonationAmountFields = ({
 					)}
 				>
 					<label htmlFor={monthlyIncomeInputId} className="text-[10px] font-medium">
-						{translations.monthlyIncomeLabel}
+						{translations.monthlyIncomeLabel}({currency})
 					</label>
 					<Input
 						id={monthlyIncomeInputId}

--- a/website/src/lib/i18n/locales/de/donation-wizard.json
+++ b/website/src/lib/i18n/locales/de/donation-wizard.json
@@ -11,7 +11,7 @@
 	},
 	"stepAmount": {
 		"title": "Spenden",
-		"monthly-income-label": "Ihr monatliches Einkommen (CHF)",
+		"monthly-income-label": "Ihr monatliches Einkommen ",
 		"choose-own-amount": "Oder eigenen Betrag wählen",
 		"your-one-percent": "Ihr 1%",
 		"other": "Andere",

--- a/website/src/lib/i18n/locales/en/donation-wizard.json
+++ b/website/src/lib/i18n/locales/en/donation-wizard.json
@@ -11,7 +11,7 @@
 	},
 	"stepAmount": {
 		"title": "Make a donation",
-		"monthly-income-label": "Your monthly income (CHF)",
+		"monthly-income-label": "Your monthly income ",
 		"choose-own-amount": "Or choose own amount",
 		"your-one-percent": "Your 1%",
 		"other": "Other",

--- a/website/src/lib/i18n/locales/fr/donation-wizard.json
+++ b/website/src/lib/i18n/locales/fr/donation-wizard.json
@@ -11,7 +11,7 @@
 	},
 	"stepAmount": {
 		"title": "Faire un don",
-		"monthly-income-label": "Votre revenu mensuel (CHF)",
+		"monthly-income-label": "Votre revenu mensuel ",
 		"choose-own-amount": "Ou choisis ton propre montant",
 		"your-one-percent": "Votre 1%",
 		"other": "Autre",

--- a/website/src/lib/i18n/locales/it/donation-wizard.json
+++ b/website/src/lib/i18n/locales/it/donation-wizard.json
@@ -11,7 +11,7 @@
 	},
 	"stepAmount": {
 		"title": "Fai una donazione",
-		"monthly-income-label": "Il tuo reddito mensile (CHF)",
+		"monthly-income-label": "Il tuo reddito mensile ",
 		"choose-own-amount": "Oppure scegli un importo personalizzato",
 		"your-one-percent": "Il tuo 1%",
 		"other": "Altro",


### PR DESCRIPTION
### Summary

* Replaced the hardcoded currency label in the donation wizard with the currently selected currency.
* Updated the donation wizard translations to remove the hardcoded `CHF` from all supported languages.
* Ensured the donation amount fields and CTA consistently reflect the selected currency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the donation wizard’s monthly income label to display the current currency alongside the label where applicable.
  * Refreshed translations so the label now appears more consistently across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->