### PR TITLE
fix: extend study card descriptions from three to five lines

### DIFF
--- a/website/src/components/storyblok/focus/study-card.tsx
+++ b/website/src/components/storyblok/focus/study-card.tsx
@@ -22,7 +22,7 @@ export const StudyCard = ({ study, lang, region }: Props) => {
 	return (
 		<article className="border-border bg-card flex flex-col gap-4 rounded-3xl border px-10 py-8 shadow-[0_4px_6px_-4px_rgba(0,0,0,0.10),0_0_20px_0_rgba(0,0,0,0.05)]">
 			<h3 className="text-foreground line-clamp-3 text-2xl font-bold">{title}</h3>
-			<p className="text-foreground line-clamp-3 text-base font-normal">{description}</p>
+			<p className="text-foreground line-clamp-5 text-base font-normal">{description}</p>
 			{metadata && <p className="text-foreground text-base font-light">{metadata}</p>}
 			{href && linkLabel && (
 				<Link


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Study card descriptions can now display up to five lines, making more of the content visible before truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->