### PR TITLE
chore: add storyblok management token to deployment

### DIFF
--- a/.github/workflows/deploy-terraform-to-gcp-prod.yml
+++ b/.github/workflows/deploy-terraform-to-gcp-prod.yml
@@ -83,6 +83,7 @@ jobs:
           TF_VAR_firebase_service_account_json: ${{ secrets.TF_PROD_FIREBASE_SERVICE_ACCOUNT_JSON }}
           TF_VAR_storyblok_preview_secret: ${{ secrets.TF_PROD_STORYBLOK_PREVIEW_SECRET }}
           TF_VAR_storyblok_webhook_secret: ${{ secrets.TF_PROD_STORYBLOK_WEBHOOK_SECRET }}
+          TF_VAR_storyblok_management_token: ${{ secrets.TF_PROD_STORYBLOK_MANAGEMENT_TOKEN }}
           TF_VAR_mapbox_token: ${{ secrets.TF_PROD_MAPBOX_TOKEN }}
           TF_VAR_env: ${{ env.ENVIRONMENT }}
           TF_VAR_app_name: ${{ env.APP_NAME }}

--- a/.github/workflows/deploy-terraform-to-gcp-staging.yml
+++ b/.github/workflows/deploy-terraform-to-gcp-staging.yml
@@ -82,6 +82,7 @@ jobs:
           TF_VAR_firebase_service_account_json: ${{ secrets.TF_STAGING_FIREBASE_SERVICE_ACCOUNT_JSON }}
           TF_VAR_storyblok_preview_secret: ${{ secrets.TF_STAGING_STORYBLOK_PREVIEW_SECRET }}
           TF_VAR_storyblok_webhook_secret: ${{ secrets.TF_STAGING_STORYBLOK_WEBHOOK_SECRET }}
+          TF_VAR_storyblok_management_token: ${{ secrets.TF_STAGING_STORYBLOK_MANAGEMENT_TOKEN }}
           TF_VAR_mapbox_token: ${{ secrets.TF_STAGING_MAPBOX_TOKEN }}
           TF_VAR_env: ${{ env.ENVIRONMENT }}
           TF_VAR_app_name: ${{ env.APP_NAME }}

--- a/README.md
+++ b/README.md
@@ -101,10 +101,11 @@ If you need this token, ask a maintainer or contact
 `support@socialincome.org`. Do not commit real API keys or secrets.
 
 Maintainers may also need these Storyblok values for preview mode, webhooks,
-or schema/type generation:
+campaign submissions, or schema/type generation:
 
 - `STORYBLOK_PREVIEW_SECRET`
 - `STORYBLOK_WEBHOOK_SECRET`
+- `STORYBLOK_MANAGEMENT_TOKEN`
 - `STORYBLOK_PERSONAL_ACCESS_TOKEN`
 - `STORYBLOK_SPACE_ID`
 
@@ -263,15 +264,20 @@ still work after a campaign becomes inactive.
 
 Server-only configuration lives in
 `website/src/lib/config/campaign-submission.config.ts`. Set the Management API
-token in `website/.env.local`:
+token in `website/.env.local` for local development:
 
 ```bash
 STORYBLOK_MANAGEMENT_TOKEN="<storyblok-personal-access-token>"
 ```
 
-The token must be able to create draft stories under `pages/campaigns` and
-upload assets in the configured asset folder. If a submission fails after partial
-progress, the API attempts compensating cleanup of the created Storyblok asset,
+Staging and production receive the same runtime variable from Cloud Run. Store
+the values as GitHub Actions secrets `TF_STAGING_STORYBLOK_MANAGEMENT_TOKEN`
+and `TF_PROD_STORYBLOK_MANAGEMENT_TOKEN`.
+
+The token must be able to list assets in the default-images folder, create
+draft stories under `pages/campaigns`, and upload assets in the configured
+asset folder. If a submission fails after partial progress, the API attempts
+compensating cleanup of the created Storyblok asset,
 Storyblok story, and database row.
 
 Future hardening (not part of the first version): Cloudflare Turnstile and

--- a/website/infra/cloud-run.tf
+++ b/website/infra/cloud-run.tf
@@ -42,6 +42,11 @@ resource "google_cloud_run_service" "google_cloud_run_service" {
         }
 
         env {
+          name  = "STORYBLOK_MANAGEMENT_TOKEN"
+          value = var.storyblok_management_token
+        }
+
+        env {
           name  = "MAPBOX_TOKEN"
           value = var.mapbox_token
         }

--- a/website/infra/variables.tf
+++ b/website/infra/variables.tf
@@ -199,6 +199,12 @@ variable "storyblok_webhook_secret" {
   sensitive   = true
 }
 
+variable "storyblok_management_token" {
+  description = "Storyblok Management API token used to list campaign default images, upload assets, and create draft campaign stories"
+  type        = string
+  sensitive   = true
+}
+
 variable "mapbox_token" {
   description = "Mapbox token for generating country map images"
   type        = string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Campaign submissions can now securely access Storyblok management capabilities for listing images, uploading assets, and creating draft stories.
  * Production and staging deployments support the required Storyblok management credentials.

* **Documentation**
  * Updated setup guidance with credential configuration, secret names, and required permissions for campaign submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->