### PR TITLE
feat: add two column block

### DIFF
--- a/website/src/components/content-blocks/two-column-layout.tsx
+++ b/website/src/components/content-blocks/two-column-layout.tsx
@@ -1,0 +1,33 @@
+import type { TwoColumnText } from '@/generated/storyblok/types/109655/storyblok-components';
+import type { ReactNode } from 'react';
+
+type Props = {
+	leftColumn?: ReactNode;
+	rightColumn?: ReactNode;
+	columnRatio?: TwoColumnText['columnRatio'];
+	columnClassName?: string;
+};
+
+const defaultColumnRatio = 'oneThirdTwoThirds';
+
+const widthClassesByColumnRatio = {
+	'': { left: 'sm:w-1/3', right: 'sm:w-2/3' },
+	oneThirdTwoThirds: { left: 'sm:w-1/3', right: 'sm:w-2/3' },
+	halfHalf: { left: 'sm:w-1/2', right: 'sm:w-1/2' },
+	twoThirdsOneThird: { left: 'sm:w-2/3', right: 'sm:w-1/3' },
+};
+
+export const TwoColumnLayout = ({ leftColumn, rightColumn, columnRatio, columnClassName }: Props) => {
+	if (!leftColumn && !rightColumn) {
+		return null;
+	}
+
+	const widthClasses = widthClassesByColumnRatio[columnRatio ?? defaultColumnRatio];
+
+	return (
+		<div className="text-foreground flex flex-col gap-6 text-lg sm:flex-row sm:gap-14">
+			<div className={`min-w-0 ${widthClasses.left} ${columnClassName ?? ''}`}>{leftColumn}</div>
+			<div className={`min-w-0 ${widthClasses.right} ${columnClassName ?? ''}`}>{rightColumn}</div>
+		</div>
+	);
+};

--- a/website/src/components/content-blocks/two-column-text-content.tsx
+++ b/website/src/components/content-blocks/two-column-text-content.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { TwoColumnLayout } from '@/components/content-blocks/two-column-layout';
 import { RichTextRenderer } from '@/components/storyblok/rich-text-renderer';
 import type { TwoColumnText } from '@/generated/storyblok/types/109655/storyblok-components';
 import type { StoryblokRichtext } from '@/generated/storyblok/types/storyblok';
@@ -10,26 +11,16 @@ type Props = {
 	columnRatio?: TwoColumnText['columnRatio'];
 };
 
-const defaultColumnRatio = 'oneThirdTwoThirds';
-
-const widthClassesByColumnRatio = {
-	'': { left: 'sm:w-1/3', right: 'sm:w-2/3' },
-	oneThirdTwoThirds: { left: 'sm:w-1/3', right: 'sm:w-2/3' },
-	halfHalf: { left: 'sm:w-1/2', right: 'sm:w-1/2' },
-	twoThirdsOneThird: { left: 'sm:w-2/3', right: 'sm:w-1/3' },
-};
-
 export const TwoColumnTextContent = ({ leftText, rightText, columnRatio }: Props) => {
 	if (!leftText && !rightText) {
 		return null;
 	}
 
-	const widthClasses = widthClassesByColumnRatio[columnRatio ?? defaultColumnRatio];
-
 	return (
-		<div className="text-foreground flex flex-col gap-6 text-lg sm:flex-row sm:gap-14">
-			<div className={widthClasses.left}>{leftText && <RichTextRenderer richTextDocument={leftText} />}</div>
-			<div className={widthClasses.right}>{rightText && <RichTextRenderer richTextDocument={rightText} />}</div>
-		</div>
+		<TwoColumnLayout
+			leftColumn={leftText && <RichTextRenderer richTextDocument={leftText} />}
+			rightColumn={rightText && <RichTextRenderer richTextDocument={rightText} />}
+			columnRatio={columnRatio}
+		/>
 	);
 };

