### PR TITLE
feat: page Slack when Cloud Run or Postgres is down

### DIFF
--- a/website/infra/monitoring.tf
+++ b/website/infra/monitoring.tf
@@ -39,3 +39,75 @@ resource "google_monitoring_alert_policy" "slack_alerts" {
 
   depends_on = [google_project_service.monitoring]
 }
+
+resource "google_monitoring_uptime_check_config" "health_ready" {
+  display_name = "Website health / DB (${var.env})"
+  timeout      = "10s"
+  period       = "60s"
+
+  http_check {
+    path         = "/api/health/ready"
+    port         = 443
+    use_ssl      = true
+    validate_ssl = true
+  }
+
+  monitored_resource {
+    type = "uptime_url"
+    labels = {
+      project_id = var.gcp_project_id
+      host       = var.website_domain
+    }
+  }
+
+  content_matchers {
+    content = "\"status\":\"ok\""
+  }
+
+  depends_on = [google_project_service.monitoring]
+}
+
+resource "google_monitoring_alert_policy" "uptime_health_ready" {
+  display_name = "Website health / DB down (${var.env})"
+  combiner     = "OR"
+
+  documentation {
+    content   = "GET https://${var.website_domain}/api/health/ready failed. Cloud Run is unreachable or Postgres did not answer SELECT 1."
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "Uptime check failed (${var.env})"
+    condition_threshold {
+      filter          = <<-EOT
+        metric.type="monitoring.googleapis.com/uptime_check/check_passed"
+        metric.label."check_id"="${google_monitoring_uptime_check_config.health_ready.uptime_check_id}"
+        resource.type="uptime_url"
+      EOT
+      duration        = "60s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = 1
+
+      aggregations {
+        alignment_period     = "1200s"
+        per_series_aligner   = "ALIGN_NEXT_OLDER"
+        cross_series_reducer = "REDUCE_COUNT_FALSE"
+        group_by_fields      = ["resource.label.*"]
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = [
+    data.google_monitoring_notification_channel.slack_alerts.name,
+  ]
+
+  alert_strategy {
+    auto_close = "3600s"
+  }
+
+  depends_on = [google_project_service.monitoring]
+}

--- a/website/src/app/api/health/ready/route.ts
+++ b/website/src/app/api/health/ready/route.ts
@@ -1,6 +1,8 @@
 import { prisma } from '@/lib/database/prisma';
 import { NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 export const GET = async () => {
 	try {
 		await prisma.$queryRaw`SELECT 1`;
@@ -9,6 +11,6 @@ export const GET = async () => {
 	} catch (error) {
 		console.error('Healthcheck DB error:', error);
 
-		return NextResponse.json({ status: 'unhealthy' }, { status: 500 });
+		return NextResponse.json({ status: 'unhealthy' }, { status: 503 });
 	}
 };


### PR DESCRIPTION
## Summary
- Cloud Monitoring calls `GET /api/health/ready` every 60 seconds and pages `#social-income-monitoring` when Cloud Run is unreachable or Postgres does not answer `SELECT 1`.
- The ready route always runs dynamically and returns **503** (not 500) when the database is down, so the uptime check treats it as failure.
- This covers outages that `SLACK_ALERT` logs cannot: if Cloud Run itself is down, the app never writes a log.

## Test plan
- [ ] Confirm `GET /api/health/ready` returns `200 {"status":"ok"}` locally with Postgres up, and `503 {"status":"unhealthy"}` if the DB is stopped.
- [ ] After staging deploy: in Cloud Monitoring, confirm the uptime check `Website health / DB (staging)` exists and is passing.
- [ ] Confirm the Slack channel is the existing `#social-income-monitoring` notification channel (same as `SLACK_ALERT`).
- [ ] Optional: temporarily break the check (wrong path or stop Cloud SQL in a controlled test) and confirm Slack fires, then restore.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring for the service readiness endpoint.
  * Sends Slack alerts when the readiness check fails for at least 60 seconds and automatically closes alerts after one hour.

* **Bug Fixes**
  * Readiness checks now accurately report temporary database failures with an HTTP 503 status.
  * Ensured health status responses reflect current service availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->