### PR TITLE
feat: alert on 5xx, scheduler failures, and homepage downtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,12 +286,18 @@ https://socialincome.org/v1/api-docs
 
 ## Monitoring
 
-The website pages Slack (`#social-income-monitoring`) when production
-Cloud Run logs contain `SLACK_ALERT`. Prefix `console.error` with that
-token for failures that must not stay silent (Stripe webhooks, payment
-imports, scheduler jobs). Staging still writes the logs but does not
-page Slack, because its Stripe and campaign data is incomplete. At most
-one Slack message is sent every 5 minutes.
+The website pages Slack (`#social-income-monitoring`) for production
+failures that must not stay silent:
+
+- Cloud Run logs that contain `SLACK_ALERT` (Stripe webhooks, payment
+  imports, scheduler jobs). Prefix `console.error` with that token.
+  Staging still writes the logs but does not page Slack, because its
+  Stripe and campaign data is incomplete. At most one Slack message is
+  sent every 5 minutes.
+- Uptime checks every 60s: `/api/health/website`, `/api/health/database`,
+  and the public homepage `/en/int`.
+- Cloud Run 5xx bursts, Cloud Scheduler job errors, Cloud SQL CPU and
+  connections, and Cloud Run memory / OOM.
 
 The recipients app still reports errors to Sentry.
 

--- a/website/infra/monitoring.tf
+++ b/website/infra/monitoring.tf
@@ -5,15 +5,151 @@ data "google_monitoring_notification_channel" "slack_alerts" {
   }
 }
 