--- a/website/src/components/content-blocks/two-column.tsx
+++ b/website/src/components/content-blocks/two-column.tsx
@@ -1,0 +1,36 @@
+import { BlockWrapper } from '@/components/block-wrapper';
+import { TwoColumnLayout } from '@/components/content-blocks/two-column-layout';
+import type { TwoColumn } from '@/generated/storyblok/types/109655/storyblok-components';
+import { storyblokEditable, type SbBlokData } from '@storyblok/react';
+import type { ReactNode } from 'react';
+
+type Props = {
+	blok: TwoColumn;
+	leftColumn?: ReactNode;
+	rightColumn?: ReactNode;
+};
+
+const nestedBlockClassName = '[&>*]:m-0 [&>*]:w-full [&>*]:max-w-none [&>*]:px-0';
+
+export const TwoColumnBlock = ({ blok, leftColumn, rightColumn }: Props) => {
+	const { columnRatio, disableMarginBottom, disableMarginTop } = blok;
+
+	if (!leftColumn && !rightColumn) {
+		return null;
+	}
+
+	return (
+		<BlockWrapper
+			disableMarginBottom={disableMarginBottom}
+			disableMarginTop={disableMarginTop}
+			{...storyblokEditable(blok as SbBlokData)}
+		>
+			<TwoColumnLayout
+				leftColumn={leftColumn}
+				rightColumn={rightColumn}
+				columnRatio={columnRatio}
+				columnClassName={nestedBlockClassName}
+			/>
+		</BlockWrapper>
+	);
+};

--- a/website/src/components/content-types/page.tsx
+++ b/website/src/components/content-types/page.tsx
@@ -25,15 +25,17 @@ import { TestimonialBlock } from '@/components/content-blocks/testimonial-entry'
 import { TextBlock } from '@/components/content-blocks/text';
 import { TransparencyCountriesBlock } from '@/components/content-blocks/transparency-countries-block';
 import { TransparencySummaryBlock } from '@/components/content-blocks/transparency-summary-block';
+import { TwoColumnBlock } from '@/components/content-blocks/two-column';
 import { TwoColumnTextBlock } from '@/components/content-blocks/two-column-text';
 import { VideoTextBlock } from '@/components/content-blocks/video-text';
 import { NewsletterSignup } from '@/components/storyblok/journal/rich-text/newsletter-signup';
-import type { Page } from '@/generated/storyblok/types/109655/storyblok-components';
+import type { Page, TwoColumn } from '@/generated/storyblok/types/109655/storyblok-components';
 import type { WebsiteLanguage, WebsiteRegion } from '@/lib/i18n/utils';
 import type { ParsedUrlQueryInput } from 'querystring';
-import { Fragment } from 'react';
+import { Fragment, type ReactNode } from 'react';
 
 type PageBlock = Page['content'][number];
