### PR TITLE
feat: add transparency countries block

### DIFF
--- a/website/src/components/content-blocks/transparency-countries-block.tsx
+++ b/website/src/components/content-blocks/transparency-countries-block.tsx
@@ -1,0 +1,105 @@
+import { BlockWrapper } from '@/components/block-wrapper';
+import { Card } from '@/components/card/card';
+import {
+	CountriesSectionClient,
+	type CountriesSectionOtherCountry,
+	type CountriesSectionSegment,
+} from '@/components/transparency/countries-section-client';
+import type { TransparencyCountries } from '@/generated/storyblok/types/109655/storyblok-components';
+import { getWebsiteCurrencyFromCookie } from '@/lib/i18n/get-website-currency';
+import { Translator } from '@/lib/i18n/translator';
+import { getSafeNumberFormatLocale, type WebsiteLanguage } from '@/lib/i18n/utils';
+import { services } from '@/lib/services/services';
+import {
+	formatPercentageDisplay,
+	TOP_CONTRIBUTING_COUNTRIES_LIMIT,
+} from '@/lib/services/transparency/countries-distribution';
+import {
+	OTHER_COUNTRY_SEGMENT_CODE,
+	type TransparencyFinancialPeriod,
+} from '@/lib/services/transparency/transparency.types';
+import { formatCurrencyLocale, formatNumberLocale } from '@/lib/utils/string-utils';
+import { storyblokEditable, type SbBlokData } from '@storyblok/react';
+
+type Props = {
+	blok: TransparencyCountries;
+	lang: WebsiteLanguage;
+};
+
+export const TransparencyCountriesBlock = async ({ blok, lang }: Props) => {
+	const financialPeriod: TransparencyFinancialPeriod = { kind: 'all-time' };
+	const displayCurrency = await getWebsiteCurrencyFromCookie();
+	const [dataResult, rates] = await Promise.all([
+		services.transparency.getContributionsByCountryData(TOP_CONTRIBUTING_COUNTRIES_LIMIT, financialPeriod),
+		services.currencyDisplay.fetchWalletPayoutDisplayRates(displayCurrency),
+	]);
+
+	if (!dataResult.success) {
+		return null;
+	}
+
+	const translator = await Translator.getInstance({ language: lang, namespaces: ['website-common'] });
+	const locale = getSafeNumberFormatLocale(lang);
+	const data = dataResult.data;
+	const formatAmount = (amountChf: number): string => {
+		const { amount, currency } = services.currencyDisplay.resolveFromChf(amountChf, displayCurrency, rates);
+
+		return formatCurrencyLocale(amount, currency, locale, { maximumFractionDigits: 0 });
+	};
+
+	const otherCountriesLabel = translator.t('transparency-page.countries.other-countries');
+	const formattedTotalAmount = formatAmount(data.totalContributionsChf);
+	const formattedCountriesCount = formatNumberLocale(data.countriesCount, locale, { maximumFractionDigits: 0 });
+	const segments: CountriesSectionSegment[] = data.segments.map((segment) => {
+		const countryName = segment.countryCode === OTHER_COUNTRY_SEGMENT_CODE ? otherCountriesLabel : segment.countryName;
+		const formattedAmount = formatAmount(segment.totalChf);
+		const formattedPercentage = formatPercentageDisplay(segment.percentageOfTotal, segment.totalChf);
+
+		return {
+			id: segment.countryCode,
+			countryCode: segment.countryCode === OTHER_COUNTRY_SEGMENT_CODE ? null : segment.countryCode,
+			countryName,
+			formattedAmount,
+			formattedPercentage,
+			unitCount: segment.unitCount,
+			color: segment.color,
+			rowAriaLabel: translator.t('transparency-page.countries.legend-row-aria', {
+				context: {
+					country: countryName,
+					amount: formattedAmount,
+					percentage: formattedPercentage,
+				},
+			}),
+		};
+	});
+	const otherCountries: CountriesSectionOtherCountry[] = data.otherCountries.map((country) => ({
+		countryCode: country.countryCode,
+		countryName: country.countryName,
+		formattedAmount: formatAmount(country.totalChf),
+	}));
+
+	return (
+		<BlockWrapper {...storyblokEditable(blok as SbBlokData)}>
+			<section>
+				<Card variant="noPadding" className="overflow-hidden px-6 py-8 sm:px-10">
+					<CountriesSectionClient
+						sectionTitle={translator.t('transparency-page.inflows.title-name')}
+						headlineTemplate={translator.t('transparency-page.countries.headline', {
+							context: { count: data.countriesCount },
+						})}
+						headlineCountryTemplate={translator.t('transparency-page.countries.headline-country')}
+						headlineOtherTemplate={translator.t('transparency-page.countries.headline-other')}
+						otherCountriesLabel={otherCountriesLabel}
+						emptyLabel={translator.t('transparency-page.countries.empty')}
+						chartAriaLabel={translator.t('transparency-page.countries.chart-aria-label')}
+						dialogTitle={translator.t('transparency-page.countries.other-countries-title')}
+						formattedTotalAmount={formattedTotalAmount}
+						formattedCountriesCount={formattedCountriesCount}
+						segments={segments}
+						otherCountries={otherCountries}
+					/>
+				</Card>
+			</section>
+		</BlockWrapper>
+	);
+};

--- a/website/src/components/content-blocks/transparency-countries-block.tsx
+++ b/website/src/components/content-blocks/transparency-countries-block.tsx
@@ -38,7 +38,7 @@ export const TransparencyCountriesBlock = async ({ blok, lang }: Props) => {
 		return null;
 	}
 
