### PR TITLE
Web: Filter and search for local partner overview page

### DIFF
--- a/website/src/app/[lang]/[region]/local-partners/page.tsx
+++ b/website/src/app/[lang]/[region]/local-partners/page.tsx
@@ -9,8 +9,9 @@ import { notFound } from 'next/navigation';
 
 export const revalidate = 900;
 
-export default async function LocalPartnersOverviewRoute({ params }: DefaultPageProps) {
+export default async function LocalPartnersOverviewRoute({ params, searchParams }: DefaultPageProps) {
 	const { lang, region } = await params;
+	const resolvedSearchParams = await searchParams;
 	const overviewResult = await services.storyblok.getStoryWithFallback<ISbStoryData<LocalPartnersOverview>>(
 		getLocalPartnersOverviewStoryPath(),
 		lang,
@@ -25,6 +26,7 @@ export default async function LocalPartnersOverviewRoute({ params }: DefaultPage
 			overview={overviewResult.data}
 			lang={lang as WebsiteLanguage}
 			region={region as WebsiteRegion}
+			searchParams={resolvedSearchParams}
 		/>
 	);
 }

--- a/website/src/components/storyblok/local-partner/local-partners-grid.tsx
+++ b/website/src/components/storyblok/local-partner/local-partners-grid.tsx
@@ -7,14 +7,19 @@ type Props = {
 	localPartners: LocalPartnerStory[];
 	lang: WebsiteLanguage;
 	region: WebsiteRegion;
+	hasActiveFilters?: boolean;
 };
 
-export const LocalPartnersGrid = async ({ localPartners, lang, region }: Props) => {
+export const LocalPartnersGrid = async ({ localPartners, lang, region, hasActiveFilters = false }: Props) => {
 	const translator = await Translator.getInstance({ language: lang, namespaces: ['website-common'] });
 	const viewDetailsLabel = translator.t('local-partners-page.view-details');
 
 	if (localPartners.length === 0) {
-		return <p className="text-muted-foreground">{translator.t('local-partners-page.empty')}</p>;
+		return (
+			<p className="text-muted-foreground">
+				{translator.t(hasActiveFilters ? 'local-partners-page.no-results' : 'local-partners-page.empty')}
+			</p>
+		);
 	}
 
 	return (

--- a/website/src/components/storyblok/local-partner/local-partners-overview-country-filter.tsx
+++ b/website/src/components/storyblok/local-partner/local-partners-overview-country-filter.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { FilterDropdown } from '@/components/filters/filter-dropdown';
+import { COUNTRY_QUERY_KEY } from './local-partners-overview-query';
+import type { FilterOption } from './local-partners-overview.server';
+
+type Props = {
+	allCountriesLabel: string;
+	countryOptions: FilterOption[];
+	selectedCountryIsoCode?: string;
+};
+
+export const LocalPartnersOverviewCountryFilter = ({ allCountriesLabel, countryOptions, selectedCountryIsoCode }: Props) => (
+	<FilterDropdown
+		allLabel={allCountriesLabel}
+		options={countryOptions}
+		queryKey={COUNTRY_QUERY_KEY}
+		selectedValue={selectedCountryIsoCode}
+	/>
+);

--- a/website/src/components/storyblok/local-partner/local-partners-overview-page.tsx
+++ b/website/src/components/storyblok/local-partner/local-partners-overview-page.tsx
@@ -5,15 +5,17 @@ import { LocalPartnersOverview } from '@/components/storyblok/local-partner/loca
 import type { LocalPartnersOverview as LocalPartnersOverviewContent } from '@/generated/storyblok/types/109655/storyblok-components';
 import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
 import { services } from '@/lib/services/services';
+import type { AnySearchParams } from '@/lib/types/page-props';
 import type { ISbStoryData } from '@storyblok/js';
 
 type Props = {
 	overview: ISbStoryData<LocalPartnersOverviewContent>;
 	lang: WebsiteLanguage;
 	region: WebsiteRegion;
+	searchParams?: AnySearchParams;
 };
 
-export const LocalPartnersOverviewPage = async ({ overview, lang, region }: Props) => {
+export const LocalPartnersOverviewPage = async ({ overview, lang, region, searchParams }: Props) => {
 	const localPartnersResult = await services.storyblok.getLocalPartners(lang);
 	const localPartners = (localPartnersResult.success ? localPartnersResult.data : []) as LocalPartnerStory[];
 	const title = overview.content.title?.trim() ?? overview.name;
@@ -28,7 +30,14 @@ export const LocalPartnersOverviewPage = async ({ overview, lang, region }: Prop
 	return (
 		<div className="flex flex-col gap-8 py-8">
 			<Breadcrumb links={breadcrumbLinks} className="py-0" />
-			<LocalPartnersOverview localPartners={localPartners} lang={lang} region={region} title={title} text={text} />
+			<LocalPartnersOverview
+				localPartners={localPartners}
+				lang={lang}
+				region={region}
+				title={title}
+				text={text}
+				searchParams={searchParams}
+			/>
 		</div>
 	);
 };

--- a/website/src/components/storyblok/local-partner/local-partners-overview-query.ts
+++ b/website/src/components/storyblok/local-partner/local-partners-overview-query.ts
@@ -1,0 +1,2 @@
+export const COUNTRY_QUERY_KEY = 'country';
+export const SEARCH_QUERY_KEY = 'search';

--- a/website/src/components/storyblok/local-partner/local-partners-overview-search.tsx
+++ b/website/src/components/storyblok/local-partner/local-partners-overview-search.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Input } from '@/components/input/input';
+import { SearchIcon } from 'lucide-react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { SEARCH_QUERY_KEY } from './local-partners-overview-query';
+
+type Props = {
+	defaultValue: string;
+	label: string;
+	placeholder: string;
+};
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export const LocalPartnersOverviewSearch = ({ defaultValue, label, placeholder }: Props) => {
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const currentValue = searchParams.get(SEARCH_QUERY_KEY) ?? defaultValue;
+	const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (searchDebounceRef.current) {
+				clearTimeout(searchDebounceRef.current);
+			}
+		};
+	}, []);
+
+	const updateSearch = (nextValue: string) => {
+		if (searchDebounceRef.current) {
+			clearTimeout(searchDebounceRef.current);
+		}
+
+		searchDebounceRef.current = setTimeout(() => {
+			const nextParams = new URLSearchParams(searchParams.toString());
+			const searchQuery = nextValue.trim();
+
+			if (searchQuery.length > 0) {
+				nextParams.set(SEARCH_QUERY_KEY, searchQuery);
+			} else {
+				nextParams.delete(SEARCH_QUERY_KEY);
+			}
+
+			const nextQuery = nextParams.toString();
+			router.replace(nextQuery.length > 0 ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
+		}, SEARCH_DEBOUNCE_MS);
+	};
+
+	return (
+		<div className="relative w-full">
+			<SearchIcon className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+			<Input
+				type="search"
+				aria-label={label}
+				placeholder={placeholder}
+				defaultValue={currentValue}
+				onChange={(event) => updateSearch(event.target.value)}
+				className="bg-card pl-9"
+			/>
+		</div>
+	);
+};

--- a/website/src/components/storyblok/local-partner/local-partners-overview.server.ts
+++ b/website/src/components/storyblok/local-partner/local-partners-overview.server.ts
@@ -1,0 +1,76 @@
+import { getCountryNameFromIsoCode } from '@/lib/types/country';
+import type { AnySearchParams } from '@/lib/types/page-props';
+import type { LocalPartnerStory } from './local-partner.types';
+import {
+	getLocalPartnerDescription,
+	getLocalPartnerIsoCode,
+	getLocalPartnerSlug,
+	getLocalPartnerTitle,
+} from './local-partner.utils';
+import { COUNTRY_QUERY_KEY, SEARCH_QUERY_KEY } from './local-partners-overview-query';
+
+export type FilterOption = {
+	value: string;
+	label: string;
+};
+
+const getQueryValue = (searchParams: AnySearchParams | undefined, key: string) => {
+	const value = searchParams?.[key];
+	const firstValue = Array.isArray(value) ? value.at(0) : value;
+
+	return typeof firstValue === 'string' ? firstValue.trim() : '';
+};
+
+export const getSearchQuery = (searchParams?: AnySearchParams) => {
+	return getQueryValue(searchParams, SEARCH_QUERY_KEY);
+};
+
+export const getCountryQuery = (searchParams?: AnySearchParams) => {
+	return getQueryValue(searchParams, COUNTRY_QUERY_KEY).toUpperCase();
+};
+
+const normalizeSearchValue = (value: string) => value.toLowerCase();
+
+const getNormalizedIsoCode = (localPartner: LocalPartnerStory) =>
+	getLocalPartnerIsoCode(localPartner.content)?.toUpperCase();
+
+export const localPartnerMatchesSearchQuery = (localPartner: LocalPartnerStory, searchQuery: string) => {
+	const keywords = [
+		getLocalPartnerTitle(localPartner.content),
+		getLocalPartnerSlug(localPartner),
+		getLocalPartnerDescription(localPartner.content),
+	]
+		.map((value) => normalizeSearchValue(value))
+		.join(' ');
+	const searchTerms = normalizeSearchValue(searchQuery).split(/\s+/);
+
+	return searchTerms.every((term) => keywords.includes(term));
+};
+
+export const localPartnerMatchesCountryQuery = (
+	localPartner: LocalPartnerStory,
+	selectedCountryIsoCode: string | undefined,
+) => {
+	if (!selectedCountryIsoCode) {
+		return true;
+	}
+
+	return getNormalizedIsoCode(localPartner) === selectedCountryIsoCode;
+};
+
+export const getCountryFilterOptions = (localPartners: LocalPartnerStory[]): FilterOption[] => {
+	const optionsByCountryIsoCode = new Map<string, FilterOption>();
+
+	localPartners.forEach((localPartner) => {
+		const countryIsoCode = getNormalizedIsoCode(localPartner);
+
+		if (countryIsoCode) {
+			optionsByCountryIsoCode.set(countryIsoCode, {
+				value: countryIsoCode,
+				label: getCountryNameFromIsoCode(countryIsoCode),
+			});
+		}
+	});
+
+	return [...optionsByCountryIsoCode.values()].sort((optionA, optionB) => optionA.label.localeCompare(optionB.label));
+};

--- a/website/src/components/storyblok/local-partner/local-partners-overview.tsx
+++ b/website/src/components/storyblok/local-partner/local-partners-overview.tsx
@@ -1,9 +1,21 @@
 import { BlockWrapper } from '@/components/block-wrapper';
+import { FilterBar } from '@/components/filters/filter-bar';
 import { LocalPartnersGrid } from '@/components/storyblok/local-partner/local-partners-grid';
 import { LocalPartnersTeaserIntro } from '@/components/storyblok/local-partner/local-partners-teaser-intro';
 import { CmsHeader } from '@/components/storyblok/shared/cms-header';
+import { Translator } from '@/lib/i18n/translator';
 import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
+import type { AnySearchParams } from '@/lib/types/page-props';
 import type { LocalPartnerStory } from './local-partner.types';
+import { LocalPartnersOverviewCountryFilter } from './local-partners-overview-country-filter';
+import { LocalPartnersOverviewSearch } from './local-partners-overview-search';
+import {
+	getCountryFilterOptions,
+	getCountryQuery,
+	getSearchQuery,
+	localPartnerMatchesCountryQuery,
+	localPartnerMatchesSearchQuery,
+} from './local-partners-overview.server';
 
 type Props = {
 	localPartners: LocalPartnerStory[];
@@ -11,16 +23,56 @@ type Props = {
 	region: WebsiteRegion;
 	title?: string;
 	text?: string;
+	searchParams?: AnySearchParams;
 };
 
-export const LocalPartnersOverview = ({ localPartners, lang, region, title, text }: Props) => {
+export const LocalPartnersOverview = async ({ localPartners, lang, region, title, text, searchParams }: Props) => {
+	const translator = await Translator.getInstance({ language: lang, namespaces: ['website-common'] });
 	const hasCmsHeader = Boolean(title?.trim()) || Boolean(text?.trim());
+	const searchQuery = getSearchQuery(searchParams);
+	const countryQuery = getCountryQuery(searchParams);
+	const countryOptions = getCountryFilterOptions(localPartners);
+	const selectedCountryIsoCode = countryOptions.some((option) => option.value === countryQuery) ? countryQuery : undefined;
+	const hasActiveFilters = Boolean(searchQuery) || Boolean(selectedCountryIsoCode);
+	const countryFilteredLocalPartners = localPartners.filter((localPartner) =>
+		localPartnerMatchesCountryQuery(localPartner, selectedCountryIsoCode),
+	);
+	const filteredLocalPartners = searchQuery
+		? countryFilteredLocalPartners.filter((localPartner) => localPartnerMatchesSearchQuery(localPartner, searchQuery))
+		: countryFilteredLocalPartners;
 
 	return (
 		<BlockWrapper disableMarginTop={true} disableMarginBottom={true}>
 			<div className="flex w-full flex-col gap-8">
-				{hasCmsHeader ? <CmsHeader title={title} text={text} /> : <LocalPartnersTeaserIntro lang={lang} />}
-				<LocalPartnersGrid localPartners={localPartners} lang={lang} region={region} />
+				{hasCmsHeader ? (
+					<CmsHeader title={title} text={text} textClassName="max-w-2xl" />
+				) : (
+					<LocalPartnersTeaserIntro lang={lang} />
+				)}
+				<FilterBar
+					filters={
+						<LocalPartnersOverviewCountryFilter
+							allCountriesLabel={translator.t('local-partners-page.all-countries', {
+								context: { count: countryOptions.length },
+							})}
+							countryOptions={countryOptions}
+							selectedCountryIsoCode={selectedCountryIsoCode}
+						/>
+					}
+					search={
+						<LocalPartnersOverviewSearch
+							defaultValue={searchQuery}
+							label={translator.t('local-partners-page.search-label')}
+							placeholder={translator.t('local-partners-page.search-placeholder')}
+						/>
+					}
+				/>
+				<LocalPartnersGrid
+					localPartners={filteredLocalPartners}
+					lang={lang}
+					region={region}
+					hasActiveFilters={hasActiveFilters}
+				/>
 			</div>
 		</BlockWrapper>
 	);

--- a/website/src/components/storyblok/shared/cms-header.tsx
+++ b/website/src/components/storyblok/shared/cms-header.tsx
@@ -1,9 +1,12 @@
+import { cn } from '@/lib/utils/cn';
+
 type Props = {
 	title?: string;
 	text?: string;
+	textClassName?: string;
 };
 
-export const CmsHeader = ({ title, text }: Props) => {
+export const CmsHeader = ({ title, text, textClassName }: Props) => {
 	const normalizedTitle = title?.trim();
 	const normalizedText = text?.trim();
 
@@ -17,7 +20,7 @@ export const CmsHeader = ({ title, text }: Props) => {
 				<h1 className="text-foreground text-5xl leading-tight font-bold md:text-6xl">{normalizedTitle}</h1>
 			) : null}
 			{normalizedText ? (
-				<p className="text-foreground text-base leading-6 sm:text-lg sm:leading-7">{normalizedText}</p>
+				<p className={cn('text-foreground text-base leading-6 sm:text-lg sm:leading-7', textClassName)}>{normalizedText}</p>
 			) : null}
 		</div>
 	);

--- a/website/src/components/storyblok/storyblok-preview-local-partners-overview-page.tsx
+++ b/website/src/components/storyblok/storyblok-preview-local-partners-overview-page.tsx
@@ -30,6 +30,8 @@ export const StoryblokPreviewLocalPartnersOverviewPage = async ({
 
 			return storyResult.success ? storyResult.data : null;
 		},
-		renderStory: (overview) => <LocalPartnersOverviewPage overview={overview} lang={lang} region={region} />,
+		renderStory: (overview) => (
+			<LocalPartnersOverviewPage overview={overview} lang={lang} region={region} searchParams={searchParams} />
+		),
 	});
 };

--- a/website/src/lib/i18n/locales/de/website-common.json
+++ b/website/src/lib/i18n/locales/de/website-common.json
@@ -61,6 +61,10 @@
 	},
 	"local-partners-page": {
 		"empty": "Keine lokalen Partner gefunden.",
+		"no-results": "Keine lokalen Partner entsprechen den gewählten Filtern.",
+		"search-label": "Lokale Partner suchen",
+		"search-placeholder": "Suchen",
+		"all-countries": "Alle Länder ({{count}})",
 		"recipient-singular": "Empfänger:in",
 		"recipient-plural": "Empfänger:innen",
 		"completed-survey-singular": "abgeschlossene Umfrage",

--- a/website/src/lib/i18n/locales/en/website-common.json
+++ b/website/src/lib/i18n/locales/en/website-common.json
@@ -61,6 +61,10 @@
 	},
 	"local-partners-page": {
 		"empty": "No local partners found.",
+		"no-results": "No local partners match the selected filters.",
+		"search-label": "Search local partners",
+		"search-placeholder": "Search",
+		"all-countries": "All countries ({{count}})",
 		"recipient-singular": "recipient",
 		"recipient-plural": "recipients",
 		"completed-survey-singular": "completed survey",

--- a/website/src/lib/i18n/locales/fr/website-common.json
+++ b/website/src/lib/i18n/locales/fr/website-common.json
@@ -61,6 +61,10 @@
 	},
 	"local-partners-page": {
 		"empty": "Aucun partenaire local trouvé.",
+		"no-results": "Aucun partenaire local ne correspond aux filtres sélectionnés.",
+		"search-label": "Rechercher des partenaires locaux",
+		"search-placeholder": "Rechercher",
+		"all-countries": "Tous les pays ({{count}})",
 		"recipient-singular": "bénéficiaire",
 		"recipient-plural": "bénéficiaires",
 		"completed-survey-singular": "enquête complétée",

--- a/website/src/lib/i18n/locales/it/website-common.json
+++ b/website/src/lib/i18n/locales/it/website-common.json
@@ -61,6 +61,10 @@
 	},
 	"local-partners-page": {
 		"empty": "Nessun partner locale trovato.",
+		"no-results": "Nessun partner locale corrisponde ai filtri selezionati.",
+		"search-label": "Cerca partner locali",
+		"search-placeholder": "Cerca",
+		"all-countries": "Tutti i paesi ({{count}})",
 		"recipient-singular": "beneficiario",
 		"recipient-plural": "beneficiari",
 		"completed-survey-singular": "questionario completato",


### PR DESCRIPTION
Before: 
<img width="1336" height="395" alt="Screenshot 2026-08-27 at 23 04 06" src="https://github.com/user-attachments/assets/34ec2081-be22-43c3-95b7-b15bbbce2907" />

After: 
<img width="1102" height="341" alt="Screenshot 2026-08-27 at 23 03 48" src="https://github.com/user-attachments/assets/95d8d94a-7f8c-44ed-aaaf-98cbaf8d672d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added search and country filters to the local partners directory.
  - Added localized filter controls, search labels, placeholders, and “all countries” options.
  - Displays a localized no-results message when filters return no matches.
  - Preserves filter and search settings during page navigation and previews.

- **Style**
  - Added flexibility to customize header text styling.

- **Documentation**
  - Added English, German, French, and Italian translations for the new directory controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->