### PR TITLE
fix: keep shared form delete actions generic

### DIFF
--- a/website/src/components/data-table/clients/recipient-dialog.tsx
+++ b/website/src/components/data-table/clients/recipient-dialog.tsx
@@ -36,7 +36,7 @@ export const RecipientDialog = ({
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-[425px]">
+			<DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-[600px]">
 				<DialogHeader>
 					<DialogTitle>{dialogTitle}</DialogTitle>
 				</DialogHeader>

--- a/website/src/components/dynamic-form/dynamic-form.tsx
+++ b/website/src/components/dynamic-form/dynamic-form.tsx
@@ -14,7 +14,7 @@ import { FC, useEffect, useRef, useState } from 'react';
 import { useForm, UseFormReturn } from 'react-hook-form';
 import z, { ZodObject, ZodTypeAny } from 'zod';
 import { MultiSelect } from '../multi-select';
-import { FormActions } from './form-actions';
+import { FormActions, type ExtraAction } from './form-actions';
 
 export type FormField = {
 	label: string;
@@ -148,11 +148,11 @@ type Props = {
 	onSubmit: (values: any) => void;
 	onCancel?: () => void;
 	onDelete?: () => void;
-	onRemoveFromProgram?: () => void;
+	extraAction?: ExtraAction;
 	mode: 'add' | 'edit' | 'readonly';
 };
 
-const DynamicForm: FC<Props> = ({ formSchema, isLoading, onSubmit, onCancel, onDelete, onRemoveFromProgram, mode }) => {
+const DynamicForm: FC<Props> = ({ formSchema, isLoading, onSubmit, onCancel, onDelete, extraAction, mode }) => {
 	const zodSchema = buildZodSchema(formSchema);
 
 	const form = useForm<z.infer<typeof zodSchema>>({
@@ -295,13 +295,7 @@ const DynamicForm: FC<Props> = ({ formSchema, isLoading, onSubmit, onCancel, onD
 						/>
 					);
 				})}
-				<FormActions
-					mode={mode}
-					isLoading={isLoading}
-					onCancel={onCancel}
-					onDelete={onDelete}
-					onRemoveFromProgram={onRemoveFromProgram}
-				/>
+				<FormActions mode={mode} isLoading={isLoading} onCancel={onCancel} onDelete={onDelete} extraAction={extraAction} />
 			</form>
 			{/* TODO: add proper loading state */}
 			{isLoading && (

--- a/website/src/components/dynamic-form/form-actions.tsx
+++ b/website/src/components/dynamic-form/form-actions.tsx
@@ -2,122 +2,123 @@ import { Button } from '@/components/button/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/dialog';
 import { useState } from 'react';
 
+export type ExtraAction = {
+	label: string;
+	confirmTitle: string;
+	confirmDescription: string;
+	confirmLabel?: string;
+	onConfirm: () => void;
+};
+
 type FormActionsProps = {
 	mode: 'add' | 'edit' | 'readonly';
 	isLoading?: boolean;
 	onCancel?: () => void;
 	onDelete?: () => void;
-	onRemoveFromProgram?: () => void;
+	extraAction?: ExtraAction;
 };
 
-export const FormActions = ({ mode, isLoading = false, onCancel, onDelete, onRemoveFromProgram }: FormActionsProps) => {
-	const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
-	const [confirmRemoveFromProgramOpen, setConfirmRemoveFromProgramOpen] = useState(false);
+type ConfirmState = {
+	title: string;
+	description: string;
+	confirmLabel: string;
+	variant: 'default' | 'destructive';
+	onConfirm: () => void;
+};
 
+export const FormActions = ({ mode, isLoading = false, onCancel, onDelete, extraAction }: FormActionsProps) => {
+	const [confirm, setConfirm] = useState<ConfirmState | null>(null);
+
+	const isEdit = mode === 'edit';
 	const showSave = mode !== 'readonly';
-	const showCancel = Boolean(onCancel);
-	const showDelete = mode === 'edit' && Boolean(onDelete);
-	const showRemoveFromProgram = mode === 'edit' && Boolean(onRemoveFromProgram);
 
 	return (
 		<>
-			<div className="flex flex-col gap-3">
-				{(showRemoveFromProgram || showDelete) && (
-					<div className="flex flex-wrap items-center justify-end gap-3">
-						{showDelete && (
-							<Button
-								type="button"
-								variant="ghost"
-								className="text-destructive hover:text-destructive"
-								disabled={isLoading}
-								onClick={() => setConfirmDeleteOpen(true)}
-							>
-								Delete Recipient
-							</Button>
-						)}
-						{showRemoveFromProgram && (
-							<Button
-								type="button"
-								variant="outline"
-								disabled={isLoading}
-								onClick={() => setConfirmRemoveFromProgramOpen(true)}
-							>
-								Remove from program
-							</Button>
-						)}
-					</div>
+			<div className="flex items-center justify-end gap-3">
+				{isEdit && onDelete && (
+					<Button
+						type="button"
+						variant="ghost"
+						className="text-destructive hover:text-destructive"
+						disabled={isLoading}
+						onClick={() =>
+							setConfirm({
+								title: 'Delete item?',
+								description: 'This action cannot be undone.',
+								confirmLabel: 'Delete permanently',
+								variant: 'destructive',
+								onConfirm: onDelete,
+							})
+						}
+					>
+						Delete
+					</Button>
 				)}
 
-				<div className="flex flex-wrap items-center justify-end gap-3">
-					{showCancel && (
-						<Button type="button" variant="outline" disabled={isLoading} onClick={onCancel}>
-							Cancel
-						</Button>
-					)}
+				{isEdit && extraAction && (
+					<Button
+						type="button"
+						variant="outline"
+						disabled={isLoading}
+						onClick={() =>
+							setConfirm({
+								title: extraAction.confirmTitle,
+								description: extraAction.confirmDescription,
+								confirmLabel: extraAction.confirmLabel ?? extraAction.label,
+								variant: 'default',
+								onConfirm: extraAction.onConfirm,
+							})
+						}
+					>
+						{extraAction.label}
+					</Button>
+				)}
 
-					{showSave && (
-						<Button type="submit" disabled={isLoading}>
-							Save
-						</Button>
-					)}
-				</div>
+				{onCancel && (
+					<Button type="button" variant="outline" disabled={isLoading} onClick={onCancel}>
+						Cancel
+					</Button>
+				)}
+
+				{showSave && (
+					<Button type="submit" disabled={isLoading}>
+						Save
+					</Button>
+				)}
 			</div>
 
-			{showDelete && (
-				<Dialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
-					<DialogContent>
-						<DialogHeader>
-							<DialogTitle>Delete item?</DialogTitle>
-						</DialogHeader>
+			<Dialog
+				open={confirm !== null}
+				onOpenChange={(open) => {
+					if (!open) {
+						setConfirm(null);
+					}
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>{confirm?.title}</DialogTitle>
+					</DialogHeader>
 
-						<p className="text-muted-foreground text-sm">This action cannot be undone.</p>
+					<p className="text-muted-foreground text-sm">{confirm?.description}</p>
 
-						<div className="mt-4 flex justify-end gap-2">
-							<Button variant="outline" onClick={() => setConfirmDeleteOpen(false)}>
-								Cancel
-							</Button>
-							<Button
-								variant="destructive"
-								onClick={() => {
-									setConfirmDeleteOpen(false);
-									onDelete?.();
-								}}
-							>
-								Delete permanently
-							</Button>
-						</div>
-					</DialogContent>
-				</Dialog>
-			)}
-
-			{showRemoveFromProgram && (
-				<Dialog open={confirmRemoveFromProgramOpen} onOpenChange={setConfirmRemoveFromProgramOpen}>
-					<DialogContent>
-						<DialogHeader>
-							<DialogTitle>Remove from program?</DialogTitle>
-						</DialogHeader>
-
-						<p className="text-muted-foreground text-sm">
-							The recipient stays in the pool and can be reassigned to a program later. This is only possible for recipients
-							without payouts.
-						</p>
-
-						<div className="mt-4 flex justify-end gap-2">
-							<Button variant="outline" onClick={() => setConfirmRemoveFromProgramOpen(false)}>
-								Cancel
-							</Button>
-							<Button
-								onClick={() => {
-									setConfirmRemoveFromProgramOpen(false);
-									onRemoveFromProgram?.();
-								}}
-							>
-								Remove from program
-							</Button>
-						</div>
-					</DialogContent>
-				</Dialog>
-			)}
+					<div className="mt-4 flex justify-end gap-2">
+						<Button variant="outline" onClick={() => setConfirm(null)}>
+							Cancel
+						</Button>
+						<Button
+							variant={confirm?.variant}
+							onClick={() => {
+								const onConfirm = confirm?.onConfirm;
+								setConfirm(null);
+								onConfirm?.();
+							}}
+						>
+							{confirm?.confirmLabel}
+						</Button>
+					</div>
+				</DialogContent>
+			</Dialog>
 		</>
 	);
 };

--- a/website/src/components/dynamic-form/form-actions.tsx
+++ b/website/src/components/dynamic-form/form-actions.tsx
@@ -28,62 +28,71 @@ type ConfirmState = {
 
 export const FormActions = ({ mode, isLoading = false, onCancel, onDelete, extraAction }: FormActionsProps) => {
 	const [confirm, setConfirm] = useState<ConfirmState | null>(null);
-
-	const isEdit = mode === 'edit';
 	const showSave = mode !== 'readonly';
+	const showSecondaryActions = mode === 'edit' && (onDelete !== undefined || extraAction !== undefined);
+
+	const closeConfirm = () => setConfirm(null);
 
 	return (
 		<>
-			<div className="flex items-center justify-end gap-3">
-				{isEdit && onDelete && (
-					<Button
-						type="button"
-						variant="ghost"
-						className="text-destructive hover:text-destructive"
-						disabled={isLoading}
-						onClick={() =>
-							setConfirm({
-								title: 'Delete item?',
-								description: 'This action cannot be undone.',
-								confirmLabel: 'Delete permanently',
-								variant: 'destructive',
-								onConfirm: onDelete,
-							})
-						}
-					>
-						Delete
-					</Button>
+			<div className="flex min-w-0 flex-wrap items-center justify-end gap-3">
+				{showSecondaryActions && (
+					<div className="mr-auto flex flex-wrap items-center gap-3">
+						{onDelete && (
+							<Button
+								type="button"
+								variant="ghost"
+								className="text-destructive hover:text-destructive"
+								disabled={isLoading}
+								onClick={() =>
+									setConfirm({
+										title: 'Delete item?',
+										description: 'This action cannot be undone.',
+										confirmLabel: 'Delete permanently',
+										variant: 'destructive',
+										onConfirm: onDelete,
+									})
+								}
+							>
+								Delete
+							</Button>
+						)}
+
+						{extraAction && (
+							<Button
+								type="button"
+								variant="ghost"
+								disabled={isLoading}
+								onClick={() =>
+									setConfirm({
+										title: extraAction.confirmTitle,
+										description: extraAction.confirmDescription,
+										confirmLabel: extraAction.confirmLabel ?? extraAction.label,
+										variant: 'default',
+										onConfirm: extraAction.onConfirm,
+									})
+								}
+							>
+								{extraAction.label}
+							</Button>
+						)}
+					</div>
 				)}
 
-				{isEdit && extraAction && (
-					<Button
-						type="button"
-						variant="outline"
-						disabled={isLoading}
-						onClick={() =>
-							setConfirm({
-								title: extraAction.confirmTitle,
-								description: extraAction.confirmDescription,
-								confirmLabel: extraAction.confirmLabel ?? extraAction.label,
-								variant: 'default',
-								onConfirm: extraAction.onConfirm,
-							})
-						}
-					>
-						{extraAction.label}
-					</Button>
-				)}
+				{(onCancel !== undefined || showSave) && (
+					<div className="flex items-center gap-3">
+						{onCancel && (
+							<Button type="button" variant="outline" disabled={isLoading} onClick={onCancel}>
+								Cancel
+							</Button>
+						)}
 
-				{onCancel && (
-					<Button type="button" variant="outline" disabled={isLoading} onClick={onCancel}>
-						Cancel
-					</Button>
-				)}
-
-				{showSave && (
-					<Button type="submit" disabled={isLoading}>
-						Save
-					</Button>
+						{showSave && (
+							<Button type="submit" disabled={isLoading}>
+								Save
+							</Button>
+						)}
+					</div>
 				)}
 			</div>
 
@@ -91,7 +100,7 @@ export const FormActions = ({ mode, isLoading = false, onCancel, onDelete, extra
 				open={confirm !== null}
 				onOpenChange={(open) => {
 					if (!open) {
-						setConfirm(null);
+						closeConfirm();
 					}
 				}}
 			>
@@ -103,14 +112,14 @@ export const FormActions = ({ mode, isLoading = false, onCancel, onDelete, extra
 					<p className="text-muted-foreground text-sm">{confirm?.description}</p>
 
 					<div className="mt-4 flex justify-end gap-2">
-						<Button variant="outline" onClick={() => setConfirm(null)}>
+						<Button variant="outline" onClick={closeConfirm}>
 							Cancel
 						</Button>
 						<Button
 							variant={confirm?.variant}
 							onClick={() => {
 								const onConfirm = confirm?.onConfirm;
-								setConfirm(null);
+								closeConfirm();
 								onConfirm?.();
 							}}
 						>

--- a/website/src/components/recipient/recipient-form.tsx
+++ b/website/src/components/recipient/recipient-form.tsx
@@ -312,6 +312,16 @@ export const RecipientForm = ({
 	}, [sessionType, programId]);
 
 	const mode = recipientId ? 'edit' : 'add';
+	const extraAction =
+		recipient?.program && sessionType === 'user'
+			? {
+					label: 'Remove from program',
+					confirmTitle: 'Remove from program?',
+					confirmDescription:
+						'The recipient stays in the pool and can be reassigned to a program later. This is only possible for recipients without payouts.',
+					onConfirm: onRemoveFromProgram,
+				}
+			: undefined;
 
 	return (
 		<DynamicForm
@@ -320,7 +330,7 @@ export const RecipientForm = ({
 			onSubmit={onSubmit}
 			onCancel={onCancel}
 			onDelete={onDelete}
-			onRemoveFromProgram={recipient?.program && sessionType === 'user' ? onRemoveFromProgram : undefined}
+			extraAction={extraAction}
 			mode={mode}
 		/>
 	);


### PR DESCRIPTION
## Summary
- Restore a generic **Delete** button and single-row layout on shared form actions (programs, payouts, orgs, etc. were showing “Delete Recipient” on two rows)
- Keep “Remove from program” as an optional extra action, passed only from the recipient form

## Test plan
- [ ] Edit a recipient assigned to a program: Delete and Remove from program both appear, confirm dialogs still work
- [ ] Edit program settings / a payout / another admin form: Delete label is “Delete”, Cancel and Save stay on the same row
- [ ] Add-mode forms still show Cancel/Save without Delete


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable extra actions to forms, including custom labels and confirmation messages.
  * Improved the recipient removal flow with a confirmation dialog before removing a recipient from a program.
  * Confirmation dialogs now close before the requested action is performed.

* **UI Improvements**
  * Increased the recipient dialog’s maximum width on small screens for improved usability.
  * Updated form action layouts so edit, delete, extra action, cancel, and save controls display more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->