### PR TITLE
fix: adjust fontsize in country statistics

### DIFF
--- a/website/src/components/storyblok/country/country-statistics.tsx
+++ b/website/src/components/storyblok/country/country-statistics.tsx
@@ -128,7 +128,7 @@ export const CountryStatistics = async ({ countryIsoCode, countryName, lang }: P
 		<BlockWrapper>
 			<section className="mx-auto max-w-4xl">
 				<div className="flex flex-col items-center gap-6">
-					<h2 className="text-primary text-center text-3xl leading-tight font-bold md:text-4xl">
+					<h2 className="text-primary text-center text-4xl leading-tight font-bold">
 						{translator.t('countries-page.statistics.title')}
 					</h2>
 					<div className="border-border bg-background w-full overflow-hidden rounded-[calc(var(--radius)+4px)] border shadow-[0px_4px_28px_0px_rgba(0,30,101,0.07)]">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the country statistics page title to use a consistent larger text size across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->