### PR TITLE
fix: rotate Cloud SQL password weekly instead of on every deploy

### DIFF
--- a/website/infra/.terraform.lock.hcl
+++ b/website/infra/.terraform.lock.hcl
@@ -2,7 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/google" {
-  version = "7.41.0"
+  version     = "7.41.0"
+  constraints = "~> 7.41"
   hashes = [
     "h1:+wur8ZrXd5n6e4qXbiSRq9GntW/gmZ7rsWsvJPo3bB4=",
     "h1:5GbcqIadyqkbxM5MATebNDSKHfkCXsCwQzqbt5DZpbQ=",
@@ -27,5 +28,47 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:cc1f3acaaf68f4ff19ef5893e9cefca63e5b93c0800517dfc0a60672911c3f26",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
     "zh:fd3a26b4d131414045af53780aae841e930ec6af432794768549760c7d364765",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.14.1"
+  constraints = "~> 0.13"
+  hashes = [
+    "h1:r93SxP++6gUlwCHDQ5OkRmcU8B0yv6ZA9nF0Dh6NJmA=",
+    "zh:0837ca5b057e5cff94dff7de2fcccafb4abaa33c45de193fe2853e684818a267",
+    "zh:15a122f72d9e0f34fc5384cc7ec089319641fee5c319748a3aa02fc42f459969",
+    "zh:342fb83093a280ea7ee0654feae1f5867c62eb8eebc1ab46f9a7ab0b4c878a62",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:99f169834d3370b8341381c6a9c7a8b01fb26027531faa38e6fb49cc23916f68",
+    "zh:9f482917c7a28cf2436578be7aa9f04f8c811aba8b5949e0223ea987a2757a91",
+    "zh:ac6b5b8732826f2d1129a8a4a038ac7a7a9ca7b77d2a4608e5703be1a1e2bff0",
+    "zh:c54782a27d58ce04f6696c6fc0b2cf1e2fba6bed239fb520521a7bce7d7193cb",
+    "zh:c8d0ddc8f575ecb44f025d54edbfe118e26397fe328a67be62325766f31eb6e7",
+    "zh:d043b96f204edd2353bf6b2a34e645ffdee2e9634d9bb747331320444810a538",
+    "zh:e32c288501ca9a6c9d22b52e839dd391fc7083d54ee6b8dc296ce0e6bd3e57ef",
+    "zh:e47fcc7bb4e9ab5cc522c3b06e4fa9c0bf94b84be8210bc6b1655c44acb2addc",
+    "zh:f61bf218322bcbe0bd2d56bba738e7fa485e9b54244e13aa12de741b37d450c0",
   ]
 }

--- a/website/infra/database.tf
+++ b/website/infra/database.tf
@@ -2,12 +2,16 @@ locals {
   is_prod = var.env == "prod"
 }
 
+resource "time_rotating" "psql_admin_password" {
+  rotation_days = 7
+}
+
 resource "random_password" "psql_admin_password" {
   length  = 16
   special = false
 
   keepers = {
-    rotation = timestamp()
+    rotation = time_rotating.psql_admin_password.rotation_rfc3339
   }
 }
 

--- a/website/infra/providers.tf
+++ b/website/infra/providers.tf
@@ -5,4 +5,19 @@ provider "google" {
 
 terraform {
   backend "gcs" {}
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.41"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Replace `timestamp()` password keeper with `time_rotating` (7 days) so most deploys no longer change the Cloud SQL credential
- Pin `hashicorp/time` and `hashicorp/random` providers and update the lockfile

## Context
Every `terraform apply` regenerated the DB password and updated Cloud Run before the new revision was ready, causing brief `/api/health/ready` failures and Slack uptime alerts.

## Test plan
- [ ] `terraform -chdir=website/infra init -backend=false && fmt -check && validate` passes in CI
- [ ] After merge to staging: first apply rotates the password once (expected); a second apply within the same week must not change `random_password` / `google_sql_user`
- [ ] `/api/health/ready` returns 200 after deploy

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database administrator passwords now rotate automatically on a weekly schedule.

* **Chores**
  * Infrastructure provider versions are now explicitly pinned for more consistent deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->