### PR TITLE
feat: postfinance reserves on transparency page

### DIFF
--- a/website/infra/cloud-scheduler.tf
+++ b/website/infra/cloud-scheduler.tf
@@ -13,6 +13,21 @@ resource "google_cloud_scheduler_job" "google_cloud_scheduler_job_exchange_rate"
   }
 }
 
+resource "google_cloud_scheduler_job" "google_cloud_scheduler_job_reserves_calculation" {
+  name        = "reserves-calculation-job"
+  description = "Calculates reserves every day at midnight"
+  schedule    = "0 0 * * *" # Cron expression for daily execution
+  time_zone   = "UTC"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.website_domain}/api/v1/reserves-calculation"
+    headers = {
+      "x-api-key" = var.scheduler_api_key
+    }
+  }
+}
+
 resource "google_cloud_scheduler_job" "google_cloud_scheduler_job_post_finance_import" {
   name        = "post-finance-import-job"
   description = "Imports payment files into Firebase Storage and extracts payment events and contributions into DB every hour"

--- a/website/src/app/api/v1/reserves-calculation/route.ts
+++ b/website/src/app/api/v1/reserves-calculation/route.ts
@@ -1,7 +1,8 @@
+import { services } from '@/lib/services/services';
 import { logger } from '@/lib/utils/logger';
 import { NextRequest, NextResponse } from 'next/server';
 
-export const POST = (request: NextRequest) => {
+export const POST = async (request: NextRequest) => {
 	const apiKey = request.headers.get('x-api-key');
 
 	if (apiKey !== process.env.SCHEDULER_API_KEY || !process.env.SCHEDULER_API_KEY) {
@@ -10,8 +11,26 @@ export const POST = (request: NextRequest) => {
 		return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
 	}
 
-	// TODO: Call external APIs, collect reserve values, and write them to the database.
-	logger.info('Reserves calculation endpoint called');
+	if (!process.env.POSTFINANCE_PAYMENTS_FILES_BUCKET) {
+		logger.alert('Payment files storage bucket env var not set');
 
-	return NextResponse.json({}, { status: 201 });
+		return NextResponse.json({ ok: false, error: 'Internal server error' }, { status: 500 });
+	}
+
+	const service = services.createReservesCalculation(process.env.POSTFINANCE_PAYMENTS_FILES_BUCKET);
+
+	try {
+		const result = await service.calculate();
+		if (!result.success) {
+			logger.alert(`Reserves calculation failed: ${result.error}`, { result }, { component: 'reserves-calculation' });
+
+			return NextResponse.json({ ok: false, error: 'Internal server error' }, { status: 500 });
+		}
+
+		return NextResponse.json({}, { status: 201 });
+	} catch (error) {
+		logger.alert(`Reserves calculation failed: ${String(error)}`, { error }, { component: 'reserves-calculation' });
+
+		return NextResponse.json({ ok: false, error: 'Internal server error' }, { status: 500 });
+	}
 };

--- a/website/src/app/api/v1/reserves-calculation/route.ts
+++ b/website/src/app/api/v1/reserves-calculation/route.ts
@@ -1,0 +1,17 @@
+import { logger } from '@/lib/utils/logger';
+import { NextRequest, NextResponse } from 'next/server';
+
+export const POST = (request: NextRequest) => {
+	const apiKey = request.headers.get('x-api-key');
+
+	if (apiKey !== process.env.SCHEDULER_API_KEY || !process.env.SCHEDULER_API_KEY) {
+		logger.alert('Scheduler API key not set or wrong');
+
+		return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+	}
+
+	// TODO: Call external APIs, collect reserve values, and write them to the database.
+	logger.info('Reserves calculation endpoint called');
+
+	return NextResponse.json({}, { status: 201 });
+};

--- a/website/src/components/content-blocks/transparency.tsx
+++ b/website/src/components/content-blocks/transparency.tsx
@@ -42,6 +42,10 @@ export const TransparencyBlock = async ({ blok, lang }: Props) => {
 	const inflows = services.currencyDisplay.resolveFromChf(inflowsChf, displayCurrency, rates);
 	const outflows = services.currencyDisplay.resolveFromChf(outflowsChf, displayCurrency, rates);
 	const reserves = services.currencyDisplay.resolveFromChf(reservesChf, displayCurrency, rates);
+	const reserveAccounts = data.reserveAccounts.map(({ amountChf, ...account }) => ({
+		...account,
+		amount: amountChf === null ? null : services.currencyDisplay.resolveFromChf(amountChf, displayCurrency, rates),
+	}));
 
 	const { currency: timeSeriesCurrency } = services.currencyDisplay.resolveFromChf(
 		data.timeRanges[0]?.totalChf ?? 0,
@@ -55,7 +59,13 @@ export const TransparencyBlock = async ({ blok, lang }: Props) => {
 
 	return (
 		<BlockWrapper className="space-y-12" {...storyblokEditable(blok as SbBlokData)}>
-			<SummarySection inflows={inflows} outflows={outflows} reserves={reserves} lang={lang} />
+			<SummarySection
+				inflows={inflows}
+				outflows={outflows}
+				reserves={reserves}
+				reserveAccounts={reserveAccounts}
+				lang={lang}
+			/>
 			<TotalsSection totals={data.totals} lang={lang} displayCurrency={displayCurrency} rates={rates} />
 			<TimeSeriesSection
 				timeRanges={resolvedTimeRanges.map(({ startIso, total }) => ({ startIso, total }))}

--- a/website/src/components/transparency/summary-section-client.tsx
+++ b/website/src/components/transparency/summary-section-client.tsx
@@ -15,7 +15,7 @@ type SummaryMetricTooltip = {
 		key: string;
 		account: string;
 		balance: string;
-		updatedAt: string;
+		recordedAt: string;
 	}[];
 };
 
@@ -77,7 +77,7 @@ export const SummarySectionClient = ({ metrics, lang }: Props) => {
 													<li key={row.key} className="flex flex-wrap gap-x-1 tabular-nums">
 														<span className="break-all">{row.account},</span>
 														<span>{row.balance},</span>
-														<span>{row.updatedAt}</span>
+														<span>{row.recordedAt}</span>
 													</li>
 												))}
 											</ul>

--- a/website/src/components/transparency/summary-section-client.tsx
+++ b/website/src/components/transparency/summary-section-client.tsx
@@ -1,10 +1,23 @@
 'use client';
 
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/tool-tip';
 import { formatSummaryMetricAmount } from '@/components/transparency/summary-metric-format';
 import { useCountUp } from '@/lib/hooks/use-count-up';
 import { getSafeNumberFormatLocale, type WebsiteLanguage } from '@/lib/i18n/utils';
+import { Info } from 'lucide-react';
 import { useInView } from 'motion/react';
 import { useRef } from 'react';
+
+type SummaryMetricTooltip = {
+	ariaLabel: string;
+	emptyMessage: string;
+	rows: {
+		key: string;
+		account: string;
+		balance: string;
+		updatedAt: string;
+	}[];
+};
 
 export type SummaryMetric = {
 	key: 'inflows' | 'outflows' | 'reserves';
@@ -12,6 +25,7 @@ export type SummaryMetric = {
 	titleCurrency: string;
 	description: string;
 	amount: number;
+	tooltip?: SummaryMetricTooltip;
 };
 
 type Props = {
@@ -39,10 +53,40 @@ export const SummarySectionClient = ({ metrics, lang }: Props) => {
 	return (
 		<section>
 			<div className="grid gap-8 md:grid-cols-3">
-				{metrics.map(({ key, titleName, titleCurrency, description, amount }) => (
+				{metrics.map(({ key, titleName, titleCurrency, description, amount, tooltip }) => (
 					<div key={key} className="border-muted-foreground/30 text-foreground flex flex-col border-l pl-6">
-						<h2>
-							<strong>{titleName}</strong> {titleCurrency}
+						<h2 className="flex items-center gap-1.5">
+							<span>
+								<strong>{titleName}</strong> {titleCurrency}
+							</span>
+							{tooltip ? (
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<button
+											type="button"
+											aria-label={tooltip.ariaLabel}
+											className="text-muted-foreground hover:text-foreground focus-visible:ring-foreground inline-flex rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2"
+										>
+											<Info aria-hidden="true" className="size-4" />
+										</button>
+									</TooltipTrigger>
+									<TooltipContent sideOffset={8} className="max-w-[calc(100vw-2rem)] px-4 py-3 text-sm sm:max-w-xl">
+										{tooltip.rows.length > 0 ? (
+											<ul className="space-y-1.5">
+												{tooltip.rows.map((row) => (
+													<li key={row.key} className="flex flex-wrap gap-x-1 tabular-nums">
+														<span className="break-all">{row.account},</span>
+														<span>{row.balance},</span>
+														<span>{row.updatedAt}</span>
+													</li>
+												))}
+											</ul>
+										) : (
+											<p>{tooltip.emptyMessage}</p>
+										)}
+									</TooltipContent>
+								</Tooltip>
+							) : null}
 						</h2>
 						<p className="mt-2 text-sm">{description}</p>
 						<SummaryMetricValue amount={amount} lang={lang} />

--- a/website/src/components/transparency/summary-section.tsx
+++ b/website/src/components/transparency/summary-section.tsx
@@ -1,31 +1,68 @@
 import { SummarySectionClient, type SummaryMetric } from '@/components/transparency/summary-section-client';
 import { Translator } from '@/lib/i18n/translator';
-import type { WebsiteLanguage } from '@/lib/i18n/utils';
+import { getSafeNumberFormatLocale, type WebsiteLanguage } from '@/lib/i18n/utils';
 import type { DisplayAmount } from '@/lib/services/currency-display/currency-display.types';
+import { formatCurrencyLocale } from '@/lib/utils/string-utils';
+
+type ReserveAccount = {
+	bankAccountId: string;
+	bankAccountNumber: string;
+	description: string | null;
+	amount: DisplayAmount | null;
+	updatedAt: Date | null;
+};
 
 type Props = {
 	inflows: DisplayAmount;
 	outflows: DisplayAmount;
 	reserves: DisplayAmount;
+	reserveAccounts: ReserveAccount[];
 	lang: WebsiteLanguage;
 };
 
-export const SummarySection = async ({ inflows, outflows, reserves, lang }: Props) => {
+export const SummarySection = async ({ inflows, outflows, reserves, reserveAccounts, lang }: Props) => {
 	const translator = await Translator.getInstance({ language: lang, namespaces: ['website-common'] });
+	const locale = getSafeNumberFormatLocale(lang);
+	const noData = translator.t('transparency-page.reserves.no-data');
+	const dateFormatter = new Intl.DateTimeFormat('de-CH', {
+		day: '2-digit',
+		month: '2-digit',
+		year: 'numeric',
+		timeZone: 'Europe/Zurich',
+	});
+	const reserveTooltipRows = reserveAccounts.map(({ bankAccountId, bankAccountNumber, description, amount, updatedAt }) => ({
+		key: bankAccountId,
+		account: [bankAccountNumber, description].find((value) => value?.trim())?.trim() ?? noData,
+		balance: amount ? formatCurrencyLocale(amount.amount, amount.currency, locale, { maximumFractionDigits: 0 }) : noData,
+		updatedAt: updatedAt ? dateFormatter.format(updatedAt) : noData,
+	}));
 	const metricSources: { key: SummaryMetric['key']; displayAmount: DisplayAmount }[] = [
 		{ key: 'inflows', displayAmount: inflows },
 		{ key: 'outflows', displayAmount: outflows },
 		{ key: 'reserves', displayAmount: reserves },
 	];
-	const metrics: SummaryMetric[] = metricSources.map(({ key, displayAmount }) => ({
-		key,
-		titleName: translator.t(`transparency-page.${key}.title-name`),
-		titleCurrency: translator.t(`transparency-page.${key}.title-currency`, {
-			context: { currency: displayAmount.currency },
-		}),
-		description: translator.t(`transparency-page.${key}.description`),
-		amount: displayAmount.amount,
-	}));
+	const metrics: SummaryMetric[] = metricSources.map(({ key, displayAmount }) => {
+		const metric = {
+			key,
+			titleName: translator.t(`transparency-page.${key}.title-name`),
+			titleCurrency: translator.t(`transparency-page.${key}.title-currency`, {
+				context: { currency: displayAmount.currency },
+			}),
+			description: translator.t(`transparency-page.${key}.description`),
+			amount: displayAmount.amount,
+		};
+
+		return key === 'reserves'
+			? {
+					...metric,
+					tooltip: {
+						ariaLabel: translator.t('transparency-page.reserves.tooltip-label'),
+						emptyMessage: noData,
+						rows: reserveTooltipRows,
+					},
+				}
+			: metric;
+	});
 
 	return <SummarySectionClient metrics={metrics} lang={lang} />;
 };

--- a/website/src/components/transparency/summary-section.tsx
+++ b/website/src/components/transparency/summary-section.tsx
@@ -9,7 +9,7 @@ type ReserveAccount = {
 	bankAccountNumber: string;
 	description: string | null;
 	amount: DisplayAmount | null;
-	updatedAt: Date | null;
+	recordedAt: Date | null;
 };
 
 type Props = {
@@ -24,45 +24,44 @@ export const SummarySection = async ({ inflows, outflows, reserves, reserveAccou
 	const translator = await Translator.getInstance({ language: lang, namespaces: ['website-common'] });
 	const locale = getSafeNumberFormatLocale(lang);
 	const noData = translator.t('transparency-page.reserves.no-data');
-	const dateFormatter = new Intl.DateTimeFormat('de-CH', {
+	const dateFormatter = new Intl.DateTimeFormat(locale, {
 		day: '2-digit',
 		month: '2-digit',
 		year: 'numeric',
 		timeZone: 'Europe/Zurich',
 	});
-	const reserveTooltipRows = reserveAccounts.map(({ bankAccountId, bankAccountNumber, description, amount, updatedAt }) => ({
-		key: bankAccountId,
-		account: [bankAccountNumber, description].find((value) => value?.trim())?.trim() ?? noData,
-		balance: amount ? formatCurrencyLocale(amount.amount, amount.currency, locale, { maximumFractionDigits: 0 }) : noData,
-		updatedAt: updatedAt ? dateFormatter.format(updatedAt) : noData,
-	}));
-	const metricSources: { key: SummaryMetric['key']; displayAmount: DisplayAmount }[] = [
-		{ key: 'inflows', displayAmount: inflows },
-		{ key: 'outflows', displayAmount: outflows },
-		{ key: 'reserves', displayAmount: reserves },
-	];
-	const metrics: SummaryMetric[] = metricSources.map(({ key, displayAmount }) => {
-		const metric = {
-			key,
-			titleName: translator.t(`transparency-page.${key}.title-name`),
-			titleCurrency: translator.t(`transparency-page.${key}.title-currency`, {
-				context: { currency: displayAmount.currency },
-			}),
-			description: translator.t(`transparency-page.${key}.description`),
-			amount: displayAmount.amount,
-		};
-
-		return key === 'reserves'
+	const reserveTooltipRows = reserveAccounts.map(
+		({ bankAccountId, bankAccountNumber, description, amount, recordedAt }) => ({
+			key: bankAccountId,
+			account: [description, bankAccountNumber].map((value) => value?.trim()).find(Boolean) ?? noData,
+			balance: amount ? formatCurrencyLocale(amount.amount, amount.currency, locale, { maximumFractionDigits: 0 }) : noData,
+			recordedAt: recordedAt ? dateFormatter.format(recordedAt) : noData,
+		}),
+	);
+	const metrics: SummaryMetric[] = (
+		[
+			{ key: 'inflows', displayAmount: inflows },
+			{ key: 'outflows', displayAmount: outflows },
+			{ key: 'reserves', displayAmount: reserves },
+		] as const
+	).map(({ key, displayAmount }) => ({
+		key,
+		titleName: translator.t(`transparency-page.${key}.title-name`),
+		titleCurrency: translator.t(`transparency-page.${key}.title-currency`, {
+			context: { currency: displayAmount.currency },
+		}),
+		description: translator.t(`transparency-page.${key}.description`),
+		amount: displayAmount.amount,
+		...(key === 'reserves'
 			? {
-					...metric,
 					tooltip: {
 						ariaLabel: translator.t('transparency-page.reserves.tooltip-label'),
 						emptyMessage: noData,
 						rows: reserveTooltipRows,
 					},
 				}
-			: metric;
-	});
+			: {}),
+	}));
 
 	return <SummarySectionClient metrics={metrics} lang={lang} />;
 };

--- a/website/src/lib/database/migrations/20260812120448_add_bank_account_and_reserve/migration.sql
+++ b/website/src/lib/database/migrations/20260812120448_add_bank_account_and_reserve/migration.sql
@@ -1,0 +1,33 @@
+-- CreateEnum
+CREATE TYPE "BankAccountType" AS ENUM ('postfinance', 'pawapay_wallet', 'custodian_stablecoin_wallet', 'local_bank', 'mobile_money_wallet');
+
+-- CreateTable
+CREATE TABLE "bank_account" (
+    "id" TEXT NOT NULL,
+    "type" "BankAccountType" NOT NULL,
+    "bank_account_number" TEXT NOT NULL,
+    "description" TEXT,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3),
+
+    CONSTRAINT "bank_account_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "reserve" (
+    "id" TEXT NOT NULL,
+    "bank_account_id" TEXT NOT NULL,
+    "amount" DECIMAL(12,4) NOT NULL,
+    "currency" "Currency" NOT NULL,
+    "amount_chf" DECIMAL(12,4) NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3),
+
+    CONSTRAINT "reserve_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "reserve_bank_account_id_idx" ON "reserve"("bank_account_id");
+
+-- AddForeignKey
+ALTER TABLE "reserve" ADD CONSTRAINT "reserve_bank_account_id_fkey" FOREIGN KEY ("bank_account_id") REFERENCES "bank_account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/website/src/lib/database/migrations/20260812173000_reserve_unique_bank_account_date/migration.sql
+++ b/website/src/lib/database/migrations/20260812173000_reserve_unique_bank_account_date/migration.sql
@@ -1,0 +1,27 @@
+-- AlterTable
+ALTER TABLE "reserve" ADD COLUMN "date" DATE;
+
+-- Backfill from created_at for any existing rows
+UPDATE "reserve"
+SET "date" = (("created_at" AT TIME ZONE 'UTC')::date)
+WHERE "date" IS NULL;
+
+-- Keep one row per (bank_account_id, date) before unique index
+WITH ranked AS (
+  SELECT
+    "id",
+    ROW_NUMBER() OVER (
+      PARTITION BY "bank_account_id", "date"
+      ORDER BY "created_at" ASC NULLS LAST, "id" ASC
+    ) AS "rn"
+  FROM "reserve"
+)
+DELETE FROM "reserve" AS "r"
+USING ranked AS "ranked"
+WHERE "r"."id" = "ranked"."id"
+  AND "ranked"."rn" > 1;
+
+ALTER TABLE "reserve" ALTER COLUMN "date" SET NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "reserve_bank_account_id_date_key" ON "reserve"("bank_account_id", "date");

--- a/website/src/lib/database/schema.prisma
+++ b/website/src/lib/database/schema.prisma
@@ -980,6 +980,7 @@ model Reserve {
   id            String      @id @default(cuid()) @map("id")
   bankAccountId String      @map("bank_account_id")
   bankAccount   BankAccount @relation(fields: [bankAccountId], references: [id])
+  date          DateTime    @map("date") @db.Date
   amount        Decimal     @map("amount") @db.Decimal(12, 4)
   currency      Currency    @map("currency")
   amountChf     Decimal     @map("amount_chf") @db.Decimal(12, 4)
@@ -987,6 +988,7 @@ model Reserve {
   createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt DateTime? @updatedAt @map("updated_at") @db.Timestamptz(3)
 
+  @@unique([bankAccountId, date])
   @@index([bankAccountId])
   @@map("reserve")
 }

--- a/website/src/lib/database/schema.prisma
+++ b/website/src/lib/database/schema.prisma
@@ -76,6 +76,14 @@ enum ExpenseType {
   staff
 }
 
+enum BankAccountType {
+  postfinance
+  pawapay_wallet
+  custodian_stablecoin_wallet
+  local_bank
+  mobile_money_wallet
+}
+
 enum UserRole {
   admin
   user
@@ -953,6 +961,34 @@ model Expense {
   updatedAt DateTime? @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   @@map("expense")
+}
+
+model BankAccount {
+  id                String          @id @default(cuid()) @map("id")
+  type              BankAccountType @map("type")
+  bankAccountNumber String          @map("bank_account_number")
+  description       String?         @map("description")
+  reserves          Reserve[]
+
+  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime? @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@map("bank_account")
+}
+
+model Reserve {
+  id            String      @id @default(cuid()) @map("id")
+  bankAccountId String      @map("bank_account_id")
+  bankAccount   BankAccount @relation(fields: [bankAccountId], references: [id])
+  amount        Decimal     @map("amount") @db.Decimal(12, 4)
+  currency      Currency    @map("currency")
+  amountChf     Decimal     @map("amount_chf") @db.Decimal(12, 4)
+
+  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime? @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  @@index([bankAccountId])
+  @@map("reserve")
 }
 
 model Address {

--- a/website/src/lib/database/seed/data/bank-accounts.data.ts
+++ b/website/src/lib/database/seed/data/bank-accounts.data.ts
@@ -1,0 +1,30 @@
+import { BankAccount, BankAccountType } from '@/generated/prisma/client';
+
+const createdAt = new Date('2025-01-01T13:00:00.000Z');
+
+export const bankAccountsData: BankAccount[] = [
+	{
+		id: 'bank-account-postfinance-1',
+		type: BankAccountType.postfinance,
+		bankAccountNumber: 'CH1909000000151126386',
+		description: null,
+		createdAt,
+		updatedAt: null,
+	},
+	{
+		id: 'bank-account-postfinance-2',
+		type: BankAccountType.postfinance,
+		bankAccountNumber: 'CH9709000000169153887',
+		description: null,
+		createdAt,
+		updatedAt: null,
+	},
+	{
+		id: 'bank-account-postfinance-3',
+		type: BankAccountType.postfinance,
+		bankAccountNumber: 'CH5709000000154860881',
+		description: null,
+		createdAt,
+		updatedAt: null,
+	},
+];

--- a/website/src/lib/database/seed/run-seed.ts
+++ b/website/src/lib/database/seed/run-seed.ts
@@ -1,6 +1,7 @@
 import { prisma } from '../prisma';
 import { accountsData } from './data/accounts.data';
 import { addressesData } from './data/addresses.data';
+import { bankAccountsData } from './data/bank-accounts.data';
 import { campaignsData } from './data/campaigns.data';
 import { contactsData } from './data/contacts.data';
 import { contributionsData } from './data/contributions.data';
@@ -32,6 +33,8 @@ import { usersData } from './data/users.data';
 
 export const seedDatabase = async () => {
 	await prisma.$transaction(async (tx) => {
+		await tx.reserve.deleteMany();
+		await tx.bankAccount.deleteMany();
 		await tx.survey.deleteMany();
 		await tx.surveySchedule.deleteMany();
 		await tx.payout.deleteMany();
@@ -70,6 +73,7 @@ export const seedDatabase = async () => {
 			data: countryMobileMoneyProviderMappingsData,
 			skipDuplicates: true,
 		});
+		await tx.bankAccount.createMany({ data: bankAccountsData, skipDuplicates: true });
 		await tx.account.createMany({ data: accountsData, skipDuplicates: true });
 		await tx.address.createMany({ data: addressesData, skipDuplicates: true });
 		await tx.phone.createMany({ data: phonesData, skipDuplicates: true });

--- a/website/src/lib/i18n/locales/de/website-common.json
+++ b/website/src/lib/i18n/locales/de/website-common.json
@@ -130,7 +130,9 @@
 		"reserves": {
 			"title-name": "Reserven",
 			"title-currency": "in {{currency}}",
-			"description": "Für Empfänger:innen in laufenden Programmen reserviert."
+			"description": "Für Empfänger:innen in laufenden Programmen reserviert.",
+			"tooltip-label": "Reservekontodetails anzeigen",
+			"no-data": "Keine Daten"
 		}
 	},
 	"program-detail-page": {

--- a/website/src/lib/i18n/locales/en/website-common.json
+++ b/website/src/lib/i18n/locales/en/website-common.json
@@ -130,7 +130,9 @@
 		"reserves": {
 			"title-name": "Reserves",
 			"title-currency": "in {{currency}}",
-			"description": "Reserved for recipients in ongoing programs."
+			"description": "Reserved for recipients in ongoing programs.",
+			"tooltip-label": "Show reserve account details",
+			"no-data": "No data"
 		}
 	},
 	"program-detail-page": {

--- a/website/src/lib/i18n/locales/fr/website-common.json
+++ b/website/src/lib/i18n/locales/fr/website-common.json
@@ -130,7 +130,9 @@
 		"reserves": {
 			"title-name": "Réserves",
 			"title-currency": "en {{currency}}",
-			"description": "Réservées aux bénéficiaires des programmes en cours."
+			"description": "Réservées aux bénéficiaires des programmes en cours.",
+			"tooltip-label": "Afficher les détails des comptes de réserve",
+			"no-data": "Aucune donnée"
 		}
 	},
 	"program-detail-page": {

--- a/website/src/lib/i18n/locales/it/website-common.json
+++ b/website/src/lib/i18n/locales/it/website-common.json
@@ -130,7 +130,9 @@
 		"reserves": {
 			"title-name": "Riserve",
 			"title-currency": "in {{currency}}",
-			"description": "Riservate ai beneficiari dei programmi in corso."
+			"description": "Riservate ai beneficiari dei programmi in corso.",
+			"tooltip-label": "Mostra i dettagli dei conti di riserva",
+			"no-data": "Nessun dato"
 		}
 	},
 	"program-detail-page": {

--- a/website/src/lib/services/bank-account/bank-account-read.service.ts
+++ b/website/src/lib/services/bank-account/bank-account-read.service.ts
@@ -1,0 +1,20 @@
+import { type BankAccount, type PrismaClient } from '@/generated/prisma/client';
+import { logger } from '@/lib/utils/logger';
+import { BaseService } from '../core/base.service';
+import { type ServiceResult } from '../core/base.types';
+
+export class BankAccountReadService extends BaseService {
+	constructor(db: PrismaClient, loggerInstance = logger) {
+		super(db, loggerInstance);
+	}
+
+	async getAll(): Promise<ServiceResult<BankAccount[]>> {
+		try {
+			return this.resultOk(await this.db.bankAccount.findMany());
+		} catch (error) {
+			this.logger.error(error);
+
+			return this.resultFail(`Could not get bank accounts: ${JSON.stringify(error)}`);
+		}
+	}
+}

--- a/website/src/lib/services/payment-file-import/__fixtures__/camt052-balances.xml
+++ b/website/src/lib/services/payment-file-import/__fixtures__/camt052-balances.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.08">
+	<BkToCstmrAcctRpt>
+		<GrpHdr>
+			<MsgId>CAMT052-TEST</MsgId>
+			<CreDtTm>2026-08-12T06:00:00Z</CreDtTm>
+		</GrpHdr>
+		<Rpt>
+			<Id>REPORT-1</Id>
+			<Acct>
+				<Id>
+					<IBAN>CH19 0900 0000 1511 2638 6</IBAN>
+				</Id>
+			</Acct>
+			<Bal>
+				<Tp>
+					<CdOrPrtry>
+						<Cd>OPBD</Cd>
+					</CdOrPrtry>
+				</Tp>
+				<Amt Ccy="CHF">100.00</Amt>
+				<CdtDbtInd>CRDT</CdtDbtInd>
+			</Bal>
+			<Bal>
+				<Tp>
+					<CdOrPrtry>
+						<Cd>CLAV</Cd>
+					</CdOrPrtry>
+				</Tp>
+				<Amt Ccy="CHF">1234.56</Amt>
+				<CdtDbtInd>CRDT</CdtDbtInd>
+			</Bal>
+		</Rpt>
+		<Rpt>
+			<Id>REPORT-2</Id>
+			<Acct>
+				<Id>
+					<IBAN>CH9709000000169153887</IBAN>
+				</Id>
+			</Acct>
+			<Bal>
+				<Tp>
+					<CdOrPrtry>
+						<Cd>CLAV</Cd>
+					</CdOrPrtry>
+				</Tp>
+				<Amt Ccy="EUR">42.25</Amt>
+				<CdtDbtInd>DBIT</CdtDbtInd>
+			</Bal>
+		</Rpt>
+		<Rpt>
+			<Id>REPORT-WITHOUT-CLAV</Id>
+			<Acct>
+				<Id>
+					<IBAN>CH5709000000154860881</IBAN>
+				</Id>
+			</Acct>
+			<Bal>
+				<Tp>
+					<CdOrPrtry>
+						<Cd>OPBD</Cd>
+					</CdOrPrtry>
+				</Tp>
+				<Amt Ccy="CHF">99.00</Amt>
+				<CdtDbtInd>CRDT</CdtDbtInd>
+			</Bal>
+		</Rpt>
+	</BkToCstmrAcctRpt>
+</Document>

--- a/website/src/lib/services/payment-file-import/postfinance-balance.service.test.ts
+++ b/website/src/lib/services/payment-file-import/postfinance-balance.service.test.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { PostFinanceBalanceService } from './postfinance-balance.service';
+
+jest.mock('@/lib/firebase/firebase-admin', () => ({
+	storageAdmin: {
+		storage: {
+			bucket: (name: string) => ({ name, getFiles: () => [[]] }),
+		},
+	},
+}));
+jest.mock('@/generated/prisma/client', () => ({
+	Currency: { CHF: 'CHF', EUR: 'EUR' },
+	PrismaClient: class {},
+}));
+
+const fixturePath = path.join(path.dirname(__filename), '__fixtures__', 'camt052-balances.xml');
+
+describe('PostFinanceBalanceService.getClavBalancesFromXml', () => {
+	const service = new PostFinanceBalanceService('test-bucket', {} as never);
+
+	test('extracts CLAV balances and normalizes IBANs', () => {
+		const result = service.getClavBalancesFromXml(fs.readFileSync(fixturePath, 'utf8'));
+
+		expect(result.success).toBe(true);
+		if (!result.success) {
+			throw new Error(result.error);
+		}
+
+		expect(result.data).toEqual([
+			{
+				iban: 'CH1909000000151126386',
+				amount: 1234.56,
+				currency: 'CHF',
+			},
+			{
+				iban: 'CH9709000000169153887',
+				amount: -42.25,
+				currency: 'EUR',
+			},
+		]);
+	});
+
+	test('ignores reports without a CLAV balance', () => {
+		const result = service.getClavBalancesFromXml(fs.readFileSync(fixturePath, 'utf8'));
+
+		expect(result.success).toBe(true);
+		if (!result.success) {
+			throw new Error(result.error);
+		}
+
+		expect(result.data.some(({ iban }) => iban === 'CH5709000000154860881')).toBe(false);
+	});
+
+	test('rejects XML from another CAMT family', () => {
+		const result = service.getClavBalancesFromXml(
+			'<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.054.001.08"></Document>',
+		);
+
+		expect(result).toEqual({ success: false, error: 'File is not a CAMT.052 document' });
+	});
+});
+
+describe('PostFinanceBalanceService.getLatestClavBalances', () => {
+	test('fails when no CLAV balance exists for a requested IBAN', async () => {
+		const file = {
+			name: 'camt.052_test.xml',
+			getMetadata: jest.fn().mockResolvedValue([{ updated: '2026-08-12T06:00:00Z' }]),
+			download: jest.fn().mockResolvedValue([Buffer.from(fs.readFileSync(fixturePath, 'utf8'))]),
+		};
+		const bucket = {
+			getFiles: jest.fn().mockResolvedValue([[file]]),
+		};
+		const service = new PostFinanceBalanceService('test-bucket', {} as never, undefined, bucket as never);
+
+		await expect(service.getLatestClavBalances(['CH5709000000154860881'])).resolves.toEqual({
+			success: false,
+			error: 'No CLAV balance found for PostFinance accounts: CH5709000000154860881',
+		});
+	});
+});

--- a/website/src/lib/services/payment-file-import/postfinance-balance.service.test.ts
+++ b/website/src/lib/services/payment-file-import/postfinance-balance.service.test.ts
@@ -59,6 +59,48 @@ describe('PostFinanceBalanceService.getClavBalancesFromXml', () => {
 
 		expect(result).toEqual({ success: false, error: 'File is not a CAMT.052 document' });
 	});
+
+	test('rejects CLAV balances with an unknown credit/debit indicator', () => {
+		const result = service.getClavBalancesFromXml(`<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.08">
+	<BkToCstmrAcctRpt>
+		<Rpt>
+			<Acct><Id><IBAN>CH1909000000151126386</IBAN></Id></Acct>
+			<Bal>
+				<Tp><CdOrPrtry><Cd>CLAV</Cd></CdOrPrtry></Tp>
+				<Amt Ccy="CHF">1234.56</Amt>
+				<CdtDbtInd>UNKNOWN</CdtDbtInd>
+			</Bal>
+		</Rpt>
+	</BkToCstmrAcctRpt>
+</Document>`);
+
+		expect(result).toEqual({
+			success: false,
+			error: 'Invalid CLAV balance for PostFinance account CH1909000000151126386',
+		});
+	});
+
+	test('rejects CLAV balances with a negative CAMT amount', () => {
+		const result = service.getClavBalancesFromXml(`<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.08">
+	<BkToCstmrAcctRpt>
+		<Rpt>
+			<Acct><Id><IBAN>CH1909000000151126386</IBAN></Id></Acct>
+			<Bal>
+				<Tp><CdOrPrtry><Cd>CLAV</Cd></CdOrPrtry></Tp>
+				<Amt Ccy="CHF">-10.00</Amt>
+				<CdtDbtInd>CRDT</CdtDbtInd>
+			</Bal>
+		</Rpt>
+	</BkToCstmrAcctRpt>
+</Document>`);
+
+		expect(result).toEqual({
+			success: false,
+			error: 'Invalid CLAV balance for PostFinance account CH1909000000151126386',
+		});
+	});
 });
 
 describe('PostFinanceBalanceService.getLatestClavBalances', () => {

--- a/website/src/lib/services/payment-file-import/postfinance-balance.service.ts
+++ b/website/src/lib/services/payment-file-import/postfinance-balance.service.ts
@@ -66,16 +66,7 @@ export class PostFinanceBalanceService extends BaseService {
 				return this.resultFail(`No CLAV balance found for PostFinance accounts: ${missingIbans.join(', ')}`);
 			}
 
-			const balances: PostFinanceBalance[] = [];
-			for (const iban of requestedIbans) {
-				const balance = balancesByIban.get(iban);
-				if (!balance) {
-					return this.resultFail(`No CLAV balance found for PostFinance account: ${iban}`);
-				}
-				balances.push(balance);
-			}
-
-			return this.resultOk(balances);
+			return this.resultOk([...balancesByIban.values()]);
 		} catch (error) {
 			this.logger.error(error);
 

--- a/website/src/lib/services/payment-file-import/postfinance-balance.service.ts
+++ b/website/src/lib/services/payment-file-import/postfinance-balance.service.ts
@@ -1,0 +1,170 @@
+import { Currency, type PrismaClient } from '@/generated/prisma/client';
+import { storageAdmin } from '@/lib/firebase/firebase-admin';
+import { logger } from '@/lib/utils/logger';
+import xmldom from '@xmldom/xmldom';
+import { type Storage } from 'firebase-admin/storage';
+import xpath from 'xpath';
+import { BaseService } from '../core/base.service';
+import { type ServiceResult } from '../core/base.types';
+import { type PostFinanceBalance } from './postfinance-balance.types';
+
+type XPathSelectableNode = Parameters<typeof xpath.select>[1];
+type StorageBucket = ReturnType<Storage['bucket']>;
+type StorageFile = ReturnType<StorageBucket['file']>;
+
+type DatedStorageFile = {
+	file: StorageFile;
+	updatedAt: number;
+};
+
+export class PostFinanceBalanceService extends BaseService {
+	private readonly bucket?: StorageBucket;
+
+	constructor(bucketName: string, db: PrismaClient, loggerInstance = logger, bucket?: StorageBucket) {
+		super(db, loggerInstance);
+		this.bucket = bucket ?? (bucketName ? storageAdmin.storage.bucket(bucketName) : undefined);
+	}
+
+	async getLatestClavBalances(ibans: string[]): Promise<ServiceResult<PostFinanceBalance[]>> {
+		if (!this.bucket) {
+			return this.resultFail('PostFinance payments files bucket is not configured');
+		}
+
+		const requestedIbans = new Set(ibans.map(this.normalizeIban));
+		if (requestedIbans.size === 0) {
+			return this.resultOk([]);
+		}
+
+		try {
+			const files = await this.getCamt052Files(this.bucket);
+			if (files.length === 0) {
+				return this.resultFail('No CAMT.052 files found');
+			}
+
+			const balancesByIban = new Map<string, PostFinanceBalance>();
+			for (const { file } of files) {
+				const [contents] = await file.download();
+				const result = this.getClavBalancesFromXml(contents.toString('utf8'));
+				if (!result.success) {
+					return result;
+				}
+
+				for (const balance of result.data) {
+					const iban = this.normalizeIban(balance.iban);
+					if (requestedIbans.has(iban) && !balancesByIban.has(iban)) {
+						balancesByIban.set(iban, { ...balance, iban });
+					}
+				}
+
+				if (balancesByIban.size === requestedIbans.size) {
+					break;
+				}
+			}
+
+			const missingIbans = [...requestedIbans].filter((iban) => !balancesByIban.has(iban));
+			if (missingIbans.length > 0) {
+				return this.resultFail(`No CLAV balance found for PostFinance accounts: ${missingIbans.join(', ')}`);
+			}
+
+			const balances: PostFinanceBalance[] = [];
+			for (const iban of requestedIbans) {
+				const balance = balancesByIban.get(iban);
+				if (!balance) {
+					return this.resultFail(`No CLAV balance found for PostFinance account: ${iban}`);
+				}
+				balances.push(balance);
+			}
+
+			return this.resultOk(balances);
+		} catch (error) {
+			this.logger.error(error);
+
+			return this.resultFail(`Could not get PostFinance balances: ${JSON.stringify(error)}`);
+		}
+	}
+
+	getClavBalancesFromXml(xml: string): ServiceResult<PostFinanceBalance[]> {
+		try {
+			const document = new xmldom.DOMParser().parseFromString(xml, 'text/xml');
+			const namespace = document.documentElement?.namespaceURI;
+			if (!namespace?.includes(':camt.052.')) {
+				return this.resultFail('File is not a CAMT.052 document');
+			}
+
+			const selectedReports = xpath.select(
+				"//*[local-name()='BkToCstmrAcctRpt']/*[local-name()='Rpt']",
+				document as unknown as XPathSelectableNode,
+			);
+			if (!Array.isArray(selectedReports)) {
+				return this.resultFail('Could not find reports in CAMT.052 file');
+			}
+
+			const balances: PostFinanceBalance[] = [];
+
+			for (const report of selectedReports) {
+				const iban = this.normalizeIban(
+					this.selectString("string(./*[local-name()='Acct']/*[local-name()='Id']/*[local-name()='IBAN'])", report),
+				);
+				const balance = xpath.select1(
+					"./*[local-name()='Bal'][./*[local-name()='Tp']/*[local-name()='CdOrPrtry']/*[local-name()='Cd']='CLAV'][last()]",
+					report,
+				);
+				if (!iban || !balance || typeof balance !== 'object') {
+					continue;
+				}
+
+				const amountValue = this.selectString("string(./*[local-name()='Amt'])", balance);
+				const currencyValue = this.selectString("string(./*[local-name()='Amt']/@Ccy)", balance).toUpperCase();
+				const creditDebitIndicator = this.selectString("string(./*[local-name()='CdtDbtInd'])", balance);
+				const amount = Number(amountValue);
+
+				if (!amountValue.trim() || !Number.isFinite(amount) || !this.isCurrency(currencyValue)) {
+					return this.resultFail(`Invalid CLAV balance for PostFinance account ${iban}`);
+				}
+
+				balances.push({
+					iban,
+					amount: creditDebitIndicator === 'DBIT' ? -Math.abs(amount) : amount,
+					currency: currencyValue,
+				});
+			}
+
+			return this.resultOk(balances);
+		} catch (error) {
+			this.logger.error(error);
+
+			return this.resultFail(`Could not parse CAMT.052 file: ${JSON.stringify(error)}`);
+		}
+	}
+
+	private async getCamt052Files(bucket: StorageBucket): Promise<DatedStorageFile[]> {
+		const [files] = await bucket.getFiles();
+		const camtFiles = files.filter((file) => /camt\.052/i.test(file.name));
+		const datedFiles = await Promise.all(
+			camtFiles.map(async (file) => {
+				const [metadata] = await file.getMetadata();
+
+				return {
+					file,
+					updatedAt: Date.parse(metadata.updated ?? metadata.timeCreated ?? ''),
+				};
+			}),
+		);
+
+		return datedFiles.sort(
+			(left, right) =>
+				(Number.isNaN(right.updatedAt) ? 0 : right.updatedAt) - (Number.isNaN(left.updatedAt) ? 0 : left.updatedAt) ||
+				right.file.name.localeCompare(left.file.name),
+		);
+	}
+
+	private normalizeIban = (iban: string): string => iban.replaceAll(/\s/g, '').toUpperCase();
+
+	private selectString(expression: string, node: XPathSelectableNode): string {
+		const value = xpath.select1(expression, node);
+
+		return typeof value === 'string' ? value : '';
+	}
+
+	private isCurrency = (value: string): value is Currency => Object.values(Currency).some((currency) => currency === value);
+}

--- a/website/src/lib/services/payment-file-import/postfinance-balance.service.ts
+++ b/website/src/lib/services/payment-file-import/postfinance-balance.service.ts
@@ -109,7 +109,13 @@ export class PostFinanceBalanceService extends BaseService {
 				const creditDebitIndicator = this.selectString("string(./*[local-name()='CdtDbtInd'])", balance);
 				const amount = Number(amountValue);
 
-				if (!amountValue.trim() || !Number.isFinite(amount) || !this.isCurrency(currencyValue)) {
+				if (
+					!amountValue.trim() ||
+					!Number.isFinite(amount) ||
+					amount < 0 ||
+					!this.isCurrency(currencyValue) ||
+					(creditDebitIndicator !== 'CRDT' && creditDebitIndicator !== 'DBIT')
+				) {
 					return this.resultFail(`Invalid CLAV balance for PostFinance account ${iban}`);
 				}
 

--- a/website/src/lib/services/payment-file-import/postfinance-balance.types.ts
+++ b/website/src/lib/services/payment-file-import/postfinance-balance.types.ts
@@ -1,0 +1,7 @@
+import { type Currency } from '@/generated/prisma/client';
+
+export type PostFinanceBalance = {
+	iban: string;
+	amount: number;
+	currency: Currency;
+};

--- a/website/src/lib/services/reserves/reserve-read.service.test.ts
+++ b/website/src/lib/services/reserves/reserve-read.service.test.ts
@@ -3,26 +3,23 @@ import { ReserveReadService } from './reserve-read.service';
 
 describe('ReserveReadService.getLatestPerBankAccount', () => {
 	test('returns the latest reserve per bank account and sums available amounts', async () => {
-		const latestUpdatedAt = new Date('2026-08-12T12:00:00.000Z');
+		const latestRecordedAt = new Date('2026-08-12T12:00:00.000Z');
 		const findMany = jest.fn().mockResolvedValue([
 			{
 				id: 'account-with-reserves',
 				bankAccountNumber: 'CH1909000000151126386',
 				description: 'Main account',
-				reserves: [
-					{ amountChf: '125.50', updatedAt: latestUpdatedAt },
-					{ amountChf: '75.25', updatedAt: new Date('2026-08-11T12:00:00.000Z') },
-				],
+				reserves: [{ amountChf: '125.50', createdAt: latestRecordedAt }],
 			},
 			{
 				id: 'account-with-reserve',
-				bankAccountNumber: '',
+				bankAccountNumber: 'CH9709000000169153887',
 				description: 'Secondary account',
-				reserves: [{ amountChf: '24.50', updatedAt: null }],
+				reserves: [{ amountChf: '24.50', createdAt: latestRecordedAt }],
 			},
 			{
 				id: 'account-without-reserve',
-				bankAccountNumber: '',
+				bankAccountNumber: 'CH5709000000154860881',
 				description: null,
 				reserves: [],
 			},
@@ -39,21 +36,21 @@ describe('ReserveReadService.getLatestPerBankAccount', () => {
 						bankAccountNumber: 'CH1909000000151126386',
 						description: 'Main account',
 						amountChf: 125.5,
-						updatedAt: latestUpdatedAt,
+						recordedAt: latestRecordedAt,
 					},
 					{
 						bankAccountId: 'account-with-reserve',
-						bankAccountNumber: '',
+						bankAccountNumber: 'CH9709000000169153887',
 						description: 'Secondary account',
 						amountChf: 24.5,
-						updatedAt: null,
+						recordedAt: latestRecordedAt,
 					},
 					{
 						bankAccountId: 'account-without-reserve',
-						bankAccountNumber: '',
+						bankAccountNumber: 'CH5709000000154860881',
 						description: null,
 						amountChf: null,
-						updatedAt: null,
+						recordedAt: null,
 					},
 				],
 				total: 150,
@@ -67,7 +64,7 @@ describe('ReserveReadService.getLatestPerBankAccount', () => {
 				reserves: {
 					orderBy: { createdAt: 'desc' },
 					take: 1,
-					select: { amountChf: true, updatedAt: true },
+					select: { amountChf: true, createdAt: true },
 				},
 			},
 		});

--- a/website/src/lib/services/reserves/reserve-read.service.test.ts
+++ b/website/src/lib/services/reserves/reserve-read.service.test.ts
@@ -1,0 +1,88 @@
+import { type PrismaClient } from '@/generated/prisma/client';
+import { ReserveReadService } from './reserve-read.service';
+
+describe('ReserveReadService.getLatestPerBankAccount', () => {
+	test('returns the latest reserve per bank account and sums available amounts', async () => {
+		const latestUpdatedAt = new Date('2026-08-12T12:00:00.000Z');
+		const findMany = jest.fn().mockResolvedValue([
+			{
+				id: 'account-with-reserves',
+				bankAccountNumber: 'CH1909000000151126386',
+				description: 'Main account',
+				reserves: [
+					{ amountChf: '125.50', updatedAt: latestUpdatedAt },
+					{ amountChf: '75.25', updatedAt: new Date('2026-08-11T12:00:00.000Z') },
+				],
+			},
+			{
+				id: 'account-with-reserve',
+				bankAccountNumber: '',
+				description: 'Secondary account',
+				reserves: [{ amountChf: '24.50', updatedAt: null }],
+			},
+			{
+				id: 'account-without-reserve',
+				bankAccountNumber: '',
+				description: null,
+				reserves: [],
+			},
+		]);
+		const db = { bankAccount: { findMany } };
+		const service = new ReserveReadService(db as unknown as PrismaClient, {} as never);
+
+		await expect(service.getLatestPerBankAccount()).resolves.toEqual({
+			success: true,
+			data: {
+				accounts: [
+					{
+						bankAccountId: 'account-with-reserves',
+						bankAccountNumber: 'CH1909000000151126386',
+						description: 'Main account',
+						amountChf: 125.5,
+						updatedAt: latestUpdatedAt,
+					},
+					{
+						bankAccountId: 'account-with-reserve',
+						bankAccountNumber: '',
+						description: 'Secondary account',
+						amountChf: 24.5,
+						updatedAt: null,
+					},
+					{
+						bankAccountId: 'account-without-reserve',
+						bankAccountNumber: '',
+						description: null,
+						amountChf: null,
+						updatedAt: null,
+					},
+				],
+				total: 150,
+			},
+		});
+		expect(findMany).toHaveBeenCalledWith({
+			select: {
+				id: true,
+				bankAccountNumber: true,
+				description: true,
+				reserves: {
+					orderBy: { createdAt: 'desc' },
+					take: 1,
+					select: { amountChf: true, updatedAt: true },
+				},
+			},
+		});
+	});
+
+	test('returns an empty account list and zero total when no bank accounts exist', async () => {
+		const db = { bankAccount: { findMany: jest.fn().mockResolvedValue([]) } };
+		const service = new ReserveReadService(db as unknown as PrismaClient, {} as never);
+
+		await expect(service.getLatestPerBankAccount()).resolves.toEqual({
+			success: true,
+			data: {
+				accounts: [],
+				total: 0,
+			},
+		});
+	});
+});

--- a/website/src/lib/services/reserves/reserve-read.service.ts
+++ b/website/src/lib/services/reserves/reserve-read.service.ts
@@ -19,7 +19,7 @@ export class ReserveReadService extends BaseService {
 					reserves: {
 						orderBy: { createdAt: 'desc' },
 						take: 1,
-						select: { amountChf: true, updatedAt: true },
+						select: { amountChf: true, createdAt: true },
 					},
 				},
 			});
@@ -29,7 +29,7 @@ export class ReserveReadService extends BaseService {
 					bankAccountNumber,
 					description,
 					amountChf: latestReserve ? Number(latestReserve.amountChf) : null,
-					updatedAt: latestReserve?.updatedAt ?? null,
+					recordedAt: latestReserve?.createdAt ?? null,
 				}),
 			);
 

--- a/website/src/lib/services/reserves/reserve-read.service.ts
+++ b/website/src/lib/services/reserves/reserve-read.service.ts
@@ -1,0 +1,46 @@
+import { type PrismaClient } from '@/generated/prisma/client';
+import { logger } from '@/lib/utils/logger';
+import { BaseService } from '../core/base.service';
+import { type ServiceResult } from '../core/base.types';
+import { type BankAccountLatestReserve, type LatestReserves } from './reserve.types';
+
+export class ReserveReadService extends BaseService {
+	constructor(db: PrismaClient, loggerInstance = logger) {
+		super(db, loggerInstance);
+	}
+
+	async getLatestPerBankAccount(): Promise<ServiceResult<LatestReserves>> {
+		try {
+			const bankAccounts = await this.db.bankAccount.findMany({
+				select: {
+					id: true,
+					bankAccountNumber: true,
+					description: true,
+					reserves: {
+						orderBy: { createdAt: 'desc' },
+						take: 1,
+						select: { amountChf: true, updatedAt: true },
+					},
+				},
+			});
+			const accounts: BankAccountLatestReserve[] = bankAccounts.map(
+				({ id, bankAccountNumber, description, reserves: [latestReserve] }) => ({
+					bankAccountId: id,
+					bankAccountNumber,
+					description,
+					amountChf: latestReserve ? Number(latestReserve.amountChf) : null,
+					updatedAt: latestReserve?.updatedAt ?? null,
+				}),
+			);
+
+			return this.resultOk({
+				accounts,
+				total: accounts.reduce((total, { amountChf }) => total + (amountChf ?? 0), 0),
+			});
+		} catch (error) {
+			this.logger.error(error);
+
+			return this.resultFail(`Could not get latest reserves: ${JSON.stringify(error)}`);
+		}
+	}
+}

--- a/website/src/lib/services/reserves/reserve-write.service.test.ts
+++ b/website/src/lib/services/reserves/reserve-write.service.test.ts
@@ -1,8 +1,9 @@
-import { type PrismaClient } from '@/generated/prisma/client';
+import { Currency, type PrismaClient } from '@/generated/prisma/client';
 import { ReserveWriteService } from './reserve-write.service';
 import { type ReserveCreateInput } from './reserve.types';
 
 jest.mock('@/generated/prisma/client', () => ({
+	Currency: { CHF: 'CHF', EUR: 'EUR' },
 	PrismaClient: class {},
 }));
 
@@ -11,30 +12,32 @@ describe('ReserveWriteService.createMany', () => {
 		bankAccountId: 'postfinance-account',
 		date: new Date('2026-08-12T00:00:00.000Z'),
 		amount: 125,
-		currency: 'CHF' as ReserveCreateInput['currency'],
+		currency: Currency.CHF,
 		amountChf: 125,
 	};
 
 	test('uses skipDuplicates so repeated writes keep a single snapshot', async () => {
 		const snapshots = new Map<string, ReserveCreateInput>();
-		const createMany = jest.fn().mockImplementation(async ({ data, skipDuplicates }) => {
-			let count = 0;
+		const createMany = jest
+			.fn()
+			.mockImplementation(({ data, skipDuplicates }: { data: ReserveCreateInput[]; skipDuplicates?: boolean }) => {
+				let count = 0;
 
-			for (const row of data as ReserveCreateInput[]) {
-				const key = `${row.bankAccountId}:${row.date.toISOString()}`;
-				if (snapshots.has(key)) {
-					if (!skipDuplicates) {
-						throw new Error(`Duplicate reserve for ${key}`);
+				for (const row of data) {
+					const key = `${row.bankAccountId}:${row.date.toISOString()}`;
+					if (snapshots.has(key)) {
+						if (!skipDuplicates) {
+							throw new Error(`Duplicate reserve for ${key}`);
+						}
+						continue;
 					}
-					continue;
+
+					snapshots.set(key, row);
+					count += 1;
 				}
 
-				snapshots.set(key, row);
-				count += 1;
-			}
-
-			return { count };
-		});
+				return Promise.resolve({ count });
+			});
 		const service = new ReserveWriteService({ reserve: { createMany } } as unknown as PrismaClient, {} as never);
 
 		await expect(service.createMany([reserve])).resolves.toEqual({ success: true, data: 1 });

--- a/website/src/lib/services/reserves/reserve-write.service.test.ts
+++ b/website/src/lib/services/reserves/reserve-write.service.test.ts
@@ -1,0 +1,56 @@
+import { type PrismaClient } from '@/generated/prisma/client';
+import { ReserveWriteService } from './reserve-write.service';
+import { type ReserveCreateInput } from './reserve.types';
+
+jest.mock('@/generated/prisma/client', () => ({
+	PrismaClient: class {},
+}));
+
+describe('ReserveWriteService.createMany', () => {
+	const reserve: ReserveCreateInput = {
+		bankAccountId: 'postfinance-account',
+		date: new Date('2026-08-12T00:00:00.000Z'),
+		amount: 125,
+		currency: 'CHF' as ReserveCreateInput['currency'],
+		amountChf: 125,
+	};
+
+	test('uses skipDuplicates so repeated writes keep a single snapshot', async () => {
+		const snapshots = new Map<string, ReserveCreateInput>();
+		const createMany = jest.fn().mockImplementation(async ({ data, skipDuplicates }) => {
+			let count = 0;
+
+			for (const row of data as ReserveCreateInput[]) {
+				const key = `${row.bankAccountId}:${row.date.toISOString()}`;
+				if (snapshots.has(key)) {
+					if (!skipDuplicates) {
+						throw new Error(`Duplicate reserve for ${key}`);
+					}
+					continue;
+				}
+
+				snapshots.set(key, row);
+				count += 1;
+			}
+
+			return { count };
+		});
+		const service = new ReserveWriteService({ reserve: { createMany } } as unknown as PrismaClient, {} as never);
+
+		await expect(service.createMany([reserve])).resolves.toEqual({ success: true, data: 1 });
+		await expect(service.createMany([reserve])).resolves.toEqual({ success: true, data: 0 });
+
+		expect(createMany).toHaveBeenCalledTimes(2);
+		expect(createMany).toHaveBeenCalledWith({ data: [reserve], skipDuplicates: true });
+		expect(snapshots.size).toBe(1);
+		expect([...snapshots.values()]).toEqual([reserve]);
+	});
+
+	test('returns zero without writing when the input list is empty', async () => {
+		const createMany = jest.fn();
+		const service = new ReserveWriteService({ reserve: { createMany } } as unknown as PrismaClient, {} as never);
+
+		await expect(service.createMany([])).resolves.toEqual({ success: true, data: 0 });
+		expect(createMany).not.toHaveBeenCalled();
+	});
+});

--- a/website/src/lib/services/reserves/reserve-write.service.ts
+++ b/website/src/lib/services/reserves/reserve-write.service.ts
@@ -15,7 +15,7 @@ export class ReserveWriteService extends BaseService {
 				return this.resultOk(0);
 			}
 
-			const { count } = await this.db.reserve.createMany({ data: reserves });
+			const { count } = await this.db.reserve.createMany({ data: reserves, skipDuplicates: true });
 
 			return this.resultOk(count);
 		} catch (error) {

--- a/website/src/lib/services/reserves/reserve-write.service.ts
+++ b/website/src/lib/services/reserves/reserve-write.service.ts
@@ -1,0 +1,27 @@
+import { type PrismaClient } from '@/generated/prisma/client';
+import { logger } from '@/lib/utils/logger';
+import { BaseService } from '../core/base.service';
+import { type ServiceResult } from '../core/base.types';
+import { type ReserveCreateInput } from './reserve.types';
+
+export class ReserveWriteService extends BaseService {
+	constructor(db: PrismaClient, loggerInstance = logger) {
+		super(db, loggerInstance);
+	}
+
+	async createMany(reserves: ReserveCreateInput[]): Promise<ServiceResult<number>> {
+		try {
+			if (reserves.length === 0) {
+				return this.resultOk(0);
+			}
+
+			const { count } = await this.db.reserve.createMany({ data: reserves });
+
+			return this.resultOk(count);
+		} catch (error) {
+			this.logger.error(error);
+
+			return this.resultFail(`Could not create reserves: ${JSON.stringify(error)}`);
+		}
+	}
+}

--- a/website/src/lib/services/reserves/reserve.types.ts
+++ b/website/src/lib/services/reserves/reserve.types.ts
@@ -6,3 +6,16 @@ export type ReserveCreateInput = {
 	currency: Currency;
 	amountChf: number;
 };
+
+export type BankAccountLatestReserve = {
+	bankAccountId: string;
+	bankAccountNumber: string;
+	description: string | null;
+	amountChf: number | null;
+	updatedAt: Date | null;
+};
+
+export type LatestReserves = {
+	accounts: BankAccountLatestReserve[];
+	total: number;
+};

--- a/website/src/lib/services/reserves/reserve.types.ts
+++ b/website/src/lib/services/reserves/reserve.types.ts
@@ -1,0 +1,8 @@
+import { type Currency } from '@/generated/prisma/client';
+
+export type ReserveCreateInput = {
+	bankAccountId: string;
+	amount: number;
+	currency: Currency;
+	amountChf: number;
+};

--- a/website/src/lib/services/reserves/reserve.types.ts
+++ b/website/src/lib/services/reserves/reserve.types.ts
@@ -2,6 +2,7 @@ import { type Currency } from '@/generated/prisma/client';
 
 export type ReserveCreateInput = {
 	bankAccountId: string;
+	date: Date;
 	amount: number;
 	currency: Currency;
 	amountChf: number;

--- a/website/src/lib/services/reserves/reserve.types.ts
+++ b/website/src/lib/services/reserves/reserve.types.ts
@@ -12,7 +12,7 @@ export type BankAccountLatestReserve = {
 	bankAccountNumber: string;
 	description: string | null;
 	amountChf: number | null;
-	updatedAt: Date | null;
+	recordedAt: Date | null;
 };
 
 export type LatestReserves = {

--- a/website/src/lib/services/reserves/reserves-calculation.service.test.ts
+++ b/website/src/lib/services/reserves/reserves-calculation.service.test.ts
@@ -119,46 +119,51 @@ describe('ReservesCalculationService.calculate', () => {
 	});
 
 	test('repeating the same calculation persists only one snapshot', async () => {
-		const { snapshots, db, createMany } = createConflictSafeReserveDb();
-		const bankAccountService = {
-			getAll: jest.fn().mockResolvedValue({ success: true, data: [postFinanceAccount] }),
-		};
-		const postFinanceBalanceService = {
-			getLatestClavBalances: jest.fn().mockResolvedValue({
-				success: true,
-				data: [{ iban: 'CH1909000000151126386', amount: 125, currency: 'CHF' }],
-			}),
-		};
-		const currencyDisplayService = {
-			getLatestRatesOrUndefined: jest.fn(),
-			convertAmount: jest.fn().mockReturnValue(125),
-		};
-		const service = new ReservesCalculationService(
-			{} as never,
-			bankAccountService as never,
-			postFinanceBalanceService as never,
-			new ReserveWriteService(db, {} as never),
-			currencyDisplayService as never,
-		);
+		jest.useFakeTimers().setSystemTime(new Date('2026-08-12T12:00:00.000Z'));
 
-		await expect(service.calculate()).resolves.toEqual({ success: true, data: 1 });
-		await expect(service.calculate()).resolves.toEqual({ success: true, data: 0 });
+		try {
+			const { snapshots, db, createMany } = createConflictSafeReserveDb();
+			const bankAccountService = {
+				getAll: jest.fn().mockResolvedValue({ success: true, data: [postFinanceAccount] }),
+			};
+			const postFinanceBalanceService = {
+				getLatestClavBalances: jest.fn().mockResolvedValue({
+					success: true,
+					data: [{ iban: 'CH1909000000151126386', amount: 125, currency: 'CHF' }],
+				}),
+			};
+			const currencyDisplayService = {
+				getLatestRatesOrUndefined: jest.fn(),
+				convertAmount: jest.fn().mockReturnValue(125),
+			};
+			const service = new ReservesCalculationService(
+				{} as never,
+				bankAccountService as never,
+				postFinanceBalanceService as never,
+				new ReserveWriteService(db, {} as never),
+				currencyDisplayService as never,
+			);
 
-		expect(createMany).toHaveBeenCalledTimes(2);
-		const firstWrite = createMany.mock.calls[0]?.[0];
-		expect(firstWrite).toEqual({
-			data: [
-				{
-					bankAccountId: 'postfinance-account',
-					date: firstWrite?.data[0]?.date,
-					amount: 125,
-					currency: 'CHF',
-					amountChf: 125,
-				},
-			],
-			skipDuplicates: true,
-		});
-		expect(firstWrite?.data[0]?.date).toBeInstanceOf(Date);
-		expect(snapshots.size).toBe(1);
+			await expect(service.calculate()).resolves.toEqual({ success: true, data: 1 });
+			await expect(service.calculate()).resolves.toEqual({ success: true, data: 0 });
+
+			expect(createMany).toHaveBeenCalledTimes(2);
+			const firstWrite = createMany.mock.calls[0]?.[0];
+			expect(firstWrite).toEqual({
+				data: [
+					{
+						bankAccountId: 'postfinance-account',
+						date: new Date('2026-08-12T00:00:00.000Z'),
+						amount: 125,
+						currency: 'CHF',
+						amountChf: 125,
+					},
+				],
+				skipDuplicates: true,
+			});
+			expect(snapshots.size).toBe(1);
+		} finally {
+			jest.useRealTimers();
+		}
 	});
 });

--- a/website/src/lib/services/reserves/reserves-calculation.service.test.ts
+++ b/website/src/lib/services/reserves/reserves-calculation.service.test.ts
@@ -1,0 +1,83 @@
+import { ReservesCalculationService } from './reserves-calculation.service';
+
+jest.mock('@/generated/prisma/client', () => ({
+	BankAccountType: {
+		postfinance: 'postfinance',
+		pawapay_wallet: 'pawapay_wallet',
+	},
+	Currency: { CHF: 'CHF', EUR: 'EUR' },
+	PrismaClient: class {},
+}));
+jest.mock('@/lib/firebase/firebase-admin', () => ({
+	storageAdmin: { storage: { bucket: () => ({}) } },
+}));
+
+const postFinanceAccount = {
+	id: 'postfinance-account',
+	type: 'postfinance',
+	bankAccountNumber: 'CH19 0900 0000 1511 2638 6',
+	description: null,
+	createdAt: new Date(),
+	updatedAt: null,
+};
+
+describe('ReservesCalculationService.calculate', () => {
+	test('loads PostFinance balances and writes converted reserves', async () => {
+		const bankAccountService = {
+			getAll: jest.fn().mockResolvedValue({ success: true, data: [postFinanceAccount] }),
+		};
+		const postFinanceBalanceService = {
+			getLatestClavBalances: jest.fn().mockResolvedValue({
+				success: true,
+				data: [{ iban: 'CH1909000000151126386', amount: 125, currency: 'EUR' }],
+			}),
+		};
+		const reserveWriteService = {
+			createMany: jest.fn().mockResolvedValue({ success: true, data: 1 }),
+		};
+		const currencyDisplayService = {
+			getLatestRatesOrUndefined: jest.fn().mockResolvedValue({ CHF: 1, EUR: 2 }),
+			convertAmount: jest.fn().mockReturnValue(62.5),
+		};
+		const service = new ReservesCalculationService(
+			{} as never,
+			bankAccountService as never,
+			postFinanceBalanceService as never,
+			reserveWriteService as never,
+			currencyDisplayService as never,
+		);
+
+		await expect(service.calculate()).resolves.toEqual({ success: true, data: 1 });
+		expect(postFinanceBalanceService.getLatestClavBalances).toHaveBeenCalledWith(['CH19 0900 0000 1511 2638 6']);
+		expect(reserveWriteService.createMany).toHaveBeenCalledWith([
+			{
+				bankAccountId: 'postfinance-account',
+				amount: 125,
+				currency: 'EUR',
+				amountChf: 62.5,
+			},
+		]);
+	});
+
+	test('skips unsupported bank account types', async () => {
+		const bankAccountService = {
+			getAll: jest.fn().mockResolvedValue({
+				success: true,
+				data: [{ ...postFinanceAccount, type: 'pawapay_wallet' }],
+			}),
+		};
+		const postFinanceBalanceService = { getLatestClavBalances: jest.fn() };
+		const reserveWriteService = { createMany: jest.fn() };
+		const service = new ReservesCalculationService(
+			{} as never,
+			bankAccountService as never,
+			postFinanceBalanceService as never,
+			reserveWriteService as never,
+			{} as never,
+		);
+
+		await expect(service.calculate()).resolves.toEqual({ success: true, data: 0 });
+		expect(postFinanceBalanceService.getLatestClavBalances).not.toHaveBeenCalled();
+		expect(reserveWriteService.createMany).not.toHaveBeenCalled();
+	});
+});

--- a/website/src/lib/services/reserves/reserves-calculation.service.test.ts
+++ b/website/src/lib/services/reserves/reserves-calculation.service.test.ts
@@ -1,4 +1,7 @@
+import { type PrismaClient } from '@/generated/prisma/client';
+import { ReserveWriteService } from './reserve-write.service';
 import { ReservesCalculationService } from './reserves-calculation.service';
+import { type ReserveCreateInput } from './reserve.types';
 
 jest.mock('@/generated/prisma/client', () => ({
 	BankAccountType: {
@@ -19,6 +22,34 @@ const postFinanceAccount = {
 	description: null,
 	createdAt: new Date(),
 	updatedAt: null,
+};
+
+const createConflictSafeReserveDb = () => {
+	const snapshots = new Map<string, ReserveCreateInput>();
+	const createMany = jest.fn().mockImplementation(async ({ data, skipDuplicates }) => {
+		let count = 0;
+
+		for (const row of data as ReserveCreateInput[]) {
+			const key = `${row.bankAccountId}:${row.date.toISOString()}`;
+			if (snapshots.has(key)) {
+				if (!skipDuplicates) {
+					throw new Error(`Duplicate reserve for ${key}`);
+				}
+				continue;
+			}
+
+			snapshots.set(key, row);
+			count += 1;
+		}
+
+		return { count };
+	});
+
+	return {
+		snapshots,
+		db: { reserve: { createMany } } as unknown as PrismaClient,
+		createMany,
+	};
 };
 
 describe('ReservesCalculationService.calculate', () => {
@@ -52,6 +83,7 @@ describe('ReservesCalculationService.calculate', () => {
 		expect(reserveWriteService.createMany).toHaveBeenCalledWith([
 			{
 				bankAccountId: 'postfinance-account',
+				date: expect.any(Date),
 				amount: 125,
 				currency: 'EUR',
 				amountChf: 62.5,
@@ -79,5 +111,47 @@ describe('ReservesCalculationService.calculate', () => {
 		await expect(service.calculate()).resolves.toEqual({ success: true, data: 0 });
 		expect(postFinanceBalanceService.getLatestClavBalances).not.toHaveBeenCalled();
 		expect(reserveWriteService.createMany).not.toHaveBeenCalled();
+	});
+
+	test('repeating the same calculation persists only one snapshot', async () => {
+		const { snapshots, db, createMany } = createConflictSafeReserveDb();
+		const bankAccountService = {
+			getAll: jest.fn().mockResolvedValue({ success: true, data: [postFinanceAccount] }),
+		};
+		const postFinanceBalanceService = {
+			getLatestClavBalances: jest.fn().mockResolvedValue({
+				success: true,
+				data: [{ iban: 'CH1909000000151126386', amount: 125, currency: 'CHF' }],
+			}),
+		};
+		const currencyDisplayService = {
+			getLatestRatesOrUndefined: jest.fn(),
+			convertAmount: jest.fn().mockReturnValue(125),
+		};
+		const service = new ReservesCalculationService(
+			{} as never,
+			bankAccountService as never,
+			postFinanceBalanceService as never,
+			new ReserveWriteService(db, {} as never),
+			currencyDisplayService as never,
+		);
+
+		await expect(service.calculate()).resolves.toEqual({ success: true, data: 1 });
+		await expect(service.calculate()).resolves.toEqual({ success: true, data: 0 });
+
+		expect(createMany).toHaveBeenCalledTimes(2);
+		expect(createMany).toHaveBeenCalledWith({
+			data: [
+				{
+					bankAccountId: 'postfinance-account',
+					date: expect.any(Date),
+					amount: 125,
+					currency: 'CHF',
+					amountChf: 125,
+				},
+			],
+			skipDuplicates: true,
+		});
+		expect(snapshots.size).toBe(1);
 	});
 });

--- a/website/src/lib/services/reserves/reserves-calculation.service.test.ts
+++ b/website/src/lib/services/reserves/reserves-calculation.service.test.ts
@@ -1,7 +1,7 @@
 import { type PrismaClient } from '@/generated/prisma/client';
 import { ReserveWriteService } from './reserve-write.service';
-import { ReservesCalculationService } from './reserves-calculation.service';
 import { type ReserveCreateInput } from './reserve.types';
+import { ReservesCalculationService } from './reserves-calculation.service';
 
 jest.mock('@/generated/prisma/client', () => ({
 	BankAccountType: {
@@ -24,12 +24,14 @@ const postFinanceAccount = {
 	updatedAt: null,
 };
 
+type ReserveCreateManyArgs = { data: ReserveCreateInput[]; skipDuplicates?: boolean };
+
 const createConflictSafeReserveDb = () => {
 	const snapshots = new Map<string, ReserveCreateInput>();
-	const createMany = jest.fn().mockImplementation(async ({ data, skipDuplicates }) => {
+	const createMany = jest.fn(({ data, skipDuplicates }: ReserveCreateManyArgs) => {
 		let count = 0;
 
-		for (const row of data as ReserveCreateInput[]) {
+		for (const row of data) {
 			const key = `${row.bankAccountId}:${row.date.toISOString()}`;
 			if (snapshots.has(key)) {
 				if (!skipDuplicates) {
@@ -42,8 +44,8 @@ const createConflictSafeReserveDb = () => {
 			count += 1;
 		}
 
-		return { count };
-	});
+		return Promise.resolve({ count });
+	}) as jest.MockedFunction<(args: ReserveCreateManyArgs) => Promise<{ count: number }>>;
 
 	return {
 		snapshots,
@@ -63,9 +65,9 @@ describe('ReservesCalculationService.calculate', () => {
 				data: [{ iban: 'CH1909000000151126386', amount: 125, currency: 'EUR' }],
 			}),
 		};
-		const reserveWriteService = {
-			createMany: jest.fn().mockResolvedValue({ success: true, data: 1 }),
-		};
+		const createMany = jest.fn().mockResolvedValue({ success: true, data: 1 }) as jest.MockedFunction<
+			(reserves: ReserveCreateInput[]) => Promise<{ success: true; data: number }>
+		>;
 		const currencyDisplayService = {
 			getLatestRatesOrUndefined: jest.fn().mockResolvedValue({ CHF: 1, EUR: 2 }),
 			convertAmount: jest.fn().mockReturnValue(62.5),
@@ -74,21 +76,24 @@ describe('ReservesCalculationService.calculate', () => {
 			{} as never,
 			bankAccountService as never,
 			postFinanceBalanceService as never,
-			reserveWriteService as never,
+			{ createMany } as never,
 			currencyDisplayService as never,
 		);
 
 		await expect(service.calculate()).resolves.toEqual({ success: true, data: 1 });
 		expect(postFinanceBalanceService.getLatestClavBalances).toHaveBeenCalledWith(['CH19 0900 0000 1511 2638 6']);
-		expect(reserveWriteService.createMany).toHaveBeenCalledWith([
+		expect(createMany).toHaveBeenCalledTimes(1);
+		const writtenReserves = createMany.mock.calls[0]?.[0] ?? [];
+		expect(writtenReserves).toEqual([
 			{
 				bankAccountId: 'postfinance-account',
-				date: expect.any(Date),
+				date: writtenReserves[0]?.date,
 				amount: 125,
 				currency: 'EUR',
 				amountChf: 62.5,
 			},
 		]);
+		expect(writtenReserves[0]?.date).toBeInstanceOf(Date);
 	});
 
 	test('skips unsupported bank account types', async () => {
@@ -140,11 +145,12 @@ describe('ReservesCalculationService.calculate', () => {
 		await expect(service.calculate()).resolves.toEqual({ success: true, data: 0 });
 
 		expect(createMany).toHaveBeenCalledTimes(2);
-		expect(createMany).toHaveBeenCalledWith({
+		const firstWrite = createMany.mock.calls[0]?.[0];
+		expect(firstWrite).toEqual({
 			data: [
 				{
 					bankAccountId: 'postfinance-account',
-					date: expect.any(Date),
+					date: firstWrite?.data[0]?.date,
 					amount: 125,
 					currency: 'CHF',
 					amountChf: 125,
@@ -152,6 +158,7 @@ describe('ReservesCalculationService.calculate', () => {
 			],
 			skipDuplicates: true,
 		});
+		expect(firstWrite?.data[0]?.date).toBeInstanceOf(Date);
 		expect(snapshots.size).toBe(1);
 	});
 });

--- a/website/src/lib/services/reserves/reserves-calculation.service.ts
+++ b/website/src/lib/services/reserves/reserves-calculation.service.ts
@@ -1,0 +1,80 @@
+import { BankAccountType, Currency, type PrismaClient } from '@/generated/prisma/client';
+import { logger } from '@/lib/utils/logger';
+import { type BankAccountReadService } from '../bank-account/bank-account-read.service';
+import { BaseService } from '../core/base.service';
+import { type ServiceResult } from '../core/base.types';
+import { type CurrencyDisplayService } from '../currency-display/currency-display.service';
+import { type PostFinanceBalanceService } from '../payment-file-import/postfinance-balance.service';
+import { type ReserveWriteService } from './reserve-write.service';
+import { type ReserveCreateInput } from './reserve.types';
+
+export class ReservesCalculationService extends BaseService {
+	constructor(
+		db: PrismaClient,
+		private readonly bankAccountService: BankAccountReadService,
+		private readonly postFinanceBalanceService: PostFinanceBalanceService,
+		private readonly reserveWriteService: ReserveWriteService,
+		private readonly currencyDisplayService: CurrencyDisplayService,
+		loggerInstance = logger,
+	) {
+		super(db, loggerInstance);
+	}
+
+	async calculate(): Promise<ServiceResult<number>> {
+		const bankAccountsResult = await this.bankAccountService.getAll();
+		if (!bankAccountsResult.success) {
+			return bankAccountsResult;
+		}
+
+		const postFinanceAccounts = bankAccountsResult.data.filter(({ type }) => {
+			switch (type) {
+				case BankAccountType.postfinance:
+					return true;
+				default:
+					this.logger.info(`Skipped reserve calculation for unsupported bank account type ${type}`);
+
+					return false;
+			}
+		});
+
+		if (postFinanceAccounts.length === 0) {
+			return this.resultOk(0);
+		}
+
+		const balancesResult = await this.postFinanceBalanceService.getLatestClavBalances(
+			postFinanceAccounts.map(({ bankAccountNumber }) => bankAccountNumber),
+		);
+		if (!balancesResult.success) {
+			return balancesResult;
+		}
+
+		const rates = balancesResult.data.some(({ currency }) => currency !== Currency.CHF)
+			? await this.currencyDisplayService.getLatestRatesOrUndefined()
+			: undefined;
+		const balancesByIban = new Map(balancesResult.data.map((balance) => [this.normalizeIban(balance.iban), balance]));
+		const reserves: ReserveCreateInput[] = [];
+
+		for (const account of postFinanceAccounts) {
+			const balance = balancesByIban.get(this.normalizeIban(account.bankAccountNumber));
+			if (!balance) {
+				return this.resultFail(`Missing PostFinance balance for bank account ${account.id}`);
+			}
+
+			const amountChf = this.currencyDisplayService.convertAmount(balance.amount, balance.currency, Currency.CHF, rates);
+			if (amountChf === undefined) {
+				return this.resultFail(`Could not convert ${balance.currency} reserve for bank account ${account.id} to CHF`);
+			}
+
+			reserves.push({
+				bankAccountId: account.id,
+				amount: balance.amount,
+				currency: balance.currency,
+				amountChf,
+			});
+		}
+
+		return this.reserveWriteService.createMany(reserves);
+	}
+
+	private normalizeIban = (iban: string): string => iban.replaceAll(/\s/g, '').toUpperCase();
+}

--- a/website/src/lib/services/reserves/reserves-calculation.service.ts
+++ b/website/src/lib/services/reserves/reserves-calculation.service.ts
@@ -52,6 +52,8 @@ export class ReservesCalculationService extends BaseService {
 			? await this.currencyDisplayService.getLatestRatesOrUndefined()
 			: undefined;
 		const balancesByIban = new Map(balancesResult.data.map((balance) => [this.normalizeIban(balance.iban), balance]));
+		const now = new Date();
+		const calculationDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
 		const reserves: ReserveCreateInput[] = [];
 
 		for (const account of postFinanceAccounts) {
@@ -67,6 +69,7 @@ export class ReservesCalculationService extends BaseService {
 
 			reserves.push({
 				bankAccountId: account.id,
+				date: calculationDate,
 				amount: balance.amount,
 				currency: balance.currency,
 				amountChf,

--- a/website/src/lib/services/services.ts
+++ b/website/src/lib/services/services.ts
@@ -258,7 +258,6 @@ const createReservesCalculation = (bucketName: string) =>
 
 export const services = {
 	read: {
-		bankAccount: bankAccountRead,
 		candidate: candidateRead,
 		campaign: campaignRead,
 		campaignPublicWebsite,
@@ -275,7 +274,6 @@ export const services = {
 		payout: payoutRead,
 		program: programRead,
 		recipient: recipientRead,
-		reserve: reserveRead,
 		survey: surveyRead,
 		user: userRead,
 	},
@@ -302,7 +300,6 @@ export const services = {
 	appReviewMode,
 	qrBill,
 	createPaymentFileImport,
-	createPostFinanceBalance,
 	createReservesCalculation,
 	exchangeRateImport,
 	candidateImport,
@@ -312,7 +309,6 @@ export const services = {
 	orangeMoneyCsvPayoutProcess,
 	telecelCsvPayoutProcess,
 	currencyDisplay,
-	reserveWrite,
 	programStats,
 	recipientImport,
 	sendgrid,

--- a/website/src/lib/services/services.ts
+++ b/website/src/lib/services/services.ts
@@ -1,5 +1,6 @@
 import { prisma } from '../database/prisma';
 import { AppReviewModeService } from './app-review-mode/app-review-mode.service';
+import { BankAccountReadService } from './bank-account/bank-account-read.service';
 import { CampaignPublicWebsiteService } from './campaign/campaign-public-website.service';
 import { CampaignReadService } from './campaign/campaign-read.service';
 import { CampaignSubmissionService } from './campaign/campaign-submission.service';
@@ -46,6 +47,7 @@ import { OrganizationReadService } from './organization/organization-read.servic
 import { OrganizationValidationService } from './organization/organization-validation.service';
 import { OrganizationWriteService } from './organization/organization-write.service';
 import { PaymentFileImportService } from './payment-file-import/payment-file-import.service';
+import { PostFinanceBalanceService } from './payment-file-import/postfinance-balance.service';
 import { OrangeMoneyCsvPayoutProcessService } from './payout-process/orange-money-csv-payout-process.service';
 import { PayoutProcessCoreService } from './payout-process/payout-process-core.service';
 import { TelecelCsvPayoutProcessService } from './payout-process/telecel-csv-payout-process.service';
@@ -65,6 +67,8 @@ import { RecipientReadService } from './recipient/recipient-read.service';
 import { RecipientStatusService } from './recipient/recipient-status.service';
 import { RecipientValidationService } from './recipient/recipient-validation.service';
 import { RecipientWriteService } from './recipient/recipient-write.service';
+import { ReserveWriteService } from './reserves/reserve-write.service';
+import { ReservesCalculationService } from './reserves/reserves-calculation.service';
 import { SendgridSubscriptionService } from './sendgrid/sendgrid-subscription.service';
 import { StoryblokManagementService } from './storyblok/storyblok-management.service';
 import { StoryblokService } from './storyblok/storyblok.service';
@@ -88,6 +92,7 @@ import { UserValidationService } from './user/user-validation.service';
 import { UserWriteService } from './user/user-write.service';
 
 const appReviewMode = new AppReviewModeService(prisma);
+const bankAccountRead = new BankAccountReadService(prisma);
 const firebaseAdmin = new FirebaseAdminService(prisma);
 const firebaseSession = new FirebaseSessionService(prisma);
 const programAccessRead = new ProgramAccessReadService(prisma);
@@ -183,6 +188,7 @@ const focusWrite = new FocusWriteService(prisma, userRead, focusValidation);
 const donationCertificateRead = new DonationCertificateReadService(prisma, programAccessRead);
 
 const currencyDisplay = new CurrencyDisplayService(exchangeRateRead);
+const reserveWrite = new ReserveWriteService(prisma);
 const programStats = new ProgramStatsService(prisma, currencyDisplay, recipientStatus);
 const campaignRead = new CampaignReadService(prisma, programAccessRead, exchangeRateRead);
 const campaignPublicWebsite = new CampaignPublicWebsiteService(prisma, storyblok);
@@ -238,9 +244,19 @@ const surveyWrite = new SurveyWriteService(prisma, programAccessRead, firebaseAd
 
 const createPaymentFileImport = (bucketName: string) =>
 	new PaymentFileImportService(bucketName, prisma, contributorRead, contributionWrite, campaignRead);
+const createPostFinanceBalance = (bucketName: string) => new PostFinanceBalanceService(bucketName, prisma);
+const createReservesCalculation = (bucketName: string) =>
+	new ReservesCalculationService(
+		prisma,
+		bankAccountRead,
+		createPostFinanceBalance(bucketName),
+		reserveWrite,
+		currencyDisplay,
+	);
 
 export const services = {
 	read: {
+		bankAccount: bankAccountRead,
 		candidate: candidateRead,
 		campaign: campaignRead,
 		campaignPublicWebsite,
@@ -283,6 +299,8 @@ export const services = {
 	appReviewMode,
 	qrBill,
 	createPaymentFileImport,
+	createPostFinanceBalance,
+	createReservesCalculation,
 	exchangeRateImport,
 	candidateImport,
 	firebaseAdmin,
@@ -291,6 +309,7 @@ export const services = {
 	orangeMoneyCsvPayoutProcess,
 	telecelCsvPayoutProcess,
 	currencyDisplay,
+	reserveWrite,
 	programStats,
 	recipientImport,
 	sendgrid,

--- a/website/src/lib/services/services.ts
+++ b/website/src/lib/services/services.ts
@@ -67,6 +67,7 @@ import { RecipientReadService } from './recipient/recipient-read.service';
 import { RecipientStatusService } from './recipient/recipient-status.service';
 import { RecipientValidationService } from './recipient/recipient-validation.service';
 import { RecipientWriteService } from './recipient/recipient-write.service';
+import { ReserveReadService } from './reserves/reserve-read.service';
 import { ReserveWriteService } from './reserves/reserve-write.service';
 import { ReservesCalculationService } from './reserves/reserves-calculation.service';
 import { SendgridSubscriptionService } from './sendgrid/sendgrid-subscription.service';
@@ -93,6 +94,7 @@ import { UserWriteService } from './user/user-write.service';
 
 const appReviewMode = new AppReviewModeService(prisma);
 const bankAccountRead = new BankAccountReadService(prisma);
+const reserveRead = new ReserveReadService(prisma);
 const firebaseAdmin = new FirebaseAdminService(prisma);
 const firebaseSession = new FirebaseSessionService(prisma);
 const programAccessRead = new ProgramAccessReadService(prisma);
@@ -102,7 +104,7 @@ const userRead = new UserReadService(prisma);
 const userValidation = new UserValidationService(prisma);
 const exchangeRateImport = new ExchangeRateImportService(prisma);
 const surveySchedule = new SurveyScheduleService(prisma);
-const transparency = new TransparencyService(prisma);
+const transparency = new TransparencyService(prisma, reserveRead);
 const githubApi = new GithubApiService(prisma);
 const storyblok = new StoryblokService(prisma);
 const journal = new JournalService(prisma, storyblok);
@@ -273,6 +275,7 @@ export const services = {
 		payout: payoutRead,
 		program: programRead,
 		recipient: recipientRead,
+		reserve: reserveRead,
 		survey: surveyRead,
 		user: userRead,
 	},

--- a/website/src/lib/services/transparency/transparency.service.ts
+++ b/website/src/lib/services/transparency/transparency.service.ts
@@ -1,7 +1,10 @@
+import { type PrismaClient } from '@/generated/prisma/client';
 import { PayoutStatus, type CountryCode } from '@/generated/prisma/enums';
 import { getCountryNameByCode, isValidCountryCode } from '@/lib/types/country';
+import { logger } from '@/lib/utils/logger';
 import { BaseService } from '../core/base.service';
 import type { ServiceResult } from '../core/base.types';
+import { type ReserveReadService } from '../reserves/reserve-read.service';
 import type {
 	ContributionsByCountry,
 	ContributionTimeRange,
@@ -13,9 +16,15 @@ import type {
 } from './transparency.types';
 import { getTransparencyFinancialPeriodDateFilter } from './transparency.types';
 
-const RESERVES_PLACEHOLDER_CHF = 42;
-
 export class TransparencyService extends BaseService {
+	constructor(
+		db: PrismaClient,
+		private readonly reserveReadService: ReserveReadService,
+		loggerInstance = logger,
+	) {
+		super(db, loggerInstance);
+	}
+
 	async getTransparencyTotals(
 		financialPeriod: TransparencyFinancialPeriod = { kind: 'all-time' },
 	): Promise<ServiceResult<TransparencyTotals>> {
@@ -56,20 +65,25 @@ export class TransparencyService extends BaseService {
 		financialPeriod: TransparencyFinancialPeriod = { kind: 'all-time' },
 	): Promise<ServiceResult<TransparencyData>> {
 		try {
-			const [totals, outflowsChf, timeRangeData, topCountries] = await Promise.all([
+			const [totals, outflowsChf, latestReservesResult, timeRangeData, topCountries] = await Promise.all([
 				this.getTotals(financialPeriod),
 				this.getOutflows(financialPeriod),
+				this.reserveReadService.getLatestPerBankAccount(),
 				this.getContributionsByTimeRanges(timeRanges),
 				this.getContributionsByCountry(15),
 			]);
+			if (!latestReservesResult.success) {
+				return this.resultFail(latestReservesResult.error);
+			}
 
 			return this.resultOk({
 				totals,
 				financialSummary: {
 					inflowsChf: totals.totalContributionsChf,
 					outflowsChf,
-					reservesChf: RESERVES_PLACEHOLDER_CHF,
+					reservesChf: latestReservesResult.data.total,
 				},
+				reserveAccounts: latestReservesResult.data.accounts,
 				timeRanges: timeRangeData,
 				topCountries,
 			});

--- a/website/src/lib/services/transparency/transparency.types.ts
+++ b/website/src/lib/services/transparency/transparency.types.ts
@@ -1,5 +1,6 @@
 import type { CountryCode } from '@/generated/prisma/enums';
 import { DateTime } from 'luxon';
+import type { BankAccountLatestReserve } from '../reserves/reserve.types';
 
 export type TimeRange = {
 	start: DateTime;
@@ -75,6 +76,7 @@ type TransparencyFinancialSummary = {
 export type TransparencyData = {
 	totals: TransparencyTotals;
 	financialSummary: TransparencyFinancialSummary;
+	reserveAccounts: BankAccountLatestReserve[];
 	timeRanges: ContributionTimeRange[];
 	topCountries: ContributionsByCountry[];
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transparency pages now show live reserve totals and account-level details, including balances and recording dates.
  * Reserve amounts are displayed in the selected currency with localized labels and clear empty-state messaging.
  * Reserve data is calculated and refreshed automatically each day.
* **Bug Fixes**
  * Improved handling of missing balances and unsupported account types.
  * Added reliable processing of PostFinance balance reports.
  * Prevented duplicate reserve entries during repeated updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->