### PR TITLE
Include triggering log in SLACK_ALERT Slack messages

### DIFF
--- a/website/infra/monitoring.tf
+++ b/website/infra/monitoring.tf
@@ -11,8 +11,13 @@ resource "google_monitoring_alert_policy" "slack_alerts" {
   enabled      = true
 
   documentation {
-    content   = "A Cloud Run log contained SLACK_ALERT. Open Logs Explorer and search for SLACK_ALERT on ${google_cloud_run_service.google_cloud_run_service.name}."
     mime_type = "text/markdown"
+    subject   = "SLACK_ALERT (${var.env}): $${log.extracted_label.message}"
+    content   = <<-EOT
+      **SLACK_ALERT** on ${google_cloud_run_service.google_cloud_run_service.name}
+
+      $${log.extracted_label.message}
+    EOT
   }
 
   conditions {
@@ -21,8 +26,11 @@ resource "google_monitoring_alert_policy" "slack_alerts" {
       filter = <<-EOT
         resource.type="cloud_run_revision"
         resource.labels.service_name="${google_cloud_run_service.google_cloud_run_service.name}"
-        SEARCH("`SLACK_ALERT`")
+        textPayload:"SLACK_ALERT"
       EOT
+      label_extractors = {
+        message = "EXTRACT(textPayload)"
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Extract the Cloud Run `textPayload` from `SLACK_ALERT` log matches and put it in the alert subject and documentation.
- Slack will show the actual `console.error` line instead of only a generic “view alert” card.

## Test plan
- [ ] Apply Terraform to staging
- [ ] Wait out the 5-minute notification rate limit from the last alert
- [ ] Hit `GET /api/v1/slack-alert-test` (with the scheduler API key)
- [ ] Confirm the Slack message title/body includes `SLACK_ALERT: Test alert from GET /api/v1/slack-alert-test`


Made with [Cursor](https://cursor.com)