### PR TITLE
fix(website): allow Cloudflare Insights and Mux Data in CSP

### DIFF
--- a/website/csp.ts
+++ b/website/csp.ts
@@ -14,6 +14,7 @@ const PRODUCTION_SCRIPT_SRC = [
 	'https://js.stripe.com',
 	'https://checkout.stripe.com',
 	'https://app.storyblok.com',
+	'https://static.cloudflareinsights.com',
 ] as const;
 
 const DEVELOPMENT_SCRIPT_SRC_EXTRA = ["'unsafe-eval'"] as const;
@@ -59,7 +60,10 @@ const PRODUCTION_CONNECT_SRC = [
 	'https://o4507045017026560.ingest.us.sentry.io',
 	'https://*.mux.com',
 	'https://*.edgemv.mux.com',
+	'https://*.litix.io',
 	'https://a.storyblok.com',
+	'https://static.cloudflareinsights.com',
+	'https://cloudflareinsights.com',
 ] as const;
 
 const LOCALHOST_CONNECT_SRC = ['http://localhost:*', 'ws://localhost:*'] as const;

--- a/website/src/components/content-blocks/hero-video.tsx
+++ b/website/src/components/content-blocks/hero-video.tsx
@@ -87,6 +87,7 @@ export const HeroVideoBlock = ({ blok, lang, subtitleUrl, translations, donation
 					muted={isMuted}
 					autoPlay={!disableAutoplay}
 					playsInline
+					crossOrigin="anonymous"
 					onPlay={() => setIsPlaying(true)}
 					onPause={() => setIsPlaying(false)}
 				>


### PR DESCRIPTION
Staging blocked Cloudflare's beacon script and Mux Data beacons to litix.io. Also set crossOrigin on the hero Mux video so cross-origin VTT captions can load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production video playback and loading for cross-origin media.
  * Enabled required Cloudflare Insights connections and scripts in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->