+locals {
+  slack_notification_channels = [data.google_monitoring_notification_channel.slack_alerts.name]
+  prod_alerts_enabled         = var.env == "prod"
+  cloud_run_service_name      = google_cloud_run_service.google_cloud_run_service.name
+  cloud_sql_database_id       = "${var.gcp_project_id}:${google_sql_database_instance.google_sql_database_instance.name}"
+
+  uptime_health_checks = {
+    website = {
+      path               = "/api/health/website"
+      timeout            = "10s"
+      content            = "\"status\":\"ok\""
+      check_display_name = "Website (${var.env})"
+      alert_name         = "Website unreachable (${var.env})"
+      alert_content      = "GET https://${var.website_domain}/api/health/website failed. Cloud Run is unreachable, TLS failed, or the container is not responding."
+    }
+    database = {
+      path               = "/api/health/database"
+      timeout            = "10s"
+      content            = "\"status\":\"ok\""
+      check_display_name = "Website database (${var.env})"
+      alert_name         = "Website DB down (${var.env})"
+      alert_content      = "GET https://${var.website_domain}/api/health/database failed. Postgres did not answer SELECT 1."
+    }
+    homepage = {
+      path               = "/en/int"
+      timeout            = "20s"
+      content            = "<title>Social Income</title>"
+      check_display_name = "Website homepage (${var.env})"
+      alert_name         = "Website homepage down (${var.env})"
+      alert_content      = "GET https://${var.website_domain}/en/int failed. SSR, Storyblok, or the public homepage is not returning a healthy page."
+    }
+  }
+
+  scheduler_job_ids = [
+    google_cloud_scheduler_job.google_cloud_scheduler_job_exchange_rate.name,
+    google_cloud_scheduler_job.google_cloud_scheduler_job_reserves_calculation.name,
+    google_cloud_scheduler_job.google_cloud_scheduler_job_post_finance_import.name,
+  ]
+
+  metric_alerts = {
+    cloud_run_5xx = {
+      display_name         = "Cloud Run 5xx (${var.env})"
+      condition_name       = "More than 10 5xx in 5 minutes (${var.env})"
+      content              = "Cloud Run ${local.cloud_run_service_name} returned more than ten 5xx responses in five minutes. Check OTP, checkout, recipients API, and SSR logs."
+      filter               = <<-EOT
+        resource.type="cloud_run_revision"
+        resource.labels.service_name="${local.cloud_run_service_name}"
+        metric.type="run.googleapis.com/request_count"
+        metric.labels.response_code_class="5xx"
+      EOT
+      duration             = "0s"
+      threshold            = 10
+      alignment_period     = "300s"
+      per_series_aligner   = "ALIGN_DELTA"
+      cross_series_reducer = "REDUCE_SUM"
+      group_by             = "resource.label.service_name"
+    }
+    cloud_sql_cpu = {
+      display_name         = "Cloud SQL CPU high (${var.env})"
+      condition_name       = "CPU utilization > 80% for 10 minutes (${var.env})"
+      content              = "Postgres CPU on ${local.cloud_sql_database_id} stayed above 80% for 10 minutes."
+      filter               = <<-EOT
+        resource.type="cloudsql_database"
+        resource.labels.database_id="${local.cloud_sql_database_id}"
+        metric.type="cloudsql.googleapis.com/database/cpu/utilization"
+      EOT
+      duration             = "600s"
+      threshold            = 0.8
+      alignment_period     = "300s"
+      per_series_aligner   = "ALIGN_MEAN"
+      cross_series_reducer = "REDUCE_MEAN"
+      group_by             = "resource.label.database_id"
+    }
+    cloud_sql_connections = {
+      display_name         = "Cloud SQL connections high (${var.env})"
+      condition_name       = "PostgreSQL backends > 80 for 5 minutes (${var.env})"
+      content              = "Postgres on ${local.cloud_sql_database_id} had more than 80 connections for 5 minutes. Prod is db-g1-small; check Prisma pool usage and Cloud Run maxScale."
+      filter               = <<-EOT
+        resource.type="cloudsql_database"
+        resource.labels.database_id="${local.cloud_sql_database_id}"
+        metric.type="cloudsql.googleapis.com/database/postgresql/num_backends"
+      EOT
+      duration             = "300s"
+      threshold            = 80
+      alignment_period     = "60s"
+      per_series_aligner   = "ALIGN_MAX"
+      cross_series_reducer = "REDUCE_MAX"
+      group_by             = "resource.label.database_id"
+    }
+    cloud_run_memory = {
+      display_name         = "Cloud Run memory high (${var.env})"
+      condition_name       = "Memory utilization p99 > 90% for 5 minutes (${var.env})"
+      content              = "Cloud Run ${local.cloud_run_service_name} p99 memory utilization stayed above 90% for 5 minutes. The container limit is 1Gi."
+      filter               = <<-EOT
+        resource.type="cloud_run_revision"
+        resource.labels.service_name="${local.cloud_run_service_name}"
+        metric.type="run.googleapis.com/container/memory/utilizations"
+      EOT
+      duration             = "300s"
+      threshold            = 0.9
+      alignment_period     = "60s"
+      per_series_aligner   = "ALIGN_PERCENTILE_99"
+      cross_series_reducer = "REDUCE_MAX"
+      group_by             = "resource.label.service_name"
+    }
+  }
+
+  log_alerts = {
+    scheduler_failed = {
+      display_name   = "Cloud Scheduler job failed (${var.env})"
+      condition_name = "Scheduler ERROR log (${var.env})"
+      content        = "A scheduler job failed before or instead of writing SLACK_ALERT. Check ${join(", ", local.scheduler_job_ids)}."
+      filter         = <<-EOT
+        resource.type="cloud_scheduler_job"
+        severity>=ERROR
+        (
+          ${join("\n  OR ", [for job_id in local.scheduler_job_ids : "resource.labels.job_id=\"${job_id}\""])}
+        )
+      EOT
+    }
+    cloud_run_oom = {
+      display_name   = "Cloud Run out of memory (${var.env})"
+      condition_name = "OOM log (${var.env})"
+      content        = "Cloud Run ${local.cloud_run_service_name} killed a request because it exceeded the 1Gi memory limit."
+      filter         = <<-EOT
+        resource.type="cloud_run_revision"
+        resource.labels.service_name="${local.cloud_run_service_name}"
+        (
+          textPayload:"exceeded the available memory"
+          OR jsonPayload.message:"exceeded the available memory"
+        )
+      EOT
+    }
+  }
+}
+
 resource "google_monitoring_alert_policy" "slack_alerts" {
   display_name = "Cloud Run SLACK_ALERT logs (${var.env})"
   combiner     = "OR"
-  enabled      = var.env == "prod"
+  enabled      = local.prod_alerts_enabled
 
   documentation {
     mime_type = "text/markdown"
     subject   = "SLACK_ALERT (${var.env})"
-    content   = "$${log.extracted_label.message}"
+    content   = "$${log.extracted_label.message}$${log.extracted_label.json_message}"
   }
 
   conditions {
@@ -21,11 +157,15 @@ resource "google_monitoring_alert_policy" "slack_alerts" {
     condition_matched_log {
       filter = <<-EOT
         resource.type="cloud_run_revision"
-        resource.labels.service_name="${google_cloud_run_service.google_cloud_run_service.name}"
-        textPayload:"SLACK_ALERT"
+        resource.labels.service_name="${local.cloud_run_service_name}"
+        (
+          textPayload:"SLACK_ALERT"
+          OR jsonPayload.message:"SLACK_ALERT"
+        )
       EOT
       label_extractors = {
-        message = "EXTRACT(textPayload)"
+        message      = "EXTRACT(textPayload)"
+        json_message = "EXTRACT(jsonPayload.message)"
       }
     }
   }
@@ -37,34 +177,15 @@ resource "google_monitoring_alert_policy" "slack_alerts" {
     auto_close = "3600s"
   }
 
-  notification_channels = [
-    data.google_monitoring_notification_channel.slack_alerts.name,
-  ]
+  notification_channels = local.slack_notification_channels
 
   depends_on = [google_project_service.monitoring]
-}
-
-locals {
-  uptime_health_checks = {
-    website = {
-      path               = "/api/health/website"
-      check_display_name = "Website (${var.env})"
-      alert_name         = "Website unreachable (${var.env})"
-      alert_content      = "GET https://${var.website_domain}/api/health/website failed. Cloud Run is unreachable, TLS failed, or the container is not responding."
-    }
-    database = {
-      path               = "/api/health/database"
-      check_display_name = "Website database (${var.env})"
-      alert_name         = "Website DB down (${var.env})"
-      alert_content      = "GET https://${var.website_domain}/api/health/database failed. Postgres did not answer SELECT 1."
-    }
-  }
 }
 
 resource "google_monitoring_uptime_check_config" "health" {
   for_each     = local.uptime_health_checks
   display_name = each.value.check_display_name
-  timeout      = "10s"
+  timeout      = each.value.timeout
   period       = "60s"
 
   http_check {
@@ -83,7 +204,7 @@ resource "google_monitoring_uptime_check_config" "health" {
   }
 
   content_matchers {
-    content = "\"status\":\"ok\""
+    content = each.value.content
   }
 
   depends_on = [google_project_service.monitoring]
@@ -125,13 +246,87 @@ resource "google_monitoring_alert_policy" "uptime_health" {
     }
   }
 
-  notification_channels = [
-    data.google_monitoring_notification_channel.slack_alerts.name,
-  ]
+  notification_channels = local.slack_notification_channels
 
   alert_strategy {
     auto_close = "3600s"
   }
+
+  depends_on = [google_project_service.monitoring]
+}
+
+resource "google_monitoring_alert_policy" "metric" {
+  for_each     = local.metric_alerts
+  display_name = each.value.display_name
+  combiner     = "OR"
+  enabled      = local.prod_alerts_enabled
+
+  documentation {
+    mime_type = "text/markdown"
+    subject   = each.value.display_name
+    content   = each.value.content
+  }
+
+  conditions {
+    display_name = each.value.condition_name
+    condition_threshold {
+      filter          = each.value.filter
+      duration        = each.value.duration
+      comparison      = "COMPARISON_GT"
+      threshold_value = each.value.threshold
+
+      aggregations {
+        alignment_period     = each.value.alignment_period
+        per_series_aligner   = each.value.per_series_aligner
+        cross_series_reducer = each.value.cross_series_reducer
+        group_by_fields      = [each.value.group_by]
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = local.slack_notification_channels
+
+  alert_strategy {
+    auto_close = "3600s"
+  }
+
+  depends_on = [google_project_service.monitoring]
+}
+
+resource "google_monitoring_alert_policy" "logs" {
+  for_each     = local.log_alerts
+  display_name = each.value.display_name
+  combiner     = "OR"
+  enabled      = local.prod_alerts_enabled
+
+  documentation {
+    mime_type = "text/markdown"
+    subject   = each.value.display_name
+    content   = each.value.content
+  }
+
+  conditions {
+    display_name = each.value.condition_name
+    condition_matched_log {
+      filter = each.value.filter
+      label_extractors = {
+        message = "EXTRACT(textPayload)"
+      }
+    }
+  }
+
+  alert_strategy {
+    notification_rate_limit {
+      period = "300s"
+    }
+    auto_close = "3600s"
+  }
+
+  notification_channels = local.slack_notification_channels
 
   depends_on = [google_project_service.monitoring]
 }

--- a/website/src/app/api/v1/stripe/webhook/route.ts
+++ b/website/src/app/api/v1/stripe/webhook/route.ts
@@ -20,12 +20,7 @@ export const POST = async (request: NextRequest) => {
 		const result = await services.stripe.handleWebhookEvent(body, signature, webhookSecret);
 
 		if (!result.success) {
-			console.error(`Stripe webhook processing failed: ${result.error}`, {
-				error: result.error,
-				signature: `${signature.slice(0, 20)}...`,
-			});
-
-			return NextResponse.json({ error: result.error }, { status: 400 });
+			return NextResponse.json({ error: result.error }, { status: result.status ?? 500 });
 		}
 
 		return NextResponse.json({ received: true });

--- a/website/src/lib/services/stripe/stripe.service.ts
+++ b/website/src/lib/services/stripe/stripe.service.ts
@@ -825,9 +825,13 @@ export class StripeService extends BaseService {
 					return this.resultOk({ skipReason: `Unhandled event type: ${event.type}` });
 			}
 		} catch (error) {
-			console.error(error);
+			if (error instanceof Stripe.errors.StripeSignatureVerificationError) {
+				return this.resultFail('Invalid Stripe signature', 400);
+			}
 
-			return this.resultFail(`Failed to handle webhook event: ${JSON.stringify(error)}`);
+			console.error(`${SLACK_ALERT}: Stripe webhook handler failed`, { error });
+
+			return this.resultFail('Failed to handle webhook event');
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add production Slack alerts for Cloud Run 5xx, Cloud Scheduler job errors, Cloud SQL CPU/connections, and Cloud Run memory/OOM.
- Uptime-check the public homepage (`/en/int`) in addition to the health JSON endpoints, and match `SLACK_ALERT` in both text and JSON logs.
- Return 500 from Stripe webhooks on processing failures so Stripe retries; invalid signatures stay 400 without paging.

## Test plan
- [ ] Review the new alert policies and homepage uptime check in `website/infra/monitoring.tf`.
- [ ] Confirm the Stripe webhook route returns 400 for invalid signatures and 500 for processing failures.
- [ ] Confirm `SLACK_ALERT` is still written for unexpected webhook handler errors.


Made with [Cursor](https://cursor.com)