### PR TITLE
Fix Sentry SI-MOBILEAPP-5V: MapperException: Failed to decode (Recipient).paymentInformation(PaymentInformation?).code: Parameter code is missing.

### DIFF
--- a/recipients_app/lib/data/datasource/demo/user_demo_data_source.dart
+++ b/recipients_app/lib/data/datasource/demo/user_demo_data_source.dart
@@ -108,7 +108,6 @@ class UserDemoDataSource implements UserDataSource {
         id: "demo",
         mobileMoneyProviderId: "demo",
         mobileMoneyProvider: const MobileMoneyProvider(id: "demo", name: "Demo Mobile Money Provider"),
-        code: "7843754",
         phoneId: "demo",
         createdAt: DateTime.now(),
         updatedAt: DateTime.now(),

--- a/recipients_app/lib/data/models/payment_information.dart
+++ b/recipients_app/lib/data/models/payment_information.dart
@@ -8,9 +8,8 @@ part "payment_information.mapper.dart";
 @MappableClass()
 class PaymentInformation with PaymentInformationMappable {
   final String id;
-  final String mobileMoneyProviderId;
-  final MobileMoneyProvider mobileMoneyProvider;
-  final String code;
+  final String? mobileMoneyProviderId;
+  final MobileMoneyProvider? mobileMoneyProvider;
   final String phoneId;
   final Phone phone;
   @MappableField(hook: DateTimeHook())
@@ -20,12 +19,11 @@ class PaymentInformation with PaymentInformationMappable {
 
   const PaymentInformation({
     required this.id,
-    required this.mobileMoneyProviderId,
-    required this.mobileMoneyProvider,
-    required this.code,
     required this.phoneId,
     required this.phone,
     required this.createdAt,
+    this.mobileMoneyProviderId,
+    this.mobileMoneyProvider,
     this.updatedAt,
   });
 }

--- a/recipients_app/lib/data/models/payment_information.mapper.dart
+++ b/recipients_app/lib/data/models/payment_information.mapper.dart
@@ -15,8 +15,8 @@ class PaymentInformationMapper extends ClassMapperBase<PaymentInformation> {
   static PaymentInformationMapper ensureInitialized() {
     if (_instance == null) {
       MapperContainer.globals.use(_instance = PaymentInformationMapper._());
-      MobileMoneyProviderMapper.ensureInitialized();
       PhoneMapper.ensureInitialized();
+      MobileMoneyProviderMapper.ensureInitialized();
     }
     return _instance!;
   }
@@ -26,19 +26,6 @@ class PaymentInformationMapper extends ClassMapperBase<PaymentInformation> {
 
   static String _$id(PaymentInformation v) => v.id;
   static const Field<PaymentInformation, String> _f$id = Field('id', _$id);
-  static String _$mobileMoneyProviderId(PaymentInformation v) =>
-      v.mobileMoneyProviderId;
-  static const Field<PaymentInformation, String> _f$mobileMoneyProviderId =
-      Field('mobileMoneyProviderId', _$mobileMoneyProviderId);
-  static MobileMoneyProvider _$mobileMoneyProvider(PaymentInformation v) =>
-      v.mobileMoneyProvider;
-  static const Field<PaymentInformation, MobileMoneyProvider>
-  _f$mobileMoneyProvider = Field('mobileMoneyProvider', _$mobileMoneyProvider);
-  static String _$code(PaymentInformation v) => v.code;
-  static const Field<PaymentInformation, String> _f$code = Field(
-    'code',
-    _$code,
-  );
   static String _$phoneId(PaymentInformation v) => v.phoneId;
   static const Field<PaymentInformation, String> _f$phoneId = Field(
     'phoneId',
@@ -55,6 +42,18 @@ class PaymentInformationMapper extends ClassMapperBase<PaymentInformation> {
     _$createdAt,
     hook: DateTimeHook(),
   );
+  static String? _$mobileMoneyProviderId(PaymentInformation v) =>
+      v.mobileMoneyProviderId;
+  static const Field<PaymentInformation, String> _f$mobileMoneyProviderId =
+      Field('mobileMoneyProviderId', _$mobileMoneyProviderId, opt: true);
+  static MobileMoneyProvider? _$mobileMoneyProvider(PaymentInformation v) =>
+      v.mobileMoneyProvider;
+  static const Field<PaymentInformation, MobileMoneyProvider>
+  _f$mobileMoneyProvider = Field(
+    'mobileMoneyProvider',
+    _$mobileMoneyProvider,
+    opt: true,
+  );
   static DateTime? _$updatedAt(PaymentInformation v) => v.updatedAt;
   static const Field<PaymentInformation, DateTime> _f$updatedAt = Field(
     'updatedAt',
@@ -66,24 +65,22 @@ class PaymentInformationMapper extends ClassMapperBase<PaymentInformation> {
   @override
   final MappableFields<PaymentInformation> fields = const {
     #id: _f$id,
-    #mobileMoneyProviderId: _f$mobileMoneyProviderId,
-    #mobileMoneyProvider: _f$mobileMoneyProvider,
-    #code: _f$code,
     #phoneId: _f$phoneId,
     #phone: _f$phone,
     #createdAt: _f$createdAt,
+    #mobileMoneyProviderId: _f$mobileMoneyProviderId,
+    #mobileMoneyProvider: _f$mobileMoneyProvider,
     #updatedAt: _f$updatedAt,
   };
 
   static PaymentInformation _instantiate(DecodingData data) {
     return PaymentInformation(
       id: data.dec(_f$id),
-      mobileMoneyProviderId: data.dec(_f$mobileMoneyProviderId),
-      mobileMoneyProvider: data.dec(_f$mobileMoneyProvider),
-      code: data.dec(_f$code),
       phoneId: data.dec(_f$phoneId),
       phone: data.dec(_f$phone),
       createdAt: data.dec(_f$createdAt),
+      mobileMoneyProviderId: data.dec(_f$mobileMoneyProviderId),
+      mobileMoneyProvider: data.dec(_f$mobileMoneyProvider),
       updatedAt: data.dec(_f$updatedAt),
     );
   }
@@ -159,17 +156,16 @@ abstract class PaymentInformationCopyWith<
   $Out
 >
     implements ClassCopyWith<$R, $In, $Out> {
-  MobileMoneyProviderCopyWith<$R, MobileMoneyProvider, MobileMoneyProvider>
-  get mobileMoneyProvider;
   PhoneCopyWith<$R, Phone, Phone> get phone;
+  MobileMoneyProviderCopyWith<$R, MobileMoneyProvider, MobileMoneyProvider>?
+  get mobileMoneyProvider;
   $R call({
     String? id,
-    String? mobileMoneyProviderId,
-    MobileMoneyProvider? mobileMoneyProvider,
-    String? code,
     String? phoneId,
     Phone? phone,
     DateTime? createdAt,
+    String? mobileMoneyProviderId,
+    MobileMoneyProvider? mobileMoneyProvider,
     DateTime? updatedAt,
   });
   PaymentInformationCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
@@ -186,40 +182,41 @@ class _PaymentInformationCopyWithImpl<$R, $Out>
   late final ClassMapperBase<PaymentInformation> $mapper =
       PaymentInformationMapper.ensureInitialized();
   @override
-  MobileMoneyProviderCopyWith<$R, MobileMoneyProvider, MobileMoneyProvider>
-  get mobileMoneyProvider => $value.mobileMoneyProvider.copyWith.$chain(
-    (v) => call(mobileMoneyProvider: v),
-  );
-  @override
   PhoneCopyWith<$R, Phone, Phone> get phone =>
       $value.phone.copyWith.$chain((v) => call(phone: v));
   @override
+  MobileMoneyProviderCopyWith<$R, MobileMoneyProvider, MobileMoneyProvider>?
+  get mobileMoneyProvider => $value.mobileMoneyProvider?.copyWith.$chain(
+    (v) => call(mobileMoneyProvider: v),
+  );
+  @override
   $R call({
     String? id,
-    String? mobileMoneyProviderId,
-    MobileMoneyProvider? mobileMoneyProvider,
-    String? code,
     String? phoneId,
     Phone? phone,
     DateTime? createdAt,
+    Object? mobileMoneyProviderId = $none,
+    Object? mobileMoneyProvider = $none,
     Object? updatedAt = $none,
   }) => $apply(
     FieldCopyWithData({
       if (id != null) #id: id,
-      if (mobileMoneyProviderId != null)
-        #mobileMoneyProviderId: mobileMoneyProviderId,
-      if (mobileMoneyProvider != null)
-        #mobileMoneyProvider: mobileMoneyProvider,
-      if (code != null) #code: code,
       if (phoneId != null) #phoneId: phoneId,
       if (phone != null) #phone: phone,
       if (createdAt != null) #createdAt: createdAt,
+      if (mobileMoneyProviderId != $none)
+        #mobileMoneyProviderId: mobileMoneyProviderId,
+      if (mobileMoneyProvider != $none)
+        #mobileMoneyProvider: mobileMoneyProvider,
       if (updatedAt != $none) #updatedAt: updatedAt,
     }),
   );
   @override
   PaymentInformation $make(CopyWithData data) => PaymentInformation(
     id: data.get(#id, or: $value.id),
+    phoneId: data.get(#phoneId, or: $value.phoneId),
+    phone: data.get(#phone, or: $value.phone),
+    createdAt: data.get(#createdAt, or: $value.createdAt),
     mobileMoneyProviderId: data.get(
       #mobileMoneyProviderId,
       or: $value.mobileMoneyProviderId,
@@ -228,10 +225,6 @@ class _PaymentInformationCopyWithImpl<$R, $Out>
       #mobileMoneyProvider,
       or: $value.mobileMoneyProvider,
     ),
-    code: data.get(#code, or: $value.code),
-    phoneId: data.get(#phoneId, or: $value.phoneId),
-    phone: data.get(#phone, or: $value.phone),
-    createdAt: data.get(#createdAt, or: $value.createdAt),
     updatedAt: data.get(#updatedAt, or: $value.updatedAt),
   );
 

--- a/recipients_app/lib/data/repositories/messaging_repository.dart
+++ b/recipients_app/lib/data/repositories/messaging_repository.dart
@@ -1,6 +1,9 @@
 // "unreachable_from_main" is ignored beacuse of the vm:entry-point function "_firebaseMessagingBackgroundHandler"
 // ignore_for_file: unreachable_from_main
 import "dart:developer";
+import "dart:io";
+
+import "package:firebase_core/firebase_core.dart";
 import "package:firebase_messaging/firebase_messaging.dart";
 
 /// This must be a top level function in order to work
@@ -80,7 +83,25 @@ class MessagingRepository {
   }
 
   Future<String?> getToken() async {
-    return await messaging.getToken();
+    const maxRetries = 3;
+    for (var attempt = 0; attempt < maxRetries; attempt++) {
+      if (Platform.isIOS) {
+        // The APNS token may not be registered with the device yet, so wait a bit before
+        // asking for the FCM token.
+        await Future.delayed(const Duration(seconds: 1));
+      }
+      try {
+        return await messaging.getToken();
+      } on FirebaseException catch (e) {
+        if (e.code != "apns-token-not-set") rethrow;
+        if (attempt == maxRetries - 1) {
+          log("PUSHNOTIFICATION: Failed to get FCM token after $maxRetries retries: ${e.code}");
+          break;
+        }
+        log("PUSHNOTIFICATION: APNS token not yet set, retrying (${attempt + 1}/$maxRetries)");
+      }
+    }
+    return null;
   }
 
   static void logRemoteMessage(RemoteMessage message) {

--- a/recipients_app/lib/view/pages/account_page.dart
+++ b/recipients_app/lib/view/pages/account_page.dart
@@ -76,7 +76,7 @@ class AccountPageState extends State<AccountPage> {
       text: widget.recipient.paymentInformation?.phone.number ?? "",
     );
     _mobileMoneyProviderController = TextEditingController(
-      text: widget.recipient.paymentInformation?.mobileMoneyProvider.name ?? "",
+      text: widget.recipient.paymentInformation?.mobileMoneyProvider?.name ?? "???",
     );
     _contactNumberController = TextEditingController(
       text: widget.recipient.contact.phone?.number ?? "",

--- a/recipients_app/pubspec.yaml
+++ b/recipients_app/pubspec.yaml
@@ -2,7 +2,7 @@ name: app
 description: Social Income App
 
 publish_to: "none"
-version: 2.0.0+1 # The build number is set in Codemagic automatically.
+version: 2.0.1+1 # The build number is set in Codemagic automatically.
 
 environment:
   sdk: ">=3.8.0 <4.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of payment information when mobile money provider details are unavailable.
  * Prevented account pages from displaying errors when provider information is missing.
  * Removed the obsolete payment code requirement from payment details.
  * Updated demo payment data to reflect the revised information requirements.
  * Improved notification token retrieval by retrying temporary iOS token availability issues and safely handling unavailable tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->