### PR TITLE
feat: add demo-surveys

### DIFF
--- a/website/src/app/[lang]/[region]/survey/demo/[survey]/page.tsx
+++ b/website/src/app/[lang]/[region]/survey/demo/[survey]/page.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { SurveyQuestionnaire } from '@/generated/prisma/enums';
+import { useTranslator } from '@/lib/hooks/useTranslator';
+import { LANGUAGE_CODES, type LanguageCode } from '@/lib/types/language';
+import { use } from 'react';
+import { Model } from 'survey-core';
+import 'survey-core/survey-core.min.css';
+import { BorderlessLightPanelless } from 'survey-core/themes';
+import { Survey as SurveyReact } from 'survey-react-ui';
+import { settings } from '../../[recipient]/[survey]/common';
+import { getQuestionnaire } from '../../[recipient]/[survey]/questionnaires';
+
+type DemoSurveyId = 'onboarding' | 'checkin' | 'offboarding' | 'followup';
+
+type DemoSurveyPageProps = {
+	params: Promise<{
+		lang: string;
+		survey: string;
+	}>;
+};
+
+const DEMO_SURVEYS: Record<DemoSurveyId, { questionnaire: SurveyQuestionnaire; titleKey: string }> = {
+	onboarding: {
+		questionnaire: SurveyQuestionnaire.onboarding,
+		titleKey: 'titleOnboarding',
+	},
+	checkin: {
+		questionnaire: SurveyQuestionnaire.checkin,
+		titleKey: 'titleCheckin',
+	},
+	offboarding: {
+		questionnaire: SurveyQuestionnaire.offboarding,
+		titleKey: 'titleOffboarding',
+	},
+	followup: {
+		questionnaire: SurveyQuestionnaire.offboarded_checkin,
+		titleKey: 'titleFollowup',
+	},
+};
+
+const isDemoSurveyId = (value: string): value is DemoSurveyId => value in DEMO_SURVEYS;
+
+const isLanguageCode = (value: string): value is LanguageCode => LANGUAGE_CODES.some((code) => code === value);
+
+export default function Page({ params }: DemoSurveyPageProps) {
+	const { lang, survey } = use(params);
+	const language = isLanguageCode(lang) ? lang : 'en';
+	const translator = useTranslator(language, 'website-survey');
+
+	if (!isDemoSurveyId(survey)) {
+		return (
+			<div className="text-destructive bg-destructive-foreground mx-auto max-w-md rounded-2xl px-5 py-4 text-sm">
+				Unknown demo survey.
+			</div>
+		);
+	}
+
+	if (!translator) {
+		return <div>{'Loading...'}</div>;
+	}
+
+	const demoSurvey = DEMO_SURVEYS[survey];
+	const model = new Model({
+		...settings(translator.t),
+		pages: getQuestionnaire(demoSurvey.questionnaire, translator.t, 'Demo Recipient'),
+	});
+	model.applyTheme(BorderlessLightPanelless);
+
+	return (
+		<section className="w-site-width max-w-content mx-auto px-4 py-6 sm:py-10 lg:py-14">
+			<div className="bg-card/95 ring-foreground/5 overflow-hidden rounded-[2rem] shadow-[0_24px_80px_rgba(31,65,101,0.12)] ring-1 backdrop-blur">
+				<div className="px-4 py-6 sm:px-8 sm:py-8 lg:px-10">
+					<div className="mb-6 space-y-2">
+						<h1 className="text-3xl font-bold tracking-tight">{translator.t(demoSurvey.titleKey)}</h1>
+						<p className="text-muted-foreground text-sm">{translator.t('demo')}</p>
+					</div>
+					<SurveyReact model={model} />
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/website/src/lib/i18n/locales/de/website-survey.json
+++ b/website/src/lib/i18n/locales/de/website-survey.json
@@ -1,5 +1,10 @@
 {
+	"titleOnboarding": "Onboarding Umfrage",
+	"titleCheckin": "Check-in Umfrage",
+	"titleOffboarding": "Offboarding Umfrage",
+	"titleFollowup": "Follow-up Umfrage",
 	"select": "Auswählen",
+	"demo": "Im Demomodus kann die Umfrage nicht gespeichert werden",
 	"survey": {
 		"common": {
 			"start": "Starten",

--- a/website/src/lib/i18n/locales/en/website-survey.json
+++ b/website/src/lib/i18n/locales/en/website-survey.json
@@ -1,5 +1,10 @@
 {
+	"titleOnboarding": "Onboarding Survey",
+	"titleCheckin": "Check-in Survey",
+	"titleOffboarding": "Offboarding Survey",
+	"titleFollowup": "Follow-up Survey",
 	"select": "Select",
+	"demo": "In demo mode the survey can't be saved",
 	"survey": {
 		"common": {
 			"start": "Start",

--- a/website/src/lib/i18n/locales/fr/website-survey.json
+++ b/website/src/lib/i18n/locales/fr/website-survey.json
@@ -1,5 +1,10 @@
 {
+	"titleOnboarding": "Enquête d'onboarding",
+	"titleCheckin": "Enquête de check-in",
+	"titleOffboarding": "Enquête d'offboarding",
+	"titleFollowup": "Enquête de follow-up",
 	"select": "Sélectionner",
+	"demo": "En mode démo, l'enquête ne peut pas être sauvegardée",
 	"survey": {
 		"common": {
 			"start": "Démarrer",

--- a/website/src/lib/i18n/locales/it/website-survey.json
+++ b/website/src/lib/i18n/locales/it/website-survey.json
@@ -1,5 +1,10 @@
 {
+	"titleOnboarding": "Questionario di onboarding",
+	"titleCheckin": "Questionario di check-in",
+	"titleOffboarding": "Questionario di offboarding",
+	"titleFollowup": "Questionario di follow-up",
 	"select": "Seleziona",
+	"demo": "In modalità demo il questionario non può essere salvato",
 	"survey": {
 		"common": {
 			"start": "Inizia",

--- a/website/src/lib/i18n/locales/kri/website-survey.json
+++ b/website/src/lib/i18n/locales/kri/website-survey.json
@@ -1,4 +1,9 @@
 {
+	"titleOnboarding": "Onboarding Sɔve",
+	"titleCheckin": "Check-in Sɔve",
+	"titleOffboarding": "Offboarding Sɔve",
+	"titleFollowup": "Follow-up Sɔve",
+	"demo": "Na demo mode, di sɔve nɔ go sev",
 	"survey": {
 		"common": {
 			"start": "Stat",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new demo survey page that displays embedded surveys for supported survey types.
  * Introduced translated page titles and a demo subtitle for the survey experience.
  * Expanded survey text in English, German, French, Italian, and Kri for onboarding, check-in, offboarding, and follow-up.

* **Bug Fixes**
  * Shows a clear message when an unsupported demo survey is requested.
  * Displays a loading state until translations are ready.
  * Added a demo-mode notice indicating surveys can’t be saved in demo mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->