### PR TITLE
docs: grant logging.configWriter for Slack log alerts

### DIFF
--- a/website/infra/README.md
+++ b/website/infra/README.md
@@ -74,6 +74,13 @@ gcloud projects add-iam-policy-binding social-income-staging \
   --condition=None
 ```
 
+```
+gcloud projects add-iam-policy-binding social-income-staging \
+  --member="serviceAccount:terraform-deployer@social-income-staging.iam.gserviceaccount.com" \
+  --role="roles/logging.configWriter" \
+  --condition=None
+```
+
 ## Step 2: Create state bucket and assign roles
 
 ```
@@ -129,5 +136,5 @@ you will have to give access to the terraform deployer for the domain.
 In Cloud Monitoring, add a Slack notification channel for
 `#social-income-monitoring` and authorize the workspace. Invite the
 Google Cloud Monitoring app to that channel. Terraform attaches the
-alert policy to this existing channel (`roles/monitoring.admin` is
-granted in Step 1).
+alert policy to this existing channel (`roles/monitoring.admin` and
+`roles/logging.configWriter` are granted in Step 1).


### PR DESCRIPTION
## Summary
- Document `roles/logging.configWriter` for the Terraform deployer. Log-based Slack alerts need `logging.notificationRules.create`, which `roles/monitoring.admin` does not include.
- Follow-up to #2728: the staging apply failed creating `google_monitoring_alert_policy.slack_alerts` until this role is granted in GCP.

## Test plan
- [ ] Grant `roles/logging.configWriter` to `terraform-deployer@social-income-staging` with `--condition=None`
- [ ] Re-run the failed Terraform deploy workflow on `main`
- [ ] Confirm the alert policy `Cloud Run SLACK_ALERT logs (staging)` exists in Monitoring


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment permissions documentation to include logging configuration access.
  * Expanded Slack monitoring setup instructions to cover the additional required role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->