### PR TITLE
Keep SLACK_ALERT Slack titles short

### DIFF
--- a/website/infra/monitoring.tf
+++ b/website/infra/monitoring.tf
@@ -12,12 +12,8 @@ resource "google_monitoring_alert_policy" "slack_alerts" {
 
   documentation {
     mime_type = "text/markdown"
-    subject   = "SLACK_ALERT (${var.env}): $${log.extracted_label.message}"
-    content   = <<-EOT
-      **SLACK_ALERT** on ${google_cloud_run_service.google_cloud_run_service.name}
-
-      $${log.extracted_label.message}
-    EOT
+    subject   = "SLACK_ALERT (${var.env})"
+    content   = "$${log.extracted_label.message}"
   }
 
   conditions {


### PR DESCRIPTION
## Summary
- Slack title is now `SLACK_ALERT (staging)` / `SLACK_ALERT (prod)` instead of the full log line.
- The triggering Cloud Run log stays in the notification documentation body.

## Test plan
- [ ] Apply Terraform
- [ ] Trigger a `SLACK_ALERT` (or wait for one)
- [ ] Confirm the Slack title is short and the log appears only in the description


Made with [Cursor](https://cursor.com)