### PR TITLE
ci: skip website workflows for recipients_app-only changes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,9 @@
 name: CodeQL
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - "recipients_app/**"
 
 jobs:
   analyze:

--- a/.github/workflows/deploy-terraform-to-gcp-staging.yml
+++ b/.github/workflows/deploy-terraform-to-gcp-staging.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "recipients_app/**"
 
 concurrency:
   group: deploy-terraform-gcp-staging

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "recipients_app/**"
 
 jobs:
   deploy:


### PR DESCRIPTION
Avoid running CodeQL (TypeScript-only), staging Terraform deploy, and Firebase rules deploy when a change only touches the mobile app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to run for relevant pull requests and pushes while excluding changes limited to the recipients app.
  * Reduced unnecessary security checks, staging deployments, and rule validations for unrelated changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->