### PR TITLE
Disable SLACK_ALERT Slack pages on staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,10 +286,12 @@ https://socialincome.org/v1/api-docs
 
 ## Monitoring
 
-The website pages Slack (`#social-income-monitoring`) when Cloud Run
-logs contain `SLACK_ALERT`. Prefix `console.error` with that token for
-failures that must not stay silent (Stripe webhooks, payment imports,
-scheduler jobs). At most one Slack message is sent every 5 minutes.
+The website pages Slack (`#social-income-monitoring`) when production
+Cloud Run logs contain `SLACK_ALERT`. Prefix `console.error` with that
+token for failures that must not stay silent (Stripe webhooks, payment
+imports, scheduler jobs). Staging still writes the logs but does not
+page Slack, because its Stripe and campaign data is incomplete. At most
+one Slack message is sent every 5 minutes.
 
 The recipients app still reports errors to Sentry.
 

--- a/website/infra/monitoring.tf
+++ b/website/infra/monitoring.tf
@@ -8,7 +8,7 @@ data "google_monitoring_notification_channel" "slack_alerts" {
 resource "google_monitoring_alert_policy" "slack_alerts" {
   display_name = "Cloud Run SLACK_ALERT logs (${var.env})"
   combiner     = "OR"
-  enabled      = true
+  enabled      = var.env == "prod"
 
   documentation {
     mime_type = "text/markdown"


### PR DESCRIPTION
## Summary
- Turn off the Cloud Run `SLACK_ALERT` log-based policy on staging (`enabled = var.env == "prod"`).
- Staging Stripe and campaign data is incomplete, so those alerts just noise `#social-income-monitoring`. Production still pages. Staging still writes the logs.

## Test plan
- [ ] Apply Terraform to staging and confirm the `Cloud Run SLACK_ALERT logs (staging)` policy is disabled
- [ ] Confirm production policy stays enabled
- [ ] Optional: hit `/api/v1/slack-alert-test` on staging and confirm Slack is not paged


Made with [Cursor](https://cursor.com)