-	const translator = await Translator.getInstance({ language: lang, namespaces: ['website-common'] });
+	const translator = await Translator.getInstance({ language: lang, namespaces: ['website-common', 'countries'] });
 	const locale = getSafeNumberFormatLocale(lang);
 	const data = dataResult.data;
 	const formatAmount = (amountChf: number): string => {
@@ -51,7 +51,10 @@ export const TransparencyCountriesBlock = async ({ blok, lang }: Props) => {
 	const formattedTotalAmount = formatAmount(data.totalContributionsChf);
 	const formattedCountriesCount = formatNumberLocale(data.countriesCount, locale, { maximumFractionDigits: 0 });
 	const segments: CountriesSectionSegment[] = data.segments.map((segment) => {
-		const countryName = segment.countryCode === OTHER_COUNTRY_SEGMENT_CODE ? otherCountriesLabel : segment.countryName;
+		const countryName =
+			segment.countryCode === OTHER_COUNTRY_SEGMENT_CODE
+				? otherCountriesLabel
+				: translator.t(segment.countryCode, { namespace: 'countries' });
 		const formattedAmount = formatAmount(segment.totalChf);
 		const formattedPercentage = formatPercentageDisplay(segment.percentageOfTotal, segment.totalChf);
 
@@ -74,7 +77,7 @@ export const TransparencyCountriesBlock = async ({ blok, lang }: Props) => {
 	});
 	const otherCountries: CountriesSectionOtherCountry[] = data.otherCountries.map((country) => ({
 		countryCode: country.countryCode,
-		countryName: country.countryName,
+		countryName: translator.t(country.countryCode, { namespace: 'countries' }),
 		formattedAmount: formatAmount(country.totalChf),
 	}));
 

--- a/website/src/components/content-types/page.tsx
+++ b/website/src/components/content-types/page.tsx
@@ -24,6 +24,7 @@ import { TestimonialCarouselBlock } from '@/components/content-blocks/testimonia
 import { TestimonialBlock } from '@/components/content-blocks/testimonial-entry';
 import { TextBlock } from '@/components/content-blocks/text';
 import { TransparencyBlock } from '@/components/content-blocks/transparency';
+import { TransparencyCountriesBlock } from '@/components/content-blocks/transparency-countries-block';
 import { TransparencySummaryBlock } from '@/components/content-blocks/transparency-summary-block';
 import { TwoColumnTextBlock } from '@/components/content-blocks/two-column-text';
 import { VideoTextBlock } from '@/components/content-blocks/video-text';
@@ -106,6 +107,8 @@ const renderPageBlock = (
 			return <TextBlock blok={block} />;
 		case 'transparency':
 			return <TransparencyBlock blok={block} lang={lang} />;
+		case 'transparencyCountries':
+			return <TransparencyCountriesBlock blok={block} lang={lang} />;
 		case 'transparencySummary':
 			return <TransparencySummaryBlock blok={block} lang={lang} />;
 		case 'twoColumnText':

--- a/website/src/components/country-flag.test.tsx
+++ b/website/src/components/country-flag.test.tsx
@@ -1,0 +1,43 @@
+/** @jest-environment jsdom */
+
+import { CountryFlag } from '@/components/country-flag';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('next/image', () => ({
+	__esModule: true,
+	default: ({ alt, onError }: { alt: string; onError?: () => void }) => (
+		<button type="button" data-testid="flag-image" data-alt={alt} onClick={onError} />
+	),
+}));
+
+describe('CountryFlag', () => {
+	test('resets the image error fallback when the country changes', () => {
+		const container = document.createElement('div');
+		const root = createRoot(container);
+
+		act(() => root.render(<CountryFlag country="CH" />));
+		act(() => container.querySelector<HTMLButtonElement>('[data-testid="flag-image"]')?.click());
+		expect(container.textContent).toBe('CH');
+
+		act(() => root.render(<CountryFlag country="DE" />));
+		expect(container.querySelector('[data-testid="flag-image"]')).not.toBeNull();
+		expect(container.textContent).not.toBe('CH');
+
+		act(() => root.unmount());
+	});
+
+	test('hides decorative flags from assistive technology', () => {
+		const container = document.createElement('div');
+		const root = createRoot(container);
+
+		act(() => root.render(<CountryFlag country="CH" decorative />));
+
+		expect(container.firstElementChild?.getAttribute('aria-hidden')).toBe('true');
+		expect(container.querySelector('[data-testid="flag-image"]')?.getAttribute('data-alt')).toBe('');
+
+		act(() => root.unmount());
+	});
+});

--- a/website/src/components/country-flag.tsx
+++ b/website/src/components/country-flag.tsx
@@ -13,9 +13,11 @@ const slugifyCountry = (name: string): string => {
 type CountryFlagProps = {
 	country: CountryCode;
 	size?: 'sm' | 'lg';
+	decorative?: boolean;
+	className?: string;
 };
 
-export const CountryFlag = ({ country, size = 'lg' }: CountryFlagProps) => {
+export const CountryFlag = ({ country, size = 'lg', decorative = false, className }: CountryFlagProps) => {
 	const [hasError, setHasError] = useState(false);
 
 	const containerSize = size === 'sm' ? 'size-4 text-[10px]' : 'size-9 text-[12px]';
@@ -24,27 +26,29 @@ export const CountryFlag = ({ country, size = 'lg' }: CountryFlagProps) => {
 
 	if (hasError) {
 		return (
-			<div
+			<span
 				className={cn(
-					'bg-muted text-muted-foreground flex items-center justify-center rounded-full uppercase',
+					'bg-muted text-muted-foreground inline-flex items-center justify-center rounded-full uppercase',
 					containerSize,
+					className,
 				)}
+				aria-hidden={decorative}
 			>
 				{country}
-			</div>
+			</span>
 		);
 	}
 
 	return (
-		<div className={cn('overflow-hidden rounded-full', containerSize)}>
+		<span className={cn('inline-flex overflow-hidden rounded-full', containerSize, className)} aria-hidden={decorative}>
 			<Image
 				src={`/assets/flags/${slug}.svg`}
-				alt={country}
+				alt={decorative ? '' : country}
 				width={36}
 				height={36}
-				className="size-full rounded-full object-cover"
+				className="block size-full rounded-full object-cover"
 				onError={() => setHasError(true)}
 			/>
-		</div>
+		</span>
 	);
 };

--- a/website/src/components/country-flag.tsx
+++ b/website/src/components/country-flag.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CountryCode } from '@/generated/prisma/enums';
+import type { CountryCode } from '@/generated/prisma/enums';
 import { cn } from '@/lib/utils/cn';
 import { WHITESPACE_REGEX } from '@/lib/utils/regex';
 import Image from 'next/image';
@@ -17,7 +17,14 @@ type CountryFlagProps = {
 	className?: string;
 };
 
-export const CountryFlag = ({ country, size = 'lg', decorative = false, className }: CountryFlagProps) => {
+const CountryFlagImage = ({
+	country,
+	size,
+	decorative,
+	className,
+}: Required<Omit<CountryFlagProps, 'className'>> & {
+	className?: string;
+}) => {
 	const [hasError, setHasError] = useState(false);
 
 	const containerSize = size === 'sm' ? 'size-4 text-[10px]' : 'size-9 text-[12px]';
@@ -32,7 +39,7 @@ export const CountryFlag = ({ country, size = 'lg', decorative = false, classNam
 					containerSize,
 					className,
 				)}
-				aria-hidden={decorative}
+				aria-hidden={decorative || undefined}
 			>
 				{country}
 			</span>
@@ -40,7 +47,10 @@ export const CountryFlag = ({ country, size = 'lg', decorative = false, classNam
 	}
 
 	return (
-		<span className={cn('inline-flex overflow-hidden rounded-full', containerSize, className)} aria-hidden={decorative}>
+		<span
+			className={cn('inline-flex overflow-hidden rounded-full', containerSize, className)}
+			aria-hidden={decorative || undefined}
+		>
 			<Image
 				src={`/assets/flags/${slug}.svg`}
 				alt={decorative ? '' : country}
@@ -51,4 +61,8 @@ export const CountryFlag = ({ country, size = 'lg', decorative = false, classNam
 			/>
 		</span>
 	);
+};
+
+export const CountryFlag = ({ country, size = 'lg', decorative = false, className }: CountryFlagProps) => {
+	return <CountryFlagImage key={country} country={country} size={size} decorative={decorative} className={className} />;
 };

--- a/website/src/components/transparency/countries-section-client.test.tsx
+++ b/website/src/components/transparency/countries-section-client.test.tsx
@@ -1,0 +1,139 @@
+/** @jest-environment jsdom */
+
+import {
+	CountriesSectionClient,
+	type CountriesSectionClientProps,
+} from '@/components/transparency/countries-section-client';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('next/image', () => ({
+	__esModule: true,
+	default: ({ alt, src }: { alt: string; src: string }) => <span data-image-src={src} data-image-alt={alt} />,
+}));
+
+const baseProps: CountriesSectionClientProps = {
+	sectionTitle: 'Inflows',
+	headlineTemplate: '{{amount}} donations arrived from {{countriesCount}} countries',
+	headlineCountryTemplate: '{{amount}} donations arrived from {{country}}',
+	headlineOtherTemplate: '{{amount}} donations arrived from other countries',
+	otherCountriesLabel: 'Other countries',
+	emptyLabel: 'No donations from any country in this period.',
+	chartAriaLabel: 'Donation amounts by country of origin',
+	dialogTitle: 'Other countries',
+	formattedTotalAmount: 'CHF 100',
+	formattedCountriesCount: '3',
+	segments: [
+		{
+			id: 'CH',
+			countryCode: 'CH',
+			countryName: 'Switzerland',
+			formattedAmount: 'CHF 80',
+			formattedPercentage: '80%',
+			unitCount: 80,
+			color: 'red',
+			rowAriaLabel: 'Switzerland, CHF 80, 80%',
+		},
+		{
+			id: 'DE',
+			countryCode: 'DE',
+			countryName: 'Germany',
+			formattedAmount: 'CHF 15',
+			formattedPercentage: '15%',
+			unitCount: 15,
+			color: 'blue',
+			rowAriaLabel: 'Germany, CHF 15, 15%',
+		},
+		{
+			id: 'OTHER',
+			countryCode: null,
+			countryName: 'Other countries',
+			formattedAmount: 'CHF 5',
+			formattedPercentage: '5%',
+			unitCount: 5,
+			color: 'gray',
+			rowAriaLabel: 'Other countries, CHF 5, 5%',
+		},
+	],
+	otherCountries: [{ countryCode: 'US', countryName: 'United States', formattedAmount: 'CHF 5' }],
+};
+
+describe('CountriesSectionClient', () => {
+	test('server-renders the headline, 100 unit bars, and legend without a loading state', () => {
+		const markup = renderToStaticMarkup(<CountriesSectionClient {...baseProps} />);
+
+		expect(markup).toContain('Inflows');
+		expect(markup).toContain('CHF 100');
+		expect(markup).toContain('donations arrived from');
+		expect(markup).toContain('>3<');
+		expect(markup).toContain('aria-label="Donation amounts by country of origin"');
+		expect((markup.match(/w-0\.5 rounded-full/g) ?? []).length).toBe(100);
+		expect(markup).toContain('--legend-rows:2');
+		expect(markup).toContain('Switzerland');
+		expect(markup).toContain('Other countries');
+		expect(markup).not.toContain('No donations from any country');
+	});
+
+	test('renders an empty state instead of the chart when there are no segments', () => {
+		const markup = renderToStaticMarkup(
+			<CountriesSectionClient
+				{...baseProps}
+				segments={[]}
+				otherCountries={[]}
+				formattedCountriesCount="0"
+				formattedTotalAmount="CHF 0"
+			/>,
+		);
+
+		expect(markup).toContain('No donations from any country in this period.');
+		expect(markup).not.toContain('aria-label="Donation amounts by country of origin"');
+	});
+
+	test('updates the headline on keyboard focus and opens the other-countries dialog', () => {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		const root = createRoot(container);
+
+		act(() => {
+			root.render(<CountriesSectionClient {...baseProps} />);
+		});
+
+		const switzerlandButton = container.querySelector<HTMLButtonElement>('button[aria-label="Switzerland, CHF 80, 80%"]');
+		expect(switzerlandButton).not.toBeNull();
+
+		act(() => {
+			switzerlandButton?.focus();
+		});
+
+		expect(container.querySelector('h2')?.textContent).toContain('CHF 80');
+		expect(container.querySelector('h2')?.textContent).toContain('Switzerland');
+
+		const germanyButton = container.querySelector<HTMLButtonElement>('button[aria-label="Germany, CHF 15, 15%"]');
+		expect(germanyButton).not.toBeNull();
+
+		act(() => {
+			germanyButton?.focus();
+		});
+
+		expect(container.querySelector('h2')?.textContent).toContain('CHF 15');
+		expect(container.querySelector('h2')?.textContent).toContain('Germany');
+		expect(container.querySelector('h2')?.textContent).not.toContain('3 countries');
+
+		const otherButton = container.querySelector<HTMLButtonElement>('button[aria-label="Other countries, CHF 5, 5%"]');
+		expect(otherButton).not.toBeNull();
+
+		act(() => {
+			otherButton?.click();
+		});
+
+		expect(document.body.textContent).toContain('United States');
+
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+	});
+});

--- a/website/src/components/transparency/countries-section-client.test.tsx
+++ b/website/src/components/transparency/countries-section-client.test.tsx
@@ -69,6 +69,9 @@ describe('CountriesSectionClient', () => {
 		expect(markup).toContain('CHF 100');
 		expect(markup).toContain('donations arrived from');
 		expect(markup).toContain('>3<');
+		expect(markup).toContain('aria-live="polite"');
+		expect(markup).toContain('aria-atomic="true"');
+		expect(markup).toContain('min-h-[2lh]');
 		expect(markup).toContain('aria-label="Donation amounts by country of origin"');
 		expect((markup.match(/w-0\.5 rounded-full/g) ?? []).length).toBe(100);
 		expect(markup).toContain('--legend-rows:2');
@@ -124,11 +127,15 @@ describe('CountriesSectionClient', () => {
 
 		const otherButton = container.querySelector<HTMLButtonElement>('button[aria-label="Other countries, CHF 5, 5%"]');
 		expect(otherButton).not.toBeNull();
+		expect(otherButton?.getAttribute('aria-haspopup')).toBe('dialog');
+		expect(otherButton?.getAttribute('aria-expanded')).toBe('false');
 
 		act(() => {
 			otherButton?.click();
 		});
 
+		expect(otherButton?.getAttribute('aria-expanded')).toBe('true');
+		expect(container.querySelector('h2')?.textContent).toContain('CHF 5');
 		expect(document.body.textContent).toContain('United States');
 
 		act(() => {

--- a/website/src/components/transparency/countries-section-client.tsx
+++ b/website/src/components/transparency/countries-section-client.tsx
@@ -137,11 +137,7 @@ export const CountriesSectionClient = ({
 		<div className="flex flex-col gap-8">
 			<div className="flex flex-col gap-2">
 				<p className="text-sm font-medium">{sectionTitle}</p>
-				<h2
-					className="min-h-[2lh] text-4xl leading-snug font-light md:text-5xl"
-					aria-live="polite"
-					aria-atomic="true"
-				>
+				<h2 className="min-h-[2lh] text-4xl leading-snug font-light md:text-5xl" aria-live="polite" aria-atomic="true">
 					{headline}
 				</h2>
 			</div>

--- a/website/src/components/transparency/countries-section-client.tsx
+++ b/website/src/components/transparency/countries-section-client.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { CountryFlag } from '@/components/country-flag';
+import { Dialog, DialogContent, DialogTitle } from '@/components/dialog';
+import { type CountryCode } from '@/generated/prisma/enums';
+import { splitTranslationTemplate } from '@/lib/services/transparency/countries-distribution';
+import { OTHER_COUNTRY_SEGMENT_CODE } from '@/lib/services/transparency/transparency.types';
+import { cn } from '@/lib/utils/cn';
+import { Fragment, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+
+export type CountriesSectionSegment = {
+	id: string;
+	countryCode: CountryCode | null;
+	countryName: string;
+	formattedAmount: string;
+	formattedPercentage: string;
+	unitCount: number;
+	color: string;
+	rowAriaLabel: string;
+};
+
+export type CountriesSectionOtherCountry = {
+	countryCode: CountryCode;
+	countryName: string;
+	formattedAmount: string;
+};
+
+export type CountriesSectionClientProps = {
+	sectionTitle: string;
+	headlineTemplate: string;
+	headlineCountryTemplate: string;
+	headlineOtherTemplate: string;
+	otherCountriesLabel: string;
+	emptyLabel: string;
+	chartAriaLabel: string;
+	dialogTitle: string;
+	formattedTotalAmount: string;
+	formattedCountriesCount: string;
+	segments: CountriesSectionSegment[];
+	otherCountries: CountriesSectionOtherCountry[];
+};
+
+const interpolateHeadline = (template: string, values: Record<string, ReactNode>): ReactNode => {
+	return splitTranslationTemplate(template).map((part, index) => {
+		if (part.type === 'text') {
+			return <Fragment key={index}>{part.value}</Fragment>;
+		}
+
+		return <Fragment key={index}>{values[part.key]}</Fragment>;
+	});
+};
+
+const EmphasizedValue = ({ children }: { children: ReactNode }) => {
+	return <strong className="font-medium tabular-nums">{children}</strong>;
+};
+
+export const CountriesSectionClient = ({
+	sectionTitle,
+	headlineTemplate,
+	headlineCountryTemplate,
+	headlineOtherTemplate,
+	otherCountriesLabel,
+	emptyLabel,
+	chartAriaLabel,
+	dialogTitle,
+	formattedTotalAmount,
+	formattedCountriesCount,
+	segments,
+	otherCountries,
+}: CountriesSectionClientProps) => {
+	const [activeSegmentId, setActiveSegmentId] = useState<string | null>(null);
+	const [isOtherDialogOpen, setIsOtherDialogOpen] = useState(false);
+	const interactionRef = useRef<HTMLDivElement>(null);
+	const resolvedActiveSegmentId = segments.some((segment) => segment.id === activeSegmentId) ? activeSegmentId : null;
+	const activeSegment = segments.find((segment) => segment.id === resolvedActiveSegmentId);
+	const hasOtherCountries = otherCountries.length > 0;
+	const unitBars = segments.flatMap((segment) =>
+		Array.from({ length: segment.unitCount }, (_, index) => ({
+			key: `${segment.id}-${index}`,
+			segmentId: segment.id,
+			color: segment.color,
+		})),
+	);
+
+	const isOtherActive = activeSegment?.id === OTHER_COUNTRY_SEGMENT_CODE;
+	const headlineValues =
+		activeSegment === undefined
+			? {
+					amount: <EmphasizedValue>{formattedTotalAmount}</EmphasizedValue>,
+					countriesCount: <EmphasizedValue>{formattedCountriesCount}</EmphasizedValue>,
+				}
+			: {
+					amount: <EmphasizedValue>{activeSegment.formattedAmount}</EmphasizedValue>,
+					country: (
+						<span className="inline-flex items-center gap-2 align-baseline">
+							<strong className="leading-none font-medium">{activeSegment.countryName}</strong>
+							{activeSegment.countryCode ? (
+								<CountryFlag
+									country={activeSegment.countryCode}
+									size="lg"
+									decorative
+									className="size-[1em] shrink-0 text-[length:inherit]"
+								/>
+							) : null}
+						</span>
+					),
+				};
+	const activeHeadlineTemplate = isOtherActive
+		? headlineOtherTemplate
+		: activeSegment === undefined
+			? headlineTemplate
+			: headlineCountryTemplate;
+	const headline = interpolateHeadline(activeHeadlineTemplate, headlineValues);
+
+	const setActiveFromEvent = (segmentId: string) => {
+		setActiveSegmentId(segmentId);
+	};
+
+	const isInsideInteraction = (target: EventTarget | null): boolean => {
+		return target instanceof Node && Boolean(interactionRef.current?.contains(target));
+	};
+
+	const clearActiveIfLeavingInteraction = (relatedTarget: EventTarget | null) => {
+		if (isInsideInteraction(relatedTarget) || isOtherDialogOpen) {
+			return;
+		}
+
+		setActiveSegmentId(null);
+	};
+
+	return (
+		<div className="flex flex-col gap-8">
+			<div className="flex flex-col gap-2">
+				<p className="text-sm font-medium">{sectionTitle}</p>
+				<h2 className="text-4xl leading-snug font-light md:text-5xl">{headline}</h2>
+			</div>
+			{segments.length === 0 ? (
+				<p className="text-muted-foreground">{emptyLabel}</p>
+			) : (
+				<div
+					ref={interactionRef}
+					className="flex flex-col gap-8"
+					onMouseLeave={(event) => clearActiveIfLeavingInteraction(event.relatedTarget)}
+				>
+					<div
+						role="img"
+						aria-label={chartAriaLabel}
+						className="flex h-[54px] w-full items-stretch justify-between sm:h-[62px]"
+					>
+						{unitBars.map((bar) => {
+							const isDimmed = resolvedActiveSegmentId !== null && bar.segmentId !== resolvedActiveSegmentId;
+
+							return (
+								<span
+									key={bar.key}
+									aria-hidden="true"
+									className={cn(
+										'h-full w-0.5 rounded-full sm:w-[3px]',
+										'transition-opacity duration-150 motion-reduce:transition-none',
+										isDimmed && 'opacity-25',
+									)}
+									style={{ backgroundColor: bar.color }}
+								/>
+							);
+						})}
+					</div>
+					<ul
+						className="grid grid-cols-1 gap-1 sm:grid-flow-col sm:grid-cols-2 sm:grid-rows-[repeat(var(--legend-rows),auto)] sm:gap-x-8"
+						style={{ '--legend-rows': Math.max(1, Math.ceil(segments.length / 2)) } as CSSProperties}
+					>
+						{segments.map((segment) => {
+							const isActive = resolvedActiveSegmentId === segment.id;
+							const isOther = segment.id === OTHER_COUNTRY_SEGMENT_CODE;
+							const rowClassName = cn(
+								'flex w-full min-w-0 items-center gap-3 rounded-lg px-2 py-2 text-left',
+								'transition-colors duration-150 motion-reduce:transition-none',
+								'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+								isActive && 'bg-muted/50',
+							);
+
+							const rowContent = (
+								<>
+									{segment.countryCode ? (
+										<CountryFlag country={segment.countryCode} size="sm" decorative />
+									) : (
+										<span className="bg-muted size-4 shrink-0 rounded-full" aria-hidden="true" />
+									)}
+									<span className="min-w-0 flex-1 truncate">{segment.countryName || otherCountriesLabel}</span>
+									<span className="text-muted-foreground shrink-0 tabular-nums">{segment.formattedAmount}</span>
+									<span className="w-12 shrink-0 text-right font-semibold tabular-nums">{segment.formattedPercentage}</span>
+								</>
+							);
+
+							return (
+								<li key={segment.id}>
+									<button
+										type="button"
+										className={rowClassName}
+										aria-label={segment.rowAriaLabel}
+										onMouseEnter={() => setActiveFromEvent(segment.id)}
+										onFocus={() => setActiveFromEvent(segment.id)}
+										onBlur={(event) => clearActiveIfLeavingInteraction(event.relatedTarget)}
+										onClick={isOther && hasOtherCountries ? () => setIsOtherDialogOpen(true) : undefined}
+									>
+										{rowContent}
+									</button>
+								</li>
+							);
+						})}
+					</ul>
+				</div>
+			)}
+			{hasOtherCountries ? (
+				<Dialog open={isOtherDialogOpen} onOpenChange={setIsOtherDialogOpen}>
+					<DialogContent className="flex max-h-[min(85vh,40rem)] flex-col overflow-hidden rounded-3xl sm:max-w-md">
+						<DialogTitle>{dialogTitle}</DialogTitle>
+						<ul className="min-h-0 overflow-y-auto">
+							{otherCountries.map((country) => (
+								<li key={country.countryCode} className="flex items-center gap-3 py-2">
+									<CountryFlag country={country.countryCode} size="sm" decorative />
+									<span className="min-w-0 flex-1 truncate">{country.countryName}</span>
+									<span className="shrink-0 tabular-nums">{country.formattedAmount}</span>
+								</li>
+							))}
+						</ul>
+					</DialogContent>
+				</Dialog>
+			) : null}
+		</div>
+	);
+};

--- a/website/src/components/transparency/countries-section-client.tsx
+++ b/website/src/components/transparency/countries-section-client.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { CountryFlag } from '@/components/country-flag';
-import { Dialog, DialogContent, DialogTitle } from '@/components/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/dialog';
 import { type CountryCode } from '@/generated/prisma/enums';
-import { splitTranslationTemplate } from '@/lib/services/transparency/countries-distribution';
+import { splitTranslationTemplate } from '@/lib/i18n/translation-template';
 import { OTHER_COUNTRY_SEGMENT_CODE } from '@/lib/services/transparency/transparency.types';
 import { cn } from '@/lib/utils/cn';
 import { Fragment, useRef, useState, type CSSProperties, type ReactNode } from 'react';
@@ -71,7 +71,12 @@ export const CountriesSectionClient = ({
 	const [activeSegmentId, setActiveSegmentId] = useState<string | null>(null);
 	const [isOtherDialogOpen, setIsOtherDialogOpen] = useState(false);
 	const interactionRef = useRef<HTMLDivElement>(null);
-	const resolvedActiveSegmentId = segments.some((segment) => segment.id === activeSegmentId) ? activeSegmentId : null;
+	const resolvedActiveSegmentId =
+		isOtherDialogOpen && segments.some(({ id }) => id === OTHER_COUNTRY_SEGMENT_CODE)
+			? OTHER_COUNTRY_SEGMENT_CODE
+			: segments.some(({ id }) => id === activeSegmentId)
+				? activeSegmentId
+				: null;
 	const activeSegment = segments.find((segment) => segment.id === resolvedActiveSegmentId);
 	const hasOtherCountries = otherCountries.length > 0;
 	const unitBars = segments.flatMap((segment) =>
@@ -132,7 +137,13 @@ export const CountriesSectionClient = ({
 		<div className="flex flex-col gap-8">
 			<div className="flex flex-col gap-2">
 				<p className="text-sm font-medium">{sectionTitle}</p>
-				<h2 className="text-4xl leading-snug font-light md:text-5xl">{headline}</h2>
+				<h2
+					className="min-h-[2lh] text-4xl leading-snug font-light md:text-5xl"
+					aria-live="polite"
+					aria-atomic="true"
+				>
+					{headline}
+				</h2>
 			</div>
 			{segments.length === 0 ? (
 				<p className="text-muted-foreground">{emptyLabel}</p>
@@ -142,11 +153,7 @@ export const CountriesSectionClient = ({
 					className="flex flex-col gap-8"
 					onMouseLeave={(event) => clearActiveIfLeavingInteraction(event.relatedTarget)}
 				>
-					<div
-						role="img"
-						aria-label={chartAriaLabel}
-						className="flex h-[54px] w-full items-stretch justify-between sm:h-[62px]"
-					>
+					<div role="img" aria-label={chartAriaLabel} className="flex h-13.5 w-full items-stretch justify-between sm:h-15.5">
 						{unitBars.map((bar) => {
 							const isDimmed = resolvedActiveSegmentId !== null && bar.segmentId !== resolvedActiveSegmentId;
 
@@ -155,7 +162,7 @@ export const CountriesSectionClient = ({
 									key={bar.key}
 									aria-hidden="true"
 									className={cn(
-										'h-full w-0.5 rounded-full sm:w-[3px]',
+										'h-full w-0.5 rounded-full sm:w-0.75',
 										'transition-opacity duration-150 motion-reduce:transition-none',
 										isDimmed && 'opacity-25',
 									)}
@@ -197,6 +204,8 @@ export const CountriesSectionClient = ({
 										type="button"
 										className={rowClassName}
 										aria-label={segment.rowAriaLabel}
+										aria-haspopup={isOther && hasOtherCountries ? 'dialog' : undefined}
+										aria-expanded={isOther && hasOtherCountries ? isOtherDialogOpen : undefined}
 										onMouseEnter={() => setActiveFromEvent(segment.id)}
 										onFocus={() => setActiveFromEvent(segment.id)}
 										onBlur={(event) => clearActiveIfLeavingInteraction(event.relatedTarget)}
@@ -214,6 +223,7 @@ export const CountriesSectionClient = ({
 				<Dialog open={isOtherDialogOpen} onOpenChange={setIsOtherDialogOpen}>
 					<DialogContent className="flex max-h-[min(85vh,40rem)] flex-col overflow-hidden rounded-3xl sm:max-w-md">
 						<DialogTitle>{dialogTitle}</DialogTitle>
+						<DialogDescription className="sr-only">{chartAriaLabel}</DialogDescription>
 						<ul className="min-h-0 overflow-y-auto">
 							{otherCountries.map((country) => (
 								<li key={country.countryCode} className="flex items-center gap-3 py-2">

--- a/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
+++ b/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
@@ -433,6 +433,7 @@ export interface Page {
     | RunwayMonthGrid
     | DonationGlobe
     | TransparencySummary
+    | TransparencyCountries
   )[];
   component: "page";
   _uid: string;
@@ -658,6 +659,12 @@ export interface Transparency {
   donationGlobe?: DonationGlobe[];
   transparencySummary?: TransparencySummary[];
   component: "transparency";
+  _uid: string;
+  [k: string]: unknown;
+}
+
+export interface TransparencyCountries {
+  component: "transparencyCountries";
   _uid: string;
   [k: string]: unknown;
 }

--- a/website/src/lib/i18n/locales/de/website-common.json
+++ b/website/src/lib/i18n/locales/de/website-common.json
@@ -136,10 +136,10 @@
 			"no-data": "Keine Daten"
 		},
 		"countries": {
-			"headline_one": "{{amount}} Spenden kamen aus {{countriesCount}} Land",
-			"headline_other": "{{amount}} Spenden kamen aus {{countriesCount}} Ländern",
-			"headline-country": "{{amount}} Spenden kamen aus {{country}}",
-			"headline-other": "{{amount}} Spenden kamen aus anderen Ländern",
+			"headline_one": "Spenden im Wert von {{amount}} kamen aus {{countriesCount}} Land",
+			"headline_other": "Spenden im Wert von {{amount}} kamen aus {{countriesCount}} Ländern",
+			"headline-country": "Spenden im Wert von {{amount}} kamen aus {{country}}",
+			"headline-other": "Spenden im Wert von {{amount}} kamen aus anderen Ländern",
 			"other-countries": "Andere Länder",
 			"other-countries-title": "Andere Länder",
 			"empty": "In diesem Zeitraum gab es keine Spenden aus Ländern.",

--- a/website/src/lib/i18n/locales/de/website-common.json
+++ b/website/src/lib/i18n/locales/de/website-common.json
@@ -134,6 +134,17 @@
 			"title-currency": "in {{currency}}",
 			"tooltip-label": "Reservekontodetails anzeigen",
 			"no-data": "Keine Daten"
+		},
+		"countries": {
+			"headline_one": "{{amount}} Spenden kamen aus {{countriesCount}} Land",
+			"headline_other": "{{amount}} Spenden kamen aus {{countriesCount}} Ländern",
+			"headline-country": "{{amount}} Spenden kamen aus {{country}}",
+			"headline-other": "{{amount}} Spenden kamen aus anderen Ländern",
+			"other-countries": "Andere Länder",
+			"other-countries-title": "Andere Länder",
+			"empty": "In diesem Zeitraum gab es keine Spenden aus Ländern.",
+			"chart-aria-label": "Spendenbeträge nach Herkunftsland",
+			"legend-row-aria": "{{country}}, {{amount}}, {{percentage}}"
 		}
 	},
 	"program-detail-page": {

--- a/website/src/lib/i18n/locales/en/website-common.json
+++ b/website/src/lib/i18n/locales/en/website-common.json
@@ -136,10 +136,10 @@
 			"no-data": "No data"
 		},
 		"countries": {
-			"headline_one": "{{amount}} donations arrived from {{countriesCount}} country",
-			"headline_other": "{{amount}} donations arrived from {{countriesCount}} countries",
-			"headline-country": "{{amount}} donations arrived from {{country}}",
-			"headline-other": "{{amount}} donations arrived from other countries",
+			"headline_one": "Donations totaling {{amount}} arrived from {{countriesCount}} country",
+			"headline_other": "Donations totaling {{amount}} arrived from {{countriesCount}} countries",
+			"headline-country": "Donations totaling {{amount}} arrived from {{country}}",
+			"headline-other": "Donations totaling {{amount}} arrived from other countries",
 			"other-countries": "other countries",
 			"other-countries-title": "Other countries",
 			"empty": "No donations from any country in this period.",

--- a/website/src/lib/i18n/locales/en/website-common.json
+++ b/website/src/lib/i18n/locales/en/website-common.json
@@ -134,6 +134,17 @@
 			"title-currency": "in {{currency}}",
 			"tooltip-label": "Show reserve account details",
 			"no-data": "No data"
+		},
+		"countries": {
+			"headline_one": "{{amount}} donations arrived from {{countriesCount}} country",
+			"headline_other": "{{amount}} donations arrived from {{countriesCount}} countries",
+			"headline-country": "{{amount}} donations arrived from {{country}}",
+			"headline-other": "{{amount}} donations arrived from other countries",
+			"other-countries": "other countries",
+			"other-countries-title": "Other countries",
+			"empty": "No donations from any country in this period.",
+			"chart-aria-label": "Donation amounts by country of origin",
+			"legend-row-aria": "{{country}}, {{amount}}, {{percentage}}"
 		}
 	},
 	"program-detail-page": {

--- a/website/src/lib/i18n/locales/fr/website-common.json
+++ b/website/src/lib/i18n/locales/fr/website-common.json
@@ -134,6 +134,17 @@
 			"title-currency": "en {{currency}}",
 			"tooltip-label": "Afficher les détails des comptes de réserve",
 			"no-data": "Aucune donnée"
+		},
+		"countries": {
+			"headline_one": "{{amount}} de dons sont arrivés de {{countriesCount}} pays",
+			"headline_other": "{{amount}} de dons sont arrivés de {{countriesCount}} pays",
+			"headline-country": "{{amount}} de dons sont arrivés de {{country}}",
+			"headline-other": "{{amount}} de dons sont arrivés d’autres pays",
+			"other-countries": "autres pays",
+			"other-countries-title": "Autres pays",
+			"empty": "Aucun don provenant d’un pays pour cette période.",
+			"chart-aria-label": "Montants des dons par pays d’origine",
+			"legend-row-aria": "{{country}}, {{amount}}, {{percentage}}"
 		}
 	},
 	"program-detail-page": {

--- a/website/src/lib/i18n/locales/fr/website-common.json
+++ b/website/src/lib/i18n/locales/fr/website-common.json
@@ -136,10 +136,10 @@
 			"no-data": "Aucune donnée"
 		},
 		"countries": {
-			"headline_one": "{{amount}} de dons sont arrivés de {{countriesCount}} pays",
-			"headline_other": "{{amount}} de dons sont arrivés de {{countriesCount}} pays",
-			"headline-country": "{{amount}} de dons sont arrivés de {{country}}",
-			"headline-other": "{{amount}} de dons sont arrivés d’autres pays",
+			"headline_one": "Des dons totalisant {{amount}} sont arrivés de {{countriesCount}} pays",
+			"headline_other": "Des dons totalisant {{amount}} sont arrivés de {{countriesCount}} pays",
+			"headline-country": "Des dons totalisant {{amount}} sont arrivés de {{country}}",
+			"headline-other": "Des dons totalisant {{amount}} sont arrivés d’autres pays",
 			"other-countries": "autres pays",
 			"other-countries-title": "Autres pays",
 			"empty": "Aucun don provenant d’un pays pour cette période.",

--- a/website/src/lib/i18n/locales/it/website-common.json
+++ b/website/src/lib/i18n/locales/it/website-common.json
@@ -134,6 +134,17 @@
 			"title-currency": "in {{currency}}",
 			"tooltip-label": "Mostra i dettagli dei conti di riserva",
 			"no-data": "Nessun dato"
+		},
+		"countries": {
+			"headline_one": "{{amount}} donazioni sono arrivate da {{countriesCount}} paese",
+			"headline_other": "{{amount}} donazioni sono arrivate da {{countriesCount}} paesi",
+			"headline-country": "{{amount}} donazioni sono arrivate da {{country}}",
+			"headline-other": "{{amount}} donazioni sono arrivate da altri paesi",
+			"other-countries": "altri paesi",
+			"other-countries-title": "Altri paesi",
+			"empty": "Nessuna donazione da nessun paese in questo periodo.",
+			"chart-aria-label": "Importi delle donazioni per paese di origine",
+			"legend-row-aria": "{{country}}, {{amount}}, {{percentage}}"
 		}
 	},
 	"program-detail-page": {

--- a/website/src/lib/i18n/locales/it/website-common.json
+++ b/website/src/lib/i18n/locales/it/website-common.json
@@ -136,10 +136,10 @@
 			"no-data": "Nessun dato"
 		},
 		"countries": {
-			"headline_one": "{{amount}} donazioni sono arrivate da {{countriesCount}} paese",
-			"headline_other": "{{amount}} donazioni sono arrivate da {{countriesCount}} paesi",
-			"headline-country": "{{amount}} donazioni sono arrivate da {{country}}",
-			"headline-other": "{{amount}} donazioni sono arrivate da altri paesi",
+			"headline_one": "Donazioni per un totale di {{amount}} sono arrivate da {{countriesCount}} paese",
+			"headline_other": "Donazioni per un totale di {{amount}} sono arrivate da {{countriesCount}} paesi",
+			"headline-country": "Donazioni per un totale di {{amount}} sono arrivate da {{country}}",
+			"headline-other": "Donazioni per un totale di {{amount}} sono arrivate da altri paesi",
 			"other-countries": "altri paesi",
 			"other-countries-title": "Altri paesi",
 			"empty": "Nessuna donazione da nessun paese in questo periodo.",

--- a/website/src/lib/i18n/translation-template.test.ts
+++ b/website/src/lib/i18n/translation-template.test.ts
@@ -1,0 +1,17 @@
+import { splitTranslationTemplate } from './translation-template';
+
+describe('splitTranslationTemplate', () => {
+	test('keeps placeholders so translations can change word order', () => {
+		expect(splitTranslationTemplate('{{amount}} donations arrived from {{countriesCount}} countries')).toEqual([
+			{ type: 'placeholder', key: 'amount' },
+			{ type: 'text', value: ' donations arrived from ' },
+			{ type: 'placeholder', key: 'countriesCount' },
+			{ type: 'text', value: ' countries' },
+		]);
+		expect(splitTranslationTemplate('{{countriesCount}} Länder spendeten {{amount}}')).toEqual([
+			{ type: 'placeholder', key: 'countriesCount' },
+			{ type: 'text', value: ' Länder spendeten ' },
+			{ type: 'placeholder', key: 'amount' },
+		]);
+	});
+});

--- a/website/src/lib/i18n/translation-template.ts
+++ b/website/src/lib/i18n/translation-template.ts
@@ -1,0 +1,27 @@
+export type TranslationTemplatePart = { type: 'text'; value: string } | { type: 'placeholder'; key: string };
+
+const PLACEHOLDER_REGEX = /\{\{(\w+)\}\}/g;
+
+export const splitTranslationTemplate = (template: string): TranslationTemplatePart[] => {
+	const parts: TranslationTemplatePart[] = [];
+	let lastIndex = 0;
+
+	for (const match of template.matchAll(PLACEHOLDER_REGEX)) {
+		const matchIndex = match.index ?? 0;
+		if (matchIndex > lastIndex) {
+			parts.push({ type: 'text', value: template.slice(lastIndex, matchIndex) });
+		}
+
+		const key = match[1];
+		if (key) {
+			parts.push({ type: 'placeholder', key });
+		}
+		lastIndex = matchIndex + match[0].length;
+	}
+
+	if (lastIndex < template.length) {
+		parts.push({ type: 'text', value: template.slice(lastIndex) });
+	}
+
+	return parts;
+};

--- a/website/src/lib/i18n/translator.test.ts
+++ b/website/src/lib/i18n/translator.test.ts
@@ -28,4 +28,21 @@ describe('Test translations', () => {
 		expect(translator.t('CH', { namespace: 'countries' })).toBe('Switzerland');
 		expect(translator.t('DE', { namespace: 'countries' })).toBe('Germany');
 	});
+
+	it('keeps transparency countries headline placeholders for interpolation', async () => {
+		const translator = await Translator.getInstance({
+			language: 'en',
+			namespaces: ['website-common'],
+		});
+
+		expect(translator.t('transparency-page.countries.headline', { context: { count: 72 } })).toBe(
+			'{{amount}} donations arrived from {{countriesCount}} countries',
+		);
+		expect(translator.t('transparency-page.countries.headline', { context: { count: 1 } })).toBe(
+			'{{amount}} donations arrived from {{countriesCount}} country',
+		);
+		expect(translator.t('transparency-page.countries.headline-country')).toBe(
+			'{{amount}} donations arrived from {{country}}',
+		);
+	});
 });

--- a/website/src/lib/i18n/translator.test.ts
+++ b/website/src/lib/i18n/translator.test.ts
@@ -36,13 +36,24 @@ describe('Test translations', () => {
 		});
 
 		expect(translator.t('transparency-page.countries.headline', { context: { count: 72 } })).toBe(
-			'{{amount}} donations arrived from {{countriesCount}} countries',
+			'Donations totaling {{amount}} arrived from {{countriesCount}} countries',
 		);
 		expect(translator.t('transparency-page.countries.headline', { context: { count: 1 } })).toBe(
-			'{{amount}} donations arrived from {{countriesCount}} country',
+			'Donations totaling {{amount}} arrived from {{countriesCount}} country',
 		);
 		expect(translator.t('transparency-page.countries.headline-country')).toBe(
-			'{{amount}} donations arrived from {{country}}',
+			'Donations totaling {{amount}} arrived from {{country}}',
+		);
+	});
+
+	it('uses valid French transparency countries copy', async () => {
+		const translator = await Translator.getInstance({
+			language: 'fr',
+			namespaces: ['website-common'],
+		});
+
+		expect(translator.t('transparency-page.countries.headline', { context: { count: 1 } })).toBe(
+			'Des dons totalisant {{amount}} sont arrivés de {{countriesCount}} pays',
 		);
 	});
 });

--- a/website/src/lib/services/transparency/countries-distribution.test.ts
+++ b/website/src/lib/services/transparency/countries-distribution.test.ts
@@ -1,0 +1,137 @@
+import { getCountryFlagColors } from '@/lib/utils/country-flag-colors';
+import {
+	allocateUnitCounts,
+	buildTransparencyCountriesData,
+	COUNTRY_DISTRIBUTION_UNIT_COUNT,
+	formatPercentageDisplay,
+	OTHER_SEGMENT_COLOR,
+	splitTranslationTemplate,
+} from './countries-distribution';
+import { OTHER_COUNTRY_SEGMENT_CODE, type CountryContributionRow } from './transparency.types';
+
+const names: Record<string, string> = {
+	CH: 'Switzerland',
+	DE: 'Germany',
+	US: 'United States',
+	FR: 'France',
+	IT: 'Italy',
+};
+
+const getCountryName = (countryCode: string): string => names[countryCode] ?? '';
+
+const row = (
+	countryCode: CountryContributionRow['countryCode'],
+	totalChf: number,
+	contributorCount = 1,
+): CountryContributionRow => ({
+	countryCode,
+	totalChf,
+	contributorCount,
+});
+
+describe('splitTranslationTemplate', () => {
+	test('keeps placeholders so translations can change word order', () => {
+		expect(splitTranslationTemplate('{{amount}} donations arrived from {{countriesCount}} countries')).toEqual([
+			{ type: 'placeholder', key: 'amount' },
+			{ type: 'text', value: ' donations arrived from ' },
+			{ type: 'placeholder', key: 'countriesCount' },
+			{ type: 'text', value: ' countries' },
+		]);
+		expect(splitTranslationTemplate('{{countriesCount}} Länder spendeten {{amount}}')).toEqual([
+			{ type: 'placeholder', key: 'countriesCount' },
+			{ type: 'text', value: ' Länder spendeten ' },
+			{ type: 'placeholder', key: 'amount' },
+		]);
+	});
+});
+
+describe('allocateUnitCounts', () => {
+	test('allocates exactly 100 units with a deterministic largest remainder', () => {
+		expect(allocateUnitCounts([1, 1, 1])).toEqual([34, 33, 33]);
+		expect(allocateUnitCounts([1, 1, 1]).reduce((sum, count) => sum + count, 0)).toBe(COUNTRY_DISTRIBUTION_UNIT_COUNT);
+		expect(allocateUnitCounts([50.6, 49.4])).toEqual([51, 49]);
+	});
+
+	test('gives a single country all units', () => {
+		expect(allocateUnitCounts([250])).toEqual([100]);
+	});
+
+	test('returns zeros for empty or zero-value datasets', () => {
+		expect(allocateUnitCounts([])).toEqual([]);
+		expect(allocateUnitCounts([0, 0])).toEqual([0, 0]);
+	});
+});
+
+describe('formatPercentageDisplay', () => {
+	test('shows <1% when a positive amount rounds to zero percent', () => {
+		expect(formatPercentageDisplay(0.4, 12)).toBe('<1%');
+		expect(formatPercentageDisplay(0, 0)).toBe('0%');
+		expect(formatPercentageDisplay(12.6, 100)).toBe('13%');
+	});
+});
+
+describe('buildTransparencyCountriesData', () => {
+	test('aggregates remaining countries into Other and sorts them by amount descending', () => {
+		const data = buildTransparencyCountriesData([row('CH', 80), row('DE', 10), row('US', 5), row('FR', 4), row('IT', 1)], {
+			limit: 2,
+			getCountryName,
+			getCountryColors: getCountryFlagColors,
+		});
+
+		expect(data.totalContributionsChf).toBe(100);
+		expect(data.countriesCount).toBe(5);
+		expect(data.segments.map((segment) => segment.countryCode)).toEqual(['CH', 'DE', OTHER_COUNTRY_SEGMENT_CODE]);
+		expect(data.segments[0]?.color).toBe('#D80027');
+		expect(data.segments[1]?.color).toBe('#FFDA44');
+		expect(data.segments.at(-1)?.color).toBe(OTHER_SEGMENT_COLOR);
+		expect(data.segments.reduce((sum, segment) => sum + segment.unitCount, 0)).toBe(100);
+		expect(data.otherCountries.map((country) => country.countryCode)).toEqual(['US', 'FR', 'IT']);
+		expect(data.otherCountries[0]?.totalChf).toBe(5);
+	});
+
+	test('omits Other when every country fits in the top limit', () => {
+		const data = buildTransparencyCountriesData([row('CH', 70), row('DE', 30)], {
+			limit: 5,
+			getCountryName,
+		});
+
+		expect(data.segments).toHaveLength(2);
+		expect(data.otherCountries).toEqual([]);
+		expect(data.segments.every((segment) => segment.countryCode !== OTHER_COUNTRY_SEGMENT_CODE)).toBe(true);
+		expect(data.segments.reduce((sum, segment) => sum + segment.unitCount, 0)).toBe(100);
+	});
+
+	test('handles a single country', () => {
+		const data = buildTransparencyCountriesData([row('CH', 42)], { limit: 15, getCountryName });
+
+		expect(data.countriesCount).toBe(1);
+		expect(data.segments).toEqual([
+			expect.objectContaining({
+				countryCode: 'CH',
+				countryName: 'Switzerland',
+				totalChf: 42,
+				percentageOfTotal: 100,
+				unitCount: 100,
+			}),
+		]);
+		expect(data.otherCountries).toEqual([]);
+	});
+
+	test('returns an empty model for missing or zero-value data', () => {
+		expect(buildTransparencyCountriesData([], { getCountryName })).toEqual({
+			totalContributionsChf: 0,
+			countriesCount: 0,
+			segments: [],
+			otherCountries: [],
+		});
+		expect(buildTransparencyCountriesData([row('CH', 0)], { getCountryName }).segments).toEqual([]);
+	});
+
+	test('falls back to the country code when a name is missing', () => {
+		const data = buildTransparencyCountriesData([row('AT', 10)], {
+			getCountryName: () => '',
+		});
+
+		expect(data.segments[0]?.countryName).toBe('AT');
+	});
+});

--- a/website/src/lib/services/transparency/countries-distribution.test.ts
+++ b/website/src/lib/services/transparency/countries-distribution.test.ts
@@ -5,19 +5,8 @@ import {
 	COUNTRY_DISTRIBUTION_UNIT_COUNT,
 	formatPercentageDisplay,
 	OTHER_SEGMENT_COLOR,
-	splitTranslationTemplate,
 } from './countries-distribution';
 import { OTHER_COUNTRY_SEGMENT_CODE, type CountryContributionRow } from './transparency.types';
-
-const names: Record<string, string> = {
-	CH: 'Switzerland',
-	DE: 'Germany',
-	US: 'United States',
-	FR: 'France',
-	IT: 'Italy',
-};
-
-const getCountryName = (countryCode: string): string => names[countryCode] ?? '';
 
 const row = (
 	countryCode: CountryContributionRow['countryCode'],
@@ -27,22 +16,6 @@ const row = (
 	countryCode,
 	totalChf,
 	contributorCount,
-});
-
-describe('splitTranslationTemplate', () => {
-	test('keeps placeholders so translations can change word order', () => {
-		expect(splitTranslationTemplate('{{amount}} donations arrived from {{countriesCount}} countries')).toEqual([
-			{ type: 'placeholder', key: 'amount' },
-			{ type: 'text', value: ' donations arrived from ' },
-			{ type: 'placeholder', key: 'countriesCount' },
-			{ type: 'text', value: ' countries' },
-		]);
-		expect(splitTranslationTemplate('{{countriesCount}} Länder spendeten {{amount}}')).toEqual([
-			{ type: 'placeholder', key: 'countriesCount' },
-			{ type: 'text', value: ' Länder spendeten ' },
-			{ type: 'placeholder', key: 'amount' },
-		]);
-	});
 });
 
 describe('allocateUnitCounts', () => {
@@ -60,6 +33,10 @@ describe('allocateUnitCounts', () => {
 		expect(allocateUnitCounts([])).toEqual([]);
 		expect(allocateUnitCounts([0, 0])).toEqual([0, 0]);
 	});
+
+	test('keeps every positive segment visible when enough units are available', () => {
+		expect(allocateUnitCounts([1_000_000, 1, 1])).toEqual([98, 1, 1]);
+	});
 });
 
 describe('formatPercentageDisplay', () => {
@@ -74,7 +51,6 @@ describe('buildTransparencyCountriesData', () => {
 	test('aggregates remaining countries into Other and sorts them by amount descending', () => {
 		const data = buildTransparencyCountriesData([row('CH', 80), row('DE', 10), row('US', 5), row('FR', 4), row('IT', 1)], {
 			limit: 2,
-			getCountryName,
 			getCountryColors: getCountryFlagColors,
 		});
 
@@ -92,7 +68,6 @@ describe('buildTransparencyCountriesData', () => {
 	test('omits Other when every country fits in the top limit', () => {
 		const data = buildTransparencyCountriesData([row('CH', 70), row('DE', 30)], {
 			limit: 5,
-			getCountryName,
 		});
 
 		expect(data.segments).toHaveLength(2);
@@ -102,13 +77,12 @@ describe('buildTransparencyCountriesData', () => {
 	});
 
 	test('handles a single country', () => {
-		const data = buildTransparencyCountriesData([row('CH', 42)], { limit: 15, getCountryName });
+		const data = buildTransparencyCountriesData([row('CH', 42)], { limit: 15 });
 
 		expect(data.countriesCount).toBe(1);
 		expect(data.segments).toEqual([
 			expect.objectContaining({
 				countryCode: 'CH',
-				countryName: 'Switzerland',
 				totalChf: 42,
 				percentageOfTotal: 100,
 				unitCount: 100,
@@ -118,20 +92,32 @@ describe('buildTransparencyCountriesData', () => {
 	});
 
 	test('returns an empty model for missing or zero-value data', () => {
-		expect(buildTransparencyCountriesData([], { getCountryName })).toEqual({
+		expect(buildTransparencyCountriesData([])).toEqual({
 			totalContributionsChf: 0,
 			countriesCount: 0,
 			segments: [],
 			otherCountries: [],
 		});
-		expect(buildTransparencyCountriesData([row('CH', 0)], { getCountryName }).segments).toEqual([]);
+		expect(buildTransparencyCountriesData([row('CH', 0)]).segments).toEqual([]);
 	});
 
-	test('falls back to the country code when a name is missing', () => {
-		const data = buildTransparencyCountriesData([row('AT', 10)], {
-			getCountryName: () => '',
-		});
+	test('does not mutate the input order', () => {
+		const rows = [row('DE', 10), row('CH', 20)];
 
-		expect(data.segments[0]?.countryName).toBe('AT');
+		buildTransparencyCountriesData(rows);
+
+		expect(rows.map(({ countryCode }) => countryCode)).toEqual(['DE', 'CH']);
+	});
+
+	test('sorts equal totals by country code and clamps invalid limits', () => {
+		const rows = [row('DE', 10), row('CH', 10)];
+
+		expect(buildTransparencyCountriesData(rows, { limit: 0 }).segments.map(({ countryCode }) => countryCode)).toEqual([
+			'CH',
+			OTHER_COUNTRY_SEGMENT_CODE,
+		]);
+		expect(
+			buildTransparencyCountriesData(rows, { limit: Number.NaN }).segments.map(({ countryCode }) => countryCode),
+		).toEqual(['CH', 'DE']);
 	});
 });

--- a/website/src/lib/services/transparency/countries-distribution.ts
+++ b/website/src/lib/services/transparency/countries-distribution.ts
@@ -1,0 +1,159 @@
+import type { CountryCode } from '@/generated/prisma/enums';
+import { assignFlagColors } from '@/lib/utils/country-flag-color';
+import {
+	OTHER_COUNTRY_SEGMENT_CODE,
+	type CountryContributionRow,
+	type TransparencyCountriesData,
+	type TransparencyCountrySegment,
+} from './transparency.types';
+
+export const TOP_CONTRIBUTING_COUNTRIES_LIMIT = 15;
+export const COUNTRY_DISTRIBUTION_UNIT_COUNT = 100;
+
+export const OTHER_SEGMENT_COLOR = 'hsl(var(--muted-foreground) / 0.4)';
+
+export type TranslationTemplatePart = { type: 'text'; value: string } | { type: 'placeholder'; key: string };
+
+const PLACEHOLDER_REGEX = /\{\{(\w+)\}\}/g;
+
+export const splitTranslationTemplate = (template: string): TranslationTemplatePart[] => {
+	const parts: TranslationTemplatePart[] = [];
+	let lastIndex = 0;
+
+	for (const match of template.matchAll(PLACEHOLDER_REGEX)) {
+		const matchIndex = match.index ?? 0;
+		if (matchIndex > lastIndex) {
+			parts.push({ type: 'text', value: template.slice(lastIndex, matchIndex) });
+		}
+
+		const key = match[1];
+		if (key) {
+			parts.push({ type: 'placeholder', key });
+		}
+		lastIndex = matchIndex + match[0].length;
+	}
+
+	if (lastIndex < template.length) {
+		parts.push({ type: 'text', value: template.slice(lastIndex) });
+	}
+
+	return parts;
+};
+
+export const allocateUnitCounts = (weights: number[], totalUnits = COUNTRY_DISTRIBUTION_UNIT_COUNT): number[] => {
+	if (weights.length === 0) {
+		return [];
+	}
+
+	const sum = weights.reduce((total, weight) => total + weight, 0);
+	if (sum <= 0) {
+		return weights.map(() => 0);
+	}
+
+	const exactShares = weights.map((weight) => (weight / sum) * totalUnits);
+	const unitCounts = exactShares.map(Math.floor);
+	let remainder = totalUnits - unitCounts.reduce((total, count) => total + count, 0);
+
+	const remainderOrder = exactShares
+		.map((share, index) => ({ index, fraction: share - (unitCounts[index] ?? 0) }))
+		.sort((left, right) => right.fraction - left.fraction || left.index - right.index);
+
+	for (const { index } of remainderOrder) {
+		if (remainder <= 0) {
+			break;
+		}
+		unitCounts[index] = (unitCounts[index] ?? 0) + 1;
+		remainder -= 1;
+	}
+
+	return unitCounts;
+};
+
+export const formatPercentageDisplay = (percentageOfTotal: number, amount: number): string => {
+	if (amount > 0 && Math.round(percentageOfTotal) === 0) {
+		return '<1%';
+	}
+
+	return `${Math.round(percentageOfTotal)}%`;
+};
+
+export const buildTransparencyCountriesData = (
+	rows: CountryContributionRow[],
+	options: {
+		limit?: number;
+		getCountryName: (countryCode: CountryCode) => string;
+		getCountryColors?: (countryCode: CountryCode) => string[];
+	},
+): TransparencyCountriesData => {
+	const limit = options.limit ?? TOP_CONTRIBUTING_COUNTRIES_LIMIT;
+	const countries = rows
+		.filter((row) => row.totalChf > 0)
+		.sort((left, right) => right.totalChf - left.totalChf || left.countryCode.localeCompare(right.countryCode));
+
+	const totalContributionsChf = countries.reduce((sum, row) => sum + row.totalChf, 0);
+	if (countries.length === 0 || totalContributionsChf <= 0) {
+		return {
+			totalContributionsChf: 0,
+			countriesCount: 0,
+			segments: [],
+			otherCountries: [],
+		};
+	}
+
+	const topCountries = countries.slice(0, limit);
+	const otherCountries = countries.slice(limit);
+	const otherTotalChf = otherCountries.reduce((sum, row) => sum + row.totalChf, 0);
+	const otherContributorCount = otherCountries.reduce((sum, row) => sum + row.contributorCount, 0);
+
+	const unresolvedSegments = [
+		...topCountries.map((row) => ({
+			countryCode: row.countryCode,
+			countryName: options.getCountryName(row.countryCode) || row.countryCode,
+			totalChf: row.totalChf,
+			contributorCount: row.contributorCount,
+		})),
+		...(otherCountries.length > 0
+			? [
+					{
+						countryCode: OTHER_COUNTRY_SEGMENT_CODE,
+						countryName: '',
+						totalChf: otherTotalChf,
+						contributorCount: otherContributorCount,
+					},
+				]
+			: []),
+	];
+
+	const unitCounts = allocateUnitCounts(unresolvedSegments.map((segment) => segment.totalChf));
+	const countryColorByCode = options.getCountryColors
+		? assignFlagColors(
+				unresolvedSegments.flatMap((segment) =>
+					segment.countryCode === OTHER_COUNTRY_SEGMENT_CODE ? [] : [segment.countryCode],
+				),
+				options.getCountryColors,
+			)
+		: new Map<CountryCode, string>();
+	const segments: TransparencyCountrySegment[] = unresolvedSegments.map((segment, index) => ({
+		countryCode: segment.countryCode,
+		countryName: segment.countryName,
+		totalChf: segment.totalChf,
+		percentageOfTotal: (segment.totalChf / totalContributionsChf) * 100,
+		unitCount: unitCounts[index] ?? 0,
+		color:
+			segment.countryCode === OTHER_COUNTRY_SEGMENT_CODE
+				? OTHER_SEGMENT_COLOR
+				: (countryColorByCode.get(segment.countryCode) ?? OTHER_SEGMENT_COLOR),
+		contributorCount: segment.contributorCount,
+	}));
+
+	return {
+		totalContributionsChf,
+		countriesCount: countries.length,
+		segments,
+		otherCountries: otherCountries.map((row) => ({
+			countryCode: row.countryCode,
+			countryName: options.getCountryName(row.countryCode) || row.countryCode,
+			totalChf: row.totalChf,
+		})),
+	};
+};

--- a/website/src/lib/services/transparency/countries-distribution.ts
+++ b/website/src/lib/services/transparency/countries-distribution.ts
@@ -5,6 +5,7 @@ import {
 	type CountryContributionRow,
 	type TransparencyCountriesData,
 	type TransparencyCountrySegment,
+	type TransparencyCountrySegmentCode,
 } from './transparency.types';
 
 export const TOP_CONTRIBUTING_COUNTRIES_LIMIT = 15;
@@ -12,32 +13,8 @@ export const COUNTRY_DISTRIBUTION_UNIT_COUNT = 100;
 
 export const OTHER_SEGMENT_COLOR = 'hsl(var(--muted-foreground) / 0.4)';
 
-export type TranslationTemplatePart = { type: 'text'; value: string } | { type: 'placeholder'; key: string };
-
-const PLACEHOLDER_REGEX = /\{\{(\w+)\}\}/g;
-
-export const splitTranslationTemplate = (template: string): TranslationTemplatePart[] => {
-	const parts: TranslationTemplatePart[] = [];
-	let lastIndex = 0;
-
-	for (const match of template.matchAll(PLACEHOLDER_REGEX)) {
-		const matchIndex = match.index ?? 0;
-		if (matchIndex > lastIndex) {
-			parts.push({ type: 'text', value: template.slice(lastIndex, matchIndex) });
-		}
-
-		const key = match[1];
-		if (key) {
-			parts.push({ type: 'placeholder', key });
-		}
-		lastIndex = matchIndex + match[0].length;
-	}
-
-	if (lastIndex < template.length) {
-		parts.push({ type: 'text', value: template.slice(lastIndex) });
-	}
-
-	return parts;
+export const compareCountryContributionRows = (left: CountryContributionRow, right: CountryContributionRow): number => {
+	return right.totalChf - left.totalChf || left.countryCode.localeCompare(right.countryCode);
 };
 
 export const allocateUnitCounts = (weights: number[], totalUnits = COUNTRY_DISTRIBUTION_UNIT_COUNT): number[] => {
@@ -66,6 +43,23 @@ export const allocateUnitCounts = (weights: number[], totalUnits = COUNTRY_DISTR
 		remainder -= 1;
 	}
 
+	for (const [index, weight] of weights.entries()) {
+		if (weight <= 0 || (unitCounts[index] ?? 0) > 0) {
+			continue;
+		}
+
+		const donorIndex = unitCounts.reduce(
+			(largestIndex, count, candidateIndex) => (count > (unitCounts[largestIndex] ?? 0) ? candidateIndex : largestIndex),
+			0,
+		);
+		if ((unitCounts[donorIndex] ?? 0) <= 1) {
+			break;
+		}
+
+		unitCounts[donorIndex] = (unitCounts[donorIndex] ?? 0) - 1;
+		unitCounts[index] = 1;
+	}
+
 	return unitCounts;
 };
 
@@ -81,14 +75,12 @@ export const buildTransparencyCountriesData = (
 	rows: CountryContributionRow[],
 	options: {
 		limit?: number;
-		getCountryName: (countryCode: CountryCode) => string;
 		getCountryColors?: (countryCode: CountryCode) => string[];
-	},
+	} = {},
 ): TransparencyCountriesData => {
-	const limit = options.limit ?? TOP_CONTRIBUTING_COUNTRIES_LIMIT;
-	const countries = rows
-		.filter((row) => row.totalChf > 0)
-		.sort((left, right) => right.totalChf - left.totalChf || left.countryCode.localeCompare(right.countryCode));
+	const requestedLimit = options.limit ?? TOP_CONTRIBUTING_COUNTRIES_LIMIT;
+	const limit = Number.isFinite(requestedLimit) ? Math.max(1, Math.floor(requestedLimit)) : TOP_CONTRIBUTING_COUNTRIES_LIMIT;
+	const countries = [...rows].filter((row) => row.totalChf > 0).sort(compareCountryContributionRows);
 
 	const totalContributionsChf = countries.reduce((sum, row) => sum + row.totalChf, 0);
 	if (countries.length === 0 || totalContributionsChf <= 0) {
@@ -103,26 +95,20 @@ export const buildTransparencyCountriesData = (
 	const topCountries = countries.slice(0, limit);
 	const otherCountries = countries.slice(limit);
 	const otherTotalChf = otherCountries.reduce((sum, row) => sum + row.totalChf, 0);
-	const otherContributorCount = otherCountries.reduce((sum, row) => sum + row.contributorCount, 0);
 
-	const unresolvedSegments = [
-		...topCountries.map((row) => ({
-			countryCode: row.countryCode,
-			countryName: options.getCountryName(row.countryCode) || row.countryCode,
-			totalChf: row.totalChf,
-			contributorCount: row.contributorCount,
-		})),
-		...(otherCountries.length > 0
-			? [
-					{
-						countryCode: OTHER_COUNTRY_SEGMENT_CODE,
-						countryName: '',
-						totalChf: otherTotalChf,
-						contributorCount: otherContributorCount,
-					},
-				]
-			: []),
-	];
+	const unresolvedSegments: {
+		countryCode: TransparencyCountrySegmentCode;
+		totalChf: number;
+	}[] = topCountries.map((row) => ({
+		countryCode: row.countryCode,
+		totalChf: row.totalChf,
+	}));
+	if (otherCountries.length > 0) {
+		unresolvedSegments.push({
+			countryCode: OTHER_COUNTRY_SEGMENT_CODE,
+			totalChf: otherTotalChf,
+		});
+	}
 
 	const unitCounts = allocateUnitCounts(unresolvedSegments.map((segment) => segment.totalChf));
 	const countryColorByCode = options.getCountryColors
@@ -135,7 +121,6 @@ export const buildTransparencyCountriesData = (
 		: new Map<CountryCode, string>();
 	const segments: TransparencyCountrySegment[] = unresolvedSegments.map((segment, index) => ({
 		countryCode: segment.countryCode,
-		countryName: segment.countryName,
 		totalChf: segment.totalChf,
 		percentageOfTotal: (segment.totalChf / totalContributionsChf) * 100,
 		unitCount: unitCounts[index] ?? 0,
@@ -143,7 +128,6 @@ export const buildTransparencyCountriesData = (
 			segment.countryCode === OTHER_COUNTRY_SEGMENT_CODE
 				? OTHER_SEGMENT_COLOR
 				: (countryColorByCode.get(segment.countryCode) ?? OTHER_SEGMENT_COLOR),
-		contributorCount: segment.contributorCount,
 	}));
 
 	return {
@@ -152,7 +136,6 @@ export const buildTransparencyCountriesData = (
 		segments,
 		otherCountries: otherCountries.map((row) => ({
 			countryCode: row.countryCode,
-			countryName: options.getCountryName(row.countryCode) || row.countryCode,
 			totalChf: row.totalChf,
 		})),
 	};

--- a/website/src/lib/services/transparency/transparency.service.test.ts
+++ b/website/src/lib/services/transparency/transparency.service.test.ts
@@ -1,0 +1,58 @@
+import type { PrismaClient } from '@/generated/prisma/client';
+import { TransparencyService } from './transparency.service';
+
+type CountryContributionQuery = {
+	where: {
+		createdAt?: {
+			gte: Date;
+			lt: Date;
+		};
+	};
+};
+
+type CountryContribution = {
+	amountChf: number;
+	contributorId: string;
+	contributor: {
+		contact: {
+			address: {
+				country: 'CH' | 'DE';
+			};
+		};
+	};
+};
+
+describe('TransparencyService.getContributionsByCountryData', () => {
+	test('applies the financial period and aggregates countries deterministically', async () => {
+		const findMany = jest.fn<Promise<CountryContribution[]>, [CountryContributionQuery]>().mockResolvedValue([
+			{
+				amountChf: 10,
+				contributorId: 'contributor-1',
+				contributor: { contact: { address: { country: 'DE' } } },
+			},
+			{
+				amountChf: 15,
+				contributorId: 'contributor-1',
+				contributor: { contact: { address: { country: 'DE' } } },
+			},
+			{
+				amountChf: 25,
+				contributorId: 'contributor-2',
+				contributor: { contact: { address: { country: 'CH' } } },
+			},
+		]);
+		const service = new TransparencyService({ contribution: { findMany } } as unknown as PrismaClient, {} as never);
+
+		const result = await service.getContributionsByCountryData(15, { kind: 'year', year: 2025 });
+
+		const [query] = findMany.mock.calls[0] ?? [];
+		expect(query?.where.createdAt?.gte).toBeInstanceOf(Date);
+		expect(query?.where.createdAt?.lt).toBeInstanceOf(Date);
+		expect(result.success).toBe(true);
+		if (!result.success) {
+			throw new Error(result.error);
+		}
+		expect(result.data.totalContributionsChf).toBe(50);
+		expect(result.data.segments.map(({ countryCode }) => countryCode)).toEqual(['CH', 'DE']);
+	});
+});

--- a/website/src/lib/services/transparency/transparency.service.ts
+++ b/website/src/lib/services/transparency/transparency.service.ts
@@ -1,14 +1,18 @@
 import { type PrismaClient } from '@/generated/prisma/client';
 import { PayoutStatus, type CountryCode } from '@/generated/prisma/enums';
 import { getCountryNameByCode, isValidCountryCode } from '@/lib/types/country';
+import { getCountryFlagColors } from '@/lib/utils/country-flag-colors';
 import { BaseService } from '../core/base.service';
 import type { ServiceResult } from '../core/base.types';
 import { type ReserveReadService } from '../reserves/reserve-read.service';
+import { buildTransparencyCountriesData, TOP_CONTRIBUTING_COUNTRIES_LIMIT } from './countries-distribution';
 import type {
 	ContributionsByCountry,
 	ContributionTimeRange,
+	CountryContributionRow,
 	CountryTransparencyTotals,
 	TimeRange,
+	TransparencyCountriesData,
 	TransparencyData,
 	TransparencyFinancialPeriod,
 	TransparencyTotals,
@@ -68,7 +72,7 @@ export class TransparencyService extends BaseService {
 				this.getOutflows(financialPeriod),
 				this.reserveReadService.getLatestPerBankAccount(),
 				this.getContributionsByTimeRanges(timeRanges),
-				this.getContributionsByCountry(15),
+				this.getContributionsByCountry(TOP_CONTRIBUTING_COUNTRIES_LIMIT, financialPeriod),
 			]);
 			if (!latestReservesResult.success) {
 				return this.resultFail(latestReservesResult.error);
@@ -89,6 +93,27 @@ export class TransparencyService extends BaseService {
 			console.error(error);
 
 			return this.resultFail(`Could not fetch transparency data: ${JSON.stringify(error)}`);
+		}
+	}
+
+	async getContributionsByCountryData(
+		limit: number = TOP_CONTRIBUTING_COUNTRIES_LIMIT,
+		financialPeriod: TransparencyFinancialPeriod = { kind: 'all-time' },
+	): Promise<ServiceResult<TransparencyCountriesData>> {
+		try {
+			const rows = await this.getCountryContributionRows(financialPeriod);
+
+			return this.resultOk(
+				buildTransparencyCountriesData(rows, {
+					limit,
+					getCountryName: getCountryNameByCode,
+					getCountryColors: getCountryFlagColors,
+				}),
+			);
+		} catch (error) {
+			console.error(error);
+
+			return this.resultFail(`Could not fetch contributions by country: ${JSON.stringify(error)}`);
 		}
 	}
 
@@ -170,10 +195,28 @@ export class TransparencyService extends BaseService {
 		);
 	}
 
-	private async getContributionsByCountry(limit: number): Promise<ContributionsByCountry[]> {
+	private async getContributionsByCountry(
+		limit: number,
+		financialPeriod: TransparencyFinancialPeriod,
+	): Promise<ContributionsByCountry[]> {
+		const allCountries = await this.getCountryContributionRows(financialPeriod);
+		const grandTotal = allCountries.reduce((sum, row) => sum + row.totalChf, 0);
+
+		return allCountries.slice(0, limit).map((row) => ({
+			country: getCountryNameByCode(row.countryCode),
+			countryCode: row.countryCode,
+			totalChf: row.totalChf,
+			contributorCount: row.contributorCount,
+			percentageOfTotal: grandTotal > 0 ? (row.totalChf / grandTotal) * 100 : 0,
+		}));
+	}
+
+	private async getCountryContributionRows(financialPeriod: TransparencyFinancialPeriod): Promise<CountryContributionRow[]> {
+		const createdAt = getTransparencyFinancialPeriodDateFilter(financialPeriod);
 		const contributions = await this.db.contribution.findMany({
 			where: {
 				status: 'succeeded',
+				createdAt,
 				contributor: {
 					contact: {
 						address: { isNot: null },
@@ -198,8 +241,8 @@ export class TransparencyService extends BaseService {
 		});
 
 		const countryMap = new Map<CountryCode, { totalChf: number; contributors: Set<string> }>();
-		for (const c of contributions) {
-			const country = c.contributor.contact.address?.country;
+		for (const contribution of contributions) {
+			const country = contribution.contributor.contact.address?.country;
 			if (!country) {
 				continue;
 			}
@@ -209,26 +252,16 @@ export class TransparencyService extends BaseService {
 				entry = { totalChf: 0, contributors: new Set() };
 				countryMap.set(country, entry);
 			}
-			entry.totalChf += Number(c.amountChf);
-			entry.contributors.add(c.contributorId);
+			entry.totalChf += Number(contribution.amountChf);
+			entry.contributors.add(contribution.contributorId);
 		}
 
-		const allCountries = [...countryMap.entries()]
+		return [...countryMap.entries()]
 			.map(([countryCode, data]) => ({
 				countryCode,
 				totalChf: data.totalChf,
 				contributorCount: data.contributors.size,
 			}))
-			.sort((a, b) => b.totalChf - a.totalChf);
-
-		const grandTotal = allCountries.reduce((sum, r) => sum + r.totalChf, 0);
-
-		return allCountries.slice(0, limit).map((r) => ({
-			country: getCountryNameByCode(r.countryCode),
-			countryCode: r.countryCode,
-			totalChf: r.totalChf,
-			contributorCount: r.contributorCount,
-			percentageOfTotal: grandTotal > 0 ? (r.totalChf / grandTotal) * 100 : 0,
-		}));
+			.sort((left, right) => right.totalChf - left.totalChf);
 	}
 }

--- a/website/src/lib/services/transparency/transparency.service.ts
+++ b/website/src/lib/services/transparency/transparency.service.ts
@@ -5,7 +5,11 @@ import { getCountryFlagColors } from '@/lib/utils/country-flag-colors';
 import { BaseService } from '../core/base.service';
 import type { ServiceResult } from '../core/base.types';
 import { type ReserveReadService } from '../reserves/reserve-read.service';
-import { buildTransparencyCountriesData, TOP_CONTRIBUTING_COUNTRIES_LIMIT } from './countries-distribution';
+import {
+	buildTransparencyCountriesData,
+	compareCountryContributionRows,
+	TOP_CONTRIBUTING_COUNTRIES_LIMIT,
+} from './countries-distribution';
 import type {
 	ContributionsByCountry,
 	ContributionTimeRange,
@@ -106,7 +110,6 @@ export class TransparencyService extends BaseService {
 			return this.resultOk(
 				buildTransparencyCountriesData(rows, {
 					limit,
-					getCountryName: getCountryNameByCode,
 					getCountryColors: getCountryFlagColors,
 				}),
 			);
@@ -262,6 +265,6 @@ export class TransparencyService extends BaseService {
 				totalChf: data.totalChf,
 				contributorCount: data.contributors.size,
 			}))
-			.sort((left, right) => right.totalChf - left.totalChf);
+			.sort(compareCountryContributionRows);
 	}
 }

--- a/website/src/lib/services/transparency/transparency.types.ts
+++ b/website/src/lib/services/transparency/transparency.types.ts
@@ -69,17 +69,14 @@ export type CountryContributionRow = {
 
 export type TransparencyCountrySegment = {
 	countryCode: TransparencyCountrySegmentCode;
-	countryName: string;
 	totalChf: number;
 	percentageOfTotal: number;
 	unitCount: number;
 	color: string;
-	contributorCount: number;
 };
 
-export type TransparencyOtherCountry = {
+type TransparencyOtherCountry = {
 	countryCode: CountryCode;
-	countryName: string;
 	totalChf: number;
 };
 

--- a/website/src/lib/services/transparency/transparency.types.ts
+++ b/website/src/lib/services/transparency/transparency.types.ts
@@ -57,6 +57,39 @@ export type ContributionsByCountry = {
 	percentageOfTotal: number;
 };
 
+export const OTHER_COUNTRY_SEGMENT_CODE = 'OTHER';
+
+export type TransparencyCountrySegmentCode = CountryCode | typeof OTHER_COUNTRY_SEGMENT_CODE;
+
+export type CountryContributionRow = {
+	countryCode: CountryCode;
+	totalChf: number;
+	contributorCount: number;
+};
+
+export type TransparencyCountrySegment = {
+	countryCode: TransparencyCountrySegmentCode;
+	countryName: string;
+	totalChf: number;
+	percentageOfTotal: number;
+	unitCount: number;
+	color: string;
+	contributorCount: number;
+};
+
+export type TransparencyOtherCountry = {
+	countryCode: CountryCode;
+	countryName: string;
+	totalChf: number;
+};
+
+export type TransparencyCountriesData = {
+	totalContributionsChf: number;
+	countriesCount: number;
+	segments: TransparencyCountrySegment[];
+	otherCountries: TransparencyOtherCountry[];
+};
+
 export type TransparencyTotals = {
 	totalContributionsChf: number;
 	totalContributors: number;

--- a/website/src/lib/utils/country-flag-color.test.ts
+++ b/website/src/lib/utils/country-flag-color.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { assignFlagColors, getRepresentativeFlagColor, MISSING_FLAG_COLOR } from './country-flag-color';
+import { getCountryFlagColors } from './country-flag-colors';
+
+const readFlag = (countryCode: string): string => {
+	return readFileSync(path.join(process.cwd(), 'public/assets/flags', `${countryCode}.svg`), 'utf8');
+};
+
+describe('getRepresentativeFlagColor', () => {
+	test('uses the distinctive fill from circular flag assets', () => {
+		expect(getRepresentativeFlagColor(readFlag('ch'))).toBe('#D80027');
+		expect(getRepresentativeFlagColor(readFlag('jp'))).toBe('#D80027');
+		expect(getRepresentativeFlagColor(readFlag('se'))).toBe('#0052B4');
+	});
+
+	test('skips near-white flag fields', () => {
+		expect(getRepresentativeFlagColor('<path fill="#F0F0F0"/><path fill="#6DA544"/>')).toBe('#6DA544');
+	});
+
+	test('falls back when a flag has no distinctive fills', () => {
+		expect(getRepresentativeFlagColor('<path fill="#FFFFFF"/>')).toBe(MISSING_FLAG_COLOR);
+	});
+});
+
+describe('assignFlagColors', () => {
+	test('uses alternate flag colors so neighbouring countries are not all red', () => {
+		const colors = assignFlagColors(['CH', 'FR', 'IT', 'SE'], getCountryFlagColors);
+
+		expect(colors.get('CH')).toBe('#D80027');
+		expect(colors.get('FR')).toBe('#0052B4');
+		expect(colors.get('IT')).toBe('#6DA544');
+		expect(colors.get('SE')).toBe('#FFDA44');
+		expect(new Set(colors.values()).size).toBe(4);
+	});
+
+	test('shifts hue when two flags only share the same red', () => {
+		const colors = assignFlagColors(['CH', 'JP'], getCountryFlagColors);
+
+		expect(colors.get('CH')).toBe('#D80027');
+		expect(colors.get('JP')).not.toBe('#D80027');
+		expect(colors.get('JP')).toMatch(/^#[0-9A-F]{6}$/);
+	});
+});
+
+describe('getCountryFlagColors', () => {
+	test('reads the existing flag asset for a country code', () => {
+		expect(getCountryFlagColors('CH')).toEqual(['#D80027']);
+		expect(getCountryFlagColors('IT')).toEqual(['#D80027', '#6DA544']);
+	});
+});

--- a/website/src/lib/utils/country-flag-color.ts
+++ b/website/src/lib/utils/country-flag-color.ts
@@ -184,7 +184,7 @@ export const getRepresentativeFlagColor = (svg: string, fallback = MISSING_FLAG_
 	return getFlagColorsFromSvg(svg)[0] ?? fallback;
 };
 
-export const pickDiverseFlagColor = (candidates: string[], usedColors: string[], fallback = MISSING_FLAG_COLOR): string => {
+const pickDiverseFlagColor = (candidates: string[], usedColors: string[], fallback = MISSING_FLAG_COLOR): string => {
 	if (candidates.length === 0) {
 		return fallback;
 	}

--- a/website/src/lib/utils/country-flag-color.ts
+++ b/website/src/lib/utils/country-flag-color.ts
@@ -1,0 +1,231 @@
+import type { CountryCode } from '@/generated/prisma/enums';
+
+export const MISSING_FLAG_COLOR = 'hsl(var(--muted-foreground))';
+
+const FLAG_FILL_REGEX = /\bfill="([^"]+)"/gi;
+const HUE_COLLISION_DEGREES = 28;
+const HUE_SHIFT_OFFSETS = [38, -34, 58, -54, 78, -74, 22, -22];
+
+const NAMED_COLORS: Record<string, string> = {
+	black: '#000000',
+	white: '#FFFFFF',
+	none: '',
+	transparent: '',
+};
+
+type RgbColor = { r: number; g: number; b: number };
+type HslColor = { h: number; s: number; l: number };
+
+const parseHexColor = (value: string): RgbColor | null => {
+	const named = NAMED_COLORS[value.toLowerCase()];
+	const hex = (named ?? value).replace('#', '').toUpperCase();
+	if (hex.length === 3) {
+		const [red, green, blue] = hex.split('');
+		if (!red || !green || !blue) {
+			return null;
+		}
+
+		return {
+			r: Number.parseInt(`${red}${red}`, 16),
+			g: Number.parseInt(`${green}${green}`, 16),
+			b: Number.parseInt(`${blue}${blue}`, 16),
+		};
+	}
+
+	if (hex.length !== 6 || Number.isNaN(Number.parseInt(hex, 16))) {
+		return null;
+	}
+
+	return {
+		r: Number.parseInt(hex.slice(0, 2), 16),
+		g: Number.parseInt(hex.slice(2, 4), 16),
+		b: Number.parseInt(hex.slice(4, 6), 16),
+	};
+};
+
+const toCssHex = (rgb: RgbColor): string => {
+	const toChannel = (channel: number): string => channel.toString(16).padStart(2, '0').toUpperCase();
+
+	return `#${toChannel(rgb.r)}${toChannel(rgb.g)}${toChannel(rgb.b)}`;
+};
+
+const isNearWhite = ({ r, g, b }: RgbColor): boolean => (r + g + b) / 3 >= 240;
+const isNearBlack = ({ r, g, b }: RgbColor): boolean => (r + g + b) / 3 <= 25;
+
+const rgbToHsl = ({ r, g, b }: RgbColor): HslColor => {
+	const red = r / 255;
+	const green = g / 255;
+	const blue = b / 255;
+	const max = Math.max(red, green, blue);
+	const min = Math.min(red, green, blue);
+	const lightness = (max + min) / 2;
+	if (max === min) {
+		return { h: 0, s: 0, l: lightness };
+	}
+
+	const delta = max - min;
+	const saturation = lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+	let hue = 0;
+	if (max === red) {
+		hue = (green - blue) / delta + (green < blue ? 6 : 0);
+	} else if (max === green) {
+		hue = (blue - red) / delta + 2;
+	} else {
+		hue = (red - green) / delta + 4;
+	}
+
+	return { h: hue * 60, s: saturation, l: lightness };
+};
+
+const hueToRgb = (p: number, q: number, t: number): number => {
+	let tone = t;
+	if (tone < 0) {
+		tone += 1;
+	}
+	if (tone > 1) {
+		tone -= 1;
+	}
+	if (tone < 1 / 6) {
+		return p + (q - p) * 6 * tone;
+	}
+	if (tone < 1 / 2) {
+		return q;
+	}
+	if (tone < 2 / 3) {
+		return p + (q - p) * (2 / 3 - tone) * 6;
+	}
+
+	return p;
+};
+
+const hslToRgb = ({ h, s, l }: HslColor): RgbColor => {
+	const hue = (((h % 360) + 360) % 360) / 360;
+	if (s === 0) {
+		const value = Math.round(l * 255);
+
+		return { r: value, g: value, b: value };
+	}
+
+	const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+	const p = 2 * l - q;
+
+	return {
+		r: Math.round(hueToRgb(p, q, hue + 1 / 3) * 255),
+		g: Math.round(hueToRgb(p, q, hue) * 255),
+		b: Math.round(hueToRgb(p, q, hue - 1 / 3) * 255),
+	};
+};
+
+const hueDistance = (left: string, right: string): number => {
+	const leftRgb = parseHexColor(left);
+	const rightRgb = parseHexColor(right);
+	if (!leftRgb || !rightRgb) {
+		return 180;
+	}
+
+	const delta = Math.abs(rgbToHsl(leftRgb).h - rgbToHsl(rightRgb).h) % 360;
+
+	return Math.min(delta, 360 - delta);
+};
+
+const minHueDistance = (color: string, usedColors: string[]): number => {
+	if (usedColors.length === 0) {
+		return 180;
+	}
+
+	return usedColors.reduce((minimum, used) => Math.min(minimum, hueDistance(color, used)), 180);
+};
+
+const shiftHexHue = (color: string, offset: number): string => {
+	const rgb = parseHexColor(color);
+	if (!rgb) {
+		return color;
+	}
+
+	const hsl = rgbToHsl(rgb);
+
+	return toCssHex(hslToRgb({ ...hsl, h: hsl.h + offset }));
+};
+
+export const getFlagColorsFromSvg = (svg: string): string[] => {
+	const fills: string[] = [];
+
+	for (const match of svg.matchAll(FLAG_FILL_REGEX)) {
+		const rawFill = match[1];
+		if (!rawFill) {
+			continue;
+		}
+
+		const rgb = parseHexColor(rawFill);
+		if (!rgb || isNearWhite(rgb)) {
+			continue;
+		}
+
+		fills.push(toCssHex(rgb));
+	}
+
+	const chromaticFills = fills.filter((fill) => {
+		const rgb = parseHexColor(fill);
+
+		return rgb !== null && !isNearBlack(rgb);
+	});
+	const candidates = chromaticFills.length > 0 ? chromaticFills : fills;
+	const counts = new Map<string, number>();
+	for (const color of candidates) {
+		counts.set(color, (counts.get(color) ?? 0) + 1);
+	}
+
+	return [...counts.entries()]
+		.sort((left, right) => right[1] - left[1] || candidates.indexOf(left[0]) - candidates.indexOf(right[0]))
+		.map(([color]) => color);
+};
+
+export const getRepresentativeFlagColor = (svg: string, fallback = MISSING_FLAG_COLOR): string => {
+	return getFlagColorsFromSvg(svg)[0] ?? fallback;
+};
+
+export const pickDiverseFlagColor = (candidates: string[], usedColors: string[], fallback = MISSING_FLAG_COLOR): string => {
+	if (candidates.length === 0) {
+		return fallback;
+	}
+
+	const ranked = [...candidates].sort((left, right) => minHueDistance(right, usedColors) - minHueDistance(left, usedColors));
+	const bestNative = ranked[0] ?? fallback;
+	if (minHueDistance(bestNative, usedColors) >= HUE_COLLISION_DEGREES) {
+		return bestNative;
+	}
+
+	const baseColor = candidates[0] ?? fallback;
+	let bestShifted = bestNative;
+	let bestDistance = minHueDistance(bestNative, usedColors);
+	for (const offset of HUE_SHIFT_OFFSETS) {
+		const shifted = shiftHexHue(baseColor, offset);
+		const distance = minHueDistance(shifted, usedColors);
+		if (distance > bestDistance) {
+			bestShifted = shifted;
+			bestDistance = distance;
+		}
+		if (distance >= HUE_COLLISION_DEGREES) {
+			return shifted;
+		}
+	}
+
+	return bestShifted;
+};
+
+export const assignFlagColors = (
+	countryCodes: CountryCode[],
+	getColors: (countryCode: CountryCode) => string[],
+	fallback = MISSING_FLAG_COLOR,
+): Map<CountryCode, string> => {
+	const assigned = new Map<CountryCode, string>();
+	const usedColors: string[] = [];
+
+	for (const countryCode of countryCodes) {
+		const color = pickDiverseFlagColor(getColors(countryCode), usedColors, fallback);
+		assigned.set(countryCode, color);
+		usedColors.push(color);
+	}
+
+	return assigned;
+};

--- a/website/src/lib/utils/country-flag-colors.ts
+++ b/website/src/lib/utils/country-flag-colors.ts
@@ -1,0 +1,27 @@
+import type { CountryCode } from '@/generated/prisma/enums';
+import { getFlagColorsFromSvg } from '@/lib/utils/country-flag-color';
+import { WHITESPACE_REGEX } from '@/lib/utils/regex';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const flagColorsCache = new Map<string, string[]>();
+
+export const getCountryFlagColors = (countryCode: CountryCode): string[] => {
+	const cached = flagColorsCache.get(countryCode);
+	if (cached) {
+		return cached;
+	}
+
+	try {
+		const slug = countryCode.toLowerCase().replace(WHITESPACE_REGEX, '_');
+		const svg = readFileSync(path.join(process.cwd(), 'public/assets/flags', `${slug}.svg`), 'utf8');
+		const colors = getFlagColorsFromSvg(svg);
+		flagColorsCache.set(countryCode, colors);
+
+		return colors;
+	} catch {
+		flagColorsCache.set(countryCode, []);
+
+		return [];
+	}
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a transparency chart showing contribution totals by country.
  * Added interactive country segments with accessible labels, focus states, and an “other countries” details dialog.
  * Added localized support in English, German, French, and Italian.
  * Improved country flag rendering with decorative and custom styling options.

* **Bug Fixes**
  * Reset flag fallback states correctly when the displayed country changes.

* **Tests**
  * Added coverage for charts, flags, translations, distribution calculations, colors, and transparency data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->