+type NestedPageBlock = TwoColumn['leftColumn'][number];
 type RichtextButtonHeaderAction = 'createProgram';
 
 type PageContentTypeProps = {
@@ -45,12 +47,12 @@ type PageContentTypeProps = {
 };
 
 const renderPageBlock = (
-	block: PageBlock,
+	block: PageBlock | NestedPageBlock,
 	lang: WebsiteLanguage,
 	region: WebsiteRegion,
 	searchParams?: ParsedUrlQueryInput,
 	richtextButtonHeaderAction?: RichtextButtonHeaderAction,
-) => {
+): ReactNode => {
 	switch (block.component) {
 		case 'donationGlobe':
 			return <DonationGlobeBlock blok={block} lang={lang} />;
@@ -108,6 +110,24 @@ const renderPageBlock = (
 			return <TransparencyCountriesBlock blok={block} lang={lang} />;
 		case 'transparencySummary':
 			return <TransparencySummaryBlock blok={block} lang={lang} />;
+		case 'twoColumn': {
+			const renderColumn = (column: typeof block.leftColumn) =>
+				column.length > 0
+					? column.map((columnBlock) => (
+							<Fragment key={columnBlock._uid}>
+								{renderPageBlock(columnBlock, lang, region, searchParams, richtextButtonHeaderAction)}
+							</Fragment>
+						))
+					: undefined;
+
+			return (
+				<TwoColumnBlock
+					blok={block}
+					leftColumn={renderColumn(block.leftColumn)}
+					rightColumn={renderColumn(block.rightColumn)}
+				/>
+			);
+		}
 		case 'twoColumnText':
 			return <TwoColumnTextBlock blok={block} />;
 		case 'videoText':
@@ -115,8 +135,6 @@ const renderPageBlock = (
 		case 'runwayMonthGrid':
 			return <RunwayMonthGridBlock blok={block} lang={lang} />;
 		default:
-			block satisfies never;
-
 			return null;
 	}
 };

--- a/website/src/components/content-types/page.tsx
+++ b/website/src/components/content-types/page.tsx
@@ -35,7 +35,7 @@ import type { ParsedUrlQueryInput } from 'querystring';
 import { Fragment, type ReactNode } from 'react';
 
 type PageBlock = Page['content'][number];
-type NestedPageBlock = TwoColumn['leftColumn'][number];
+type NestedPageBlock = Extract<TwoColumn['leftColumn'][number], PageBlock>;
 type RichtextButtonHeaderAction = 'createProgram';
 
 type PageContentTypeProps = {
@@ -135,6 +135,8 @@ const renderPageBlock = (
 		case 'runwayMonthGrid':
 			return <RunwayMonthGridBlock blok={block} lang={lang} />;
 		default:
+			block satisfies never;
+
 			return null;
 	}
 };

--- a/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
+++ b/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
@@ -427,6 +427,7 @@ export interface Page {
     | Testimonial
     | TestimonialCarousel
     | Text
+    | TwoColumn
     | TwoColumnText
     | VideoText
     | OpenSourceStats
@@ -671,6 +672,151 @@ export interface TransparencySummary {
   outflowsDescription?: string;
   reservesDescription?: string;
   component: "transparencySummary";
+  _uid: string;
+  [k: string]: unknown;
+}
+
+export interface TwoColumn {
+  leftColumn: (
+    | ActionButton
+    | Article
+    | ArticleType
+    | BannerSection
+    | Button
+    | Campaign
+    | CampaignDonate
+    | CampaignGlobals
+    | CampaignOverview
+    | Country
+    | CountryOverview
+    | Document
+    | DonationGlobe
+    | DonationsTotal
+    | Downloads
+    | DropdownItem
+    | EmbeddedVideo
+    | ExplainerVideoHeader
+    | Faq
+    | FaqSelection
+    | Focus
+    | FocusOverview
+    | HeroVideo
+    | ImageText
+    | ImageWithCaption
+    | ImpactMeasurement
+    | JournalTeasers
+    | Layout
+    | LocalPartner
+    | LocalPartnersOverview
+    | Lottie
+    | MenuItem
+    | MenuItemGroup
+    | ModalCard
+    | ModalCards
+    | NewsletterForm
+    | NewsletterSignup
+    | OpenSource
+    | OpenSourceContributors
+    | OpenSourceIssues
+    | OpenSourceStats
+    | Page
+    | Partnership
+    | PartnershipsCarousel
+    | Person
+    | PersonGrid
+    | Program
+    | ProgramGrid
+    | ProgramOverview
+    | QuotedText
+    | ReferenceArticle
+    | ReferencesGroup
+    | RichtextButtonHeader
+    | RunwayMonthGrid
+    | Spacer
+    | Study
+    | Tag
+    | TeamGrid
+    | Testimonial
+    | TestimonialCarousel
+    | Text
+    | TransparencyCountries
+    | TransparencySummary
+    | TwoColumn
+    | TwoColumnText
+    | VideoText
+  )[];
+  rightColumn: (
+    | ActionButton
+    | Article
+    | ArticleType
+    | BannerSection
+    | Button
+    | Campaign
+    | CampaignDonate
+    | CampaignGlobals
+    | CampaignOverview
+    | Country
+    | CountryOverview
+    | Document
+    | DonationGlobe
+    | DonationsTotal
+    | Downloads
+    | DropdownItem
+    | EmbeddedVideo
+    | ExplainerVideoHeader
+    | Faq
+    | FaqSelection
+    | Focus
+    | FocusOverview
+    | HeroVideo
+    | ImageText
+    | ImageWithCaption
+    | ImpactMeasurement
+    | JournalTeasers
+    | Layout
+    | LocalPartner
+    | LocalPartnersOverview
+    | Lottie
+    | MenuItem
+    | MenuItemGroup
+    | ModalCard
+    | ModalCards
+    | NewsletterForm
+    | NewsletterSignup
+    | OpenSource
+    | OpenSourceContributors
+    | OpenSourceIssues
+    | OpenSourceStats
+    | Page
+    | Partnership
+    | PartnershipsCarousel
+    | Person
+    | PersonGrid
+    | Program
+    | ProgramGrid
+    | ProgramOverview
+    | QuotedText
+    | ReferenceArticle
+    | ReferencesGroup
+    | RichtextButtonHeader
+    | RunwayMonthGrid
+    | Spacer
+    | Study
+    | Tag
+    | TeamGrid
+    | Testimonial
+    | TestimonialCarousel
+    | Text
+    | TransparencyCountries
+    | TransparencySummary
+    | TwoColumn
+    | TwoColumnText
+    | VideoText
+  )[];
+  columnRatio?: "" | "oneThirdTwoThirds" | "halfHalf" | "twoThirdsOneThird";
+  disableMarginTop?: boolean;
+  disableMarginBottom?: boolean;
+  component: "twoColumn";
   _uid: string;
   [k: string]: unknown;
 }

--- a/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
+++ b/website/src/generated/storyblok/types/109655/storyblok-components.d.ts
@@ -678,140 +678,68 @@ export interface TransparencySummary {
 
 export interface TwoColumn {
   leftColumn: (
-    | ActionButton
-    | Article
-    | ArticleType
-    | BannerSection
-    | Button
-    | Campaign
-    | CampaignDonate
-    | CampaignGlobals
-    | CampaignOverview
-    | Country
-    | CountryOverview
-    | Document
-    | DonationGlobe
     | DonationsTotal
     | Downloads
-    | DropdownItem
-    | EmbeddedVideo
-    | ExplainerVideoHeader
-    | Faq
     | FaqSelection
-    | Focus
-    | FocusOverview
     | HeroVideo
     | ImageText
-    | ImageWithCaption
     | ImpactMeasurement
     | JournalTeasers
-    | Layout
-    | LocalPartner
-    | LocalPartnersOverview
-    | Lottie
-    | MenuItem
-    | MenuItemGroup
-    | ModalCard
     | ModalCards
-    | NewsletterForm
-    | NewsletterSignup
-    | OpenSource
-    | OpenSourceContributors
-    | OpenSourceIssues
-    | OpenSourceStats
-    | Page
-    | Partnership
     | PartnershipsCarousel
-    | Person
-    | PersonGrid
-    | Program
     | ProgramGrid
-    | ProgramOverview
-    | QuotedText
-    | ReferenceArticle
-    | ReferencesGroup
-    | RichtextButtonHeader
-    | RunwayMonthGrid
-    | Spacer
-    | Study
-    | Tag
     | TeamGrid
     | Testimonial
     | TestimonialCarousel
     | Text
-    | TransparencyCountries
-    | TransparencySummary
     | TwoColumn
     | TwoColumnText
     | VideoText
+    | OpenSourceStats
+    | OpenSourceContributors
+    | OpenSourceIssues
+    | Spacer
+    | ExplainerVideoHeader
+    | RichtextButtonHeader
+    | NewsletterForm
+    | Lottie
+    | PersonGrid
+    | RunwayMonthGrid
+    | DonationGlobe
+    | TransparencySummary
+    | TransparencyCountries
   )[];
   rightColumn: (
-    | ActionButton
-    | Article
-    | ArticleType
-    | BannerSection
-    | Button
-    | Campaign
-    | CampaignDonate
-    | CampaignGlobals
-    | CampaignOverview
-    | Country
-    | CountryOverview
-    | Document
-    | DonationGlobe
     | DonationsTotal
     | Downloads
-    | DropdownItem
-    | EmbeddedVideo
-    | ExplainerVideoHeader
-    | Faq
     | FaqSelection
-    | Focus
-    | FocusOverview
     | HeroVideo
     | ImageText
-    | ImageWithCaption
     | ImpactMeasurement
     | JournalTeasers
-    | Layout
-    | LocalPartner
-    | LocalPartnersOverview
-    | Lottie
-    | MenuItem
-    | MenuItemGroup
-    | ModalCard
     | ModalCards
-    | NewsletterForm
-    | NewsletterSignup
-    | OpenSource
-    | OpenSourceContributors
-    | OpenSourceIssues
-    | OpenSourceStats
-    | Page
-    | Partnership
     | PartnershipsCarousel
-    | Person
-    | PersonGrid
-    | Program
     | ProgramGrid
-    | ProgramOverview
-    | QuotedText
-    | ReferenceArticle
-    | ReferencesGroup
-    | RichtextButtonHeader
-    | RunwayMonthGrid
-    | Spacer
-    | Study
-    | Tag
     | TeamGrid
     | Testimonial
     | TestimonialCarousel
     | Text
-    | TransparencyCountries
-    | TransparencySummary
     | TwoColumn
     | TwoColumnText
     | VideoText
+    | OpenSourceStats
+    | OpenSourceContributors
+    | OpenSourceIssues
+    | Spacer
+    | ExplainerVideoHeader
+    | RichtextButtonHeader
+    | NewsletterForm
+    | Lottie
+    | PersonGrid
+    | RunwayMonthGrid
+    | DonationGlobe
+    | TransparencySummary
+    | TransparencyCountries
   )[];
   columnRatio?: "" | "oneThirdTwoThirds" | "halfHalf" | "twoThirdsOneThird";
   disableMarginTop?: boolean;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying content in flexible two-column layouts.
  * Added configurable column ratios: one-third/two-thirds, half-and-half, or two-thirds/one-third.
  * Added support for nested content blocks within either column.
  * Added optional shared styling for column content and page editing metadata.
  * Empty columns are omitted when no content